### PR TITLE
feat(types): ship JSX TypeScript declarations for what-framework/what-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to What Framework will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **JSX TypeScript types.** `what-framework/jsx-runtime` and `what-core/jsx-runtime` (and their `jsx-dev-runtime` counterparts) now ship type declarations, including a `JSX` namespace with `IntrinsicElements`. TypeScript users authoring JSX with `"jsxImportSource": "what-framework"` previously got `TS7026` (no `JSX.IntrinsicElements`) and `TS7016` (no declaration for `what-framework/jsx-runtime`) on every element under `strict`; JSX now type-checks. Types mirror What's lenient runtime — both `class`/`className`, camelCase and lowercase event handlers, reactive `() => value` attribute values, `data-`/`aria-`/custom attributes, and SVG — while still rejecting genuinely wrong props (e.g. a non-function `onclick`). Works under `jsx: "react-jsx"`, `"react-jsxdev"`, and `"preserve"` (the create-what scaffold config).
+
 ## [0.11.2] - 2026-06-26 — recharts SVG portal fix; persistent router layout; component-swap reconciler fix
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
       "devDependencies": {
         "esbuild": "^0.28.1",
         "jsdom": "^29.1.1",
-        "playwright": "^1.58.2"
+        "playwright": "^1.58.2",
+        "typescript": "^5.7.3"
       },
       "engines": {
         "node": ">=20"
@@ -5614,6 +5615,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
@@ -6548,10 +6563,10 @@
     },
     "packages/cache": {
       "name": "what-isr",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "peerDependencies": {
-        "what-server": "^0.11.1"
+        "what-server": "^0.11.2"
       },
       "peerDependenciesMeta": {
         "what-server": {
@@ -6561,10 +6576,10 @@
     },
     "packages/cli": {
       "name": "what-framework-cli",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "what-framework": "^0.11.1"
+        "what-framework": "^0.11.2"
       },
       "bin": {
         "what": "src/cli.js"
@@ -6572,7 +6587,7 @@
     },
     "packages/compiler": {
       "name": "what-compiler",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.23.0",
@@ -6580,16 +6595,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0",
-        "what-core": "^0.11.1"
+        "what-core": "^0.11.2"
       }
     },
     "packages/core": {
       "name": "what-core",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT"
     },
     "packages/create-what": {
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "bin": {
         "create-what": "index.js"
@@ -6597,15 +6612,15 @@
     },
     "packages/devtools": {
       "name": "what-devtools",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "peerDependencies": {
-        "what-core": "^0.11.1"
+        "what-core": "^0.11.2"
       }
     },
     "packages/devtools-mcp": {
       "name": "what-devtools-mcp",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -6621,7 +6636,7 @@
     },
     "packages/eslint-plugin": {
       "name": "eslint-plugin-what",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "peerDependencies": {
         "eslint": ">=9.0.0"
@@ -6629,7 +6644,7 @@
     },
     "packages/mcp-server": {
       "name": "what-mcp",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "deprecated": "Use what-devtools-mcp instead. This package is superseded by the unified MCP server.",
       "license": "MIT",
       "dependencies": {
@@ -6641,27 +6656,27 @@
     },
     "packages/react-compat": {
       "name": "what-react",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "peerDependencies": {
-        "what-core": "^0.11.1"
+        "what-core": "^0.11.2"
       }
     },
     "packages/router": {
       "name": "what-router",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "peerDependencies": {
-        "what-core": "^0.11.1"
+        "what-core": "^0.11.2"
       }
     },
     "packages/server": {
       "name": "what-server",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "peerDependencies": {
-        "what-core": "^0.11.1",
-        "what-router": "^0.11.1"
+        "what-core": "^0.11.2",
+        "what-router": "^0.11.2"
       },
       "peerDependenciesMeta": {
         "what-router": {
@@ -6671,17 +6686,17 @@
     },
     "packages/what": {
       "name": "what-framework",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "what-compiler": "^0.11.1",
-        "what-core": "^0.11.1",
-        "what-router": "^0.11.1",
-        "what-server": "^0.11.1"
+        "what-compiler": "^0.11.2",
+        "what-core": "^0.11.2",
+        "what-router": "^0.11.2",
+        "what-server": "^0.11.2"
       }
     },
     "packages/what-text": {
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "peerDependencies": {
         "@chenglou/pretext": ">=0.0.5",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "devDependencies": {
     "esbuild": "^0.28.1",
     "jsdom": "^29.1.1",
-    "playwright": "^1.58.2"
+    "playwright": "^1.58.2",
+    "typescript": "^5.7.3"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.5"

--- a/packages/core/jsx-dev-runtime.d.ts
+++ b/packages/core/jsx-dev-runtime.d.ts
@@ -1,0 +1,15 @@
+// What Framework — JSX dev-runtime type definitions.
+// Re-exports the runtime types (including the JSX namespace) and adds jsxDEV,
+// which the "react-jsxdev" transform emits in development builds.
+import type { VNode } from './index';
+
+export * from './jsx-runtime';
+
+export function jsxDEV(
+  type: any,
+  props: any,
+  key?: any,
+  isStaticChildren?: boolean,
+  source?: any,
+  self?: any,
+): VNode;

--- a/packages/core/jsx-runtime.d.ts
+++ b/packages/core/jsx-runtime.d.ts
@@ -1,0 +1,311 @@
+// What Framework — JSX runtime type definitions.
+//
+// Enables type-checked JSX authoring with:
+//   "jsx": "react-jsx", "jsxImportSource": "what-framework"  (or "what-core")
+//
+// What is DOM-native and lenient at runtime: attributes pass through as-is,
+// both `class`/`className` and camelCase/lowercase event handlers are accepted
+// (events are bound via `key.slice(2).toLowerCase()`), and any attribute value
+// may be reactive — a plain value OR a `() => value` thunk. These types mirror
+// that behavior: common attributes are explicitly typed for autocomplete and
+// documentation, while an index signature keeps arbitrary/custom attributes and
+// web-component tags valid (never false-flagging code the runtime accepts).
+
+import type { VNode, VNodeChild } from './index';
+
+export { Fragment } from './index';
+
+/** A JSX attribute value in What may be static or a reactive `() => value` thunk. */
+export type Reactive<T> = T | (() => T);
+
+export function jsx(type: any, props: any, key?: any): VNode;
+export function jsxs(type: any, props: any, key?: any): VNode;
+
+type EventHandler<E extends Event = Event> = (event: E & { currentTarget: EventTarget & Element; target: Element }) => void;
+
+interface WhatEventHandlers {
+  // What lowercases the event name, so both spellings resolve to the same DOM event.
+  onClick?: EventHandler<MouseEvent>;
+  onclick?: EventHandler<MouseEvent>;
+  onDblClick?: EventHandler<MouseEvent>;
+  ondblclick?: EventHandler<MouseEvent>;
+  onMouseDown?: EventHandler<MouseEvent>;
+  onmousedown?: EventHandler<MouseEvent>;
+  onMouseUp?: EventHandler<MouseEvent>;
+  onmouseup?: EventHandler<MouseEvent>;
+  onMouseEnter?: EventHandler<MouseEvent>;
+  onmouseenter?: EventHandler<MouseEvent>;
+  onMouseLeave?: EventHandler<MouseEvent>;
+  onmouseleave?: EventHandler<MouseEvent>;
+  onMouseMove?: EventHandler<MouseEvent>;
+  onmousemove?: EventHandler<MouseEvent>;
+  onInput?: EventHandler<InputEvent>;
+  oninput?: EventHandler<InputEvent>;
+  onChange?: EventHandler<Event>;
+  onchange?: EventHandler<Event>;
+  onSubmit?: EventHandler<SubmitEvent>;
+  onsubmit?: EventHandler<SubmitEvent>;
+  onReset?: EventHandler<Event>;
+  onreset?: EventHandler<Event>;
+  onKeyDown?: EventHandler<KeyboardEvent>;
+  onkeydown?: EventHandler<KeyboardEvent>;
+  onKeyUp?: EventHandler<KeyboardEvent>;
+  onkeyup?: EventHandler<KeyboardEvent>;
+  onKeyPress?: EventHandler<KeyboardEvent>;
+  onkeypress?: EventHandler<KeyboardEvent>;
+  onFocus?: EventHandler<FocusEvent>;
+  onfocus?: EventHandler<FocusEvent>;
+  onBlur?: EventHandler<FocusEvent>;
+  onblur?: EventHandler<FocusEvent>;
+  onScroll?: EventHandler<Event>;
+  onscroll?: EventHandler<Event>;
+}
+
+interface WhatHTMLAttributes extends WhatEventHandlers {
+  children?: VNodeChild;
+  /** Component-list reconciliation key. */
+  key?: string | number;
+  ref?: ((el: any) => void) | { current: any };
+
+  class?: Reactive<string>;
+  className?: Reactive<string>;
+  id?: Reactive<string>;
+  style?: Reactive<string | Record<string, string | number>>;
+  title?: Reactive<string>;
+  role?: Reactive<string>;
+  slot?: Reactive<string>;
+  lang?: Reactive<string>;
+  dir?: Reactive<string>;
+  hidden?: Reactive<boolean>;
+  draggable?: Reactive<boolean>;
+  contentEditable?: Reactive<boolean | string>;
+  tabindex?: Reactive<number | string>;
+  tabIndex?: Reactive<number | string>;
+
+  // Common data-/aria- attributes remain typed; arbitrary ones fall through below.
+  [dataAttr: `data-${string}`]: any;
+  [ariaAttr: `aria-${string}`]: any;
+  /** What passes unknown attributes straight to the DOM; keep them valid. */
+  [attr: string]: any;
+}
+
+interface WhatInputAttributes extends WhatHTMLAttributes {
+  type?: Reactive<string>;
+  value?: Reactive<string | number>;
+  checked?: Reactive<boolean>;
+  placeholder?: Reactive<string>;
+  disabled?: Reactive<boolean>;
+  readonly?: Reactive<boolean>;
+  readOnly?: Reactive<boolean>;
+  required?: Reactive<boolean>;
+  name?: Reactive<string>;
+  min?: Reactive<string | number>;
+  max?: Reactive<string | number>;
+  step?: Reactive<string | number>;
+  pattern?: Reactive<string>;
+  autocomplete?: Reactive<string>;
+  autofocus?: Reactive<boolean>;
+}
+
+interface WhatAnchorAttributes extends WhatHTMLAttributes {
+  href?: Reactive<string>;
+  target?: Reactive<string>;
+  rel?: Reactive<string>;
+  download?: Reactive<string | boolean>;
+}
+
+interface WhatImgAttributes extends WhatHTMLAttributes {
+  src?: Reactive<string>;
+  srcset?: Reactive<string>;
+  alt?: Reactive<string>;
+  width?: Reactive<string | number>;
+  height?: Reactive<string | number>;
+  loading?: Reactive<'eager' | 'lazy'>;
+  decoding?: Reactive<'async' | 'auto' | 'sync'>;
+}
+
+interface WhatButtonAttributes extends WhatHTMLAttributes {
+  type?: Reactive<'button' | 'submit' | 'reset'>;
+  disabled?: Reactive<boolean>;
+  name?: Reactive<string>;
+  value?: Reactive<string | number>;
+  form?: Reactive<string>;
+}
+
+interface WhatFormAttributes extends WhatHTMLAttributes {
+  action?: Reactive<string>;
+  method?: Reactive<string>;
+  enctype?: Reactive<string>;
+  novalidate?: Reactive<boolean>;
+  target?: Reactive<string>;
+}
+
+interface WhatLabelAttributes extends WhatHTMLAttributes {
+  for?: Reactive<string>;
+  htmlFor?: Reactive<string>;
+}
+
+interface WhatOptionAttributes extends WhatHTMLAttributes {
+  value?: Reactive<string | number>;
+  selected?: Reactive<boolean>;
+  disabled?: Reactive<boolean>;
+}
+
+interface WhatSelectAttributes extends WhatHTMLAttributes {
+  value?: Reactive<string | number>;
+  name?: Reactive<string>;
+  disabled?: Reactive<boolean>;
+  required?: Reactive<boolean>;
+  multiple?: Reactive<boolean>;
+}
+
+interface WhatTextareaAttributes extends WhatHTMLAttributes {
+  value?: Reactive<string>;
+  placeholder?: Reactive<string>;
+  rows?: Reactive<string | number>;
+  cols?: Reactive<string | number>;
+  disabled?: Reactive<boolean>;
+  readonly?: Reactive<boolean>;
+  required?: Reactive<boolean>;
+  name?: Reactive<string>;
+}
+
+interface WhatMediaAttributes extends WhatHTMLAttributes {
+  src?: Reactive<string>;
+  controls?: Reactive<boolean>;
+  autoplay?: Reactive<boolean>;
+  loop?: Reactive<boolean>;
+  muted?: Reactive<boolean>;
+  poster?: Reactive<string>;
+  preload?: Reactive<string>;
+}
+
+// SVG (recharts and other chart libraries render through this).
+interface WhatSVGAttributes extends WhatHTMLAttributes {
+  width?: Reactive<string | number>;
+  height?: Reactive<string | number>;
+  viewBox?: Reactive<string>;
+  fill?: Reactive<string>;
+  stroke?: Reactive<string>;
+  x?: Reactive<string | number>;
+  y?: Reactive<string | number>;
+  cx?: Reactive<string | number>;
+  cy?: Reactive<string | number>;
+  r?: Reactive<string | number>;
+  d?: Reactive<string>;
+  points?: Reactive<string>;
+  transform?: Reactive<string>;
+}
+
+export namespace JSX {
+  type Element = VNode;
+  interface ElementChildrenAttribute {
+    children: {};
+  }
+  interface IntrinsicAttributes {
+    key?: string | number;
+  }
+
+  interface IntrinsicElements {
+    // Element-specific typing (autocomplete for the props that matter most).
+    a: WhatAnchorAttributes;
+    img: WhatImgAttributes;
+    input: WhatInputAttributes;
+    button: WhatButtonAttributes;
+    form: WhatFormAttributes;
+    label: WhatLabelAttributes;
+    option: WhatOptionAttributes;
+    select: WhatSelectAttributes;
+    textarea: WhatTextareaAttributes;
+    video: WhatMediaAttributes;
+    audio: WhatMediaAttributes;
+    source: WhatMediaAttributes;
+
+    // Structural / text / sectioning elements.
+    div: WhatHTMLAttributes;
+    span: WhatHTMLAttributes;
+    p: WhatHTMLAttributes;
+    section: WhatHTMLAttributes;
+    article: WhatHTMLAttributes;
+    header: WhatHTMLAttributes;
+    footer: WhatHTMLAttributes;
+    main: WhatHTMLAttributes;
+    aside: WhatHTMLAttributes;
+    nav: WhatHTMLAttributes;
+    h1: WhatHTMLAttributes;
+    h2: WhatHTMLAttributes;
+    h3: WhatHTMLAttributes;
+    h4: WhatHTMLAttributes;
+    h5: WhatHTMLAttributes;
+    h6: WhatHTMLAttributes;
+    ul: WhatHTMLAttributes;
+    ol: WhatHTMLAttributes;
+    li: WhatHTMLAttributes;
+    dl: WhatHTMLAttributes;
+    dt: WhatHTMLAttributes;
+    dd: WhatHTMLAttributes;
+    table: WhatHTMLAttributes;
+    thead: WhatHTMLAttributes;
+    tbody: WhatHTMLAttributes;
+    tfoot: WhatHTMLAttributes;
+    tr: WhatHTMLAttributes;
+    th: WhatHTMLAttributes;
+    td: WhatHTMLAttributes;
+    caption: WhatHTMLAttributes;
+    colgroup: WhatHTMLAttributes;
+    col: WhatHTMLAttributes;
+    fieldset: WhatHTMLAttributes;
+    legend: WhatHTMLAttributes;
+    strong: WhatHTMLAttributes;
+    em: WhatHTMLAttributes;
+    b: WhatHTMLAttributes;
+    i: WhatHTMLAttributes;
+    u: WhatHTMLAttributes;
+    small: WhatHTMLAttributes;
+    mark: WhatHTMLAttributes;
+    code: WhatHTMLAttributes;
+    pre: WhatHTMLAttributes;
+    kbd: WhatHTMLAttributes;
+    blockquote: WhatHTMLAttributes;
+    hr: WhatHTMLAttributes;
+    br: WhatHTMLAttributes;
+    figure: WhatHTMLAttributes;
+    figcaption: WhatHTMLAttributes;
+    details: WhatHTMLAttributes;
+    summary: WhatHTMLAttributes;
+    dialog: WhatHTMLAttributes;
+    picture: WhatHTMLAttributes;
+    iframe: WhatHTMLAttributes;
+    canvas: WhatHTMLAttributes;
+    template: WhatHTMLAttributes;
+    slot: WhatHTMLAttributes;
+    time: WhatHTMLAttributes;
+    progress: WhatHTMLAttributes;
+    meter: WhatHTMLAttributes;
+    output: WhatHTMLAttributes;
+    datalist: WhatHTMLAttributes;
+    optgroup: WhatHTMLAttributes;
+
+    // SVG.
+    svg: WhatSVGAttributes;
+    g: WhatSVGAttributes;
+    path: WhatSVGAttributes;
+    circle: WhatSVGAttributes;
+    ellipse: WhatSVGAttributes;
+    rect: WhatSVGAttributes;
+    line: WhatSVGAttributes;
+    polyline: WhatSVGAttributes;
+    polygon: WhatSVGAttributes;
+    text: WhatSVGAttributes;
+    tspan: WhatSVGAttributes;
+    defs: WhatSVGAttributes;
+    linearGradient: WhatSVGAttributes;
+    radialGradient: WhatSVGAttributes;
+    stop: WhatSVGAttributes;
+    clipPath: WhatSVGAttributes;
+    use: WhatSVGAttributes;
+
+    // Custom elements / web components remain valid.
+    [tagName: string]: WhatHTMLAttributes;
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,10 +13,12 @@
       "import": "./src/index.js"
     },
     "./jsx-runtime": {
+      "types": "./jsx-runtime.d.ts",
       "production": "./dist/jsx-runtime.min.js",
       "import": "./src/jsx-runtime.js"
     },
     "./jsx-dev-runtime": {
+      "types": "./jsx-dev-runtime.d.ts",
       "production": "./dist/jsx-dev-runtime.min.js",
       "import": "./src/jsx-dev-runtime.js"
     },
@@ -35,6 +37,8 @@
     "src",
     "dist/**/*.min.js",
     "index.d.ts",
+    "jsx-runtime.d.ts",
+    "jsx-dev-runtime.d.ts",
     "render.d.ts",
     "testing.d.ts"
   ],

--- a/packages/core/test/fixtures/jsx/bad.tsx
+++ b/packages/core/test/fixtures/jsx/bad.tsx
@@ -1,0 +1,7 @@
+// Invalid What JSX — the types MUST reject this (proves the runtime types are
+// not blanket `any`). A string is not a valid onclick handler.
+function Bad() {
+  return <button onclick={'not a function'}>x</button>;
+}
+
+export default Bad;

--- a/packages/core/test/fixtures/jsx/good.tsx
+++ b/packages/core/test/fixtures/jsx/good.tsx
@@ -1,0 +1,27 @@
+// Valid What JSX — must type-check clean under strict mode.
+// Guards packages/core/jsx-runtime.d.ts (JSX.IntrinsicElements + runtime types).
+import { signal } from 'what-framework';
+
+function Counter() {
+  const count = signal(0);
+  return (
+    <div class="counter" id="root">
+      {/* reactive text child */}
+      <span>{() => `Count: ${count()}`}</span>
+      {/* lowercase + camelCase event handlers both valid */}
+      <button onclick={() => count((c) => c + 1)}>inc</button>
+      <button onClick={() => count((c) => c - 1)}>dec</button>
+      {/* reactive attribute value */}
+      <input type="text" value={() => String(count())} disabled={false} />
+      <a href="/home" target="_blank">home</a>
+      {/* data-/aria- and arbitrary attributes pass through */}
+      <div data-testid="x" aria-label="y" custom-attr="z" />
+      {/* SVG (recharts-style) */}
+      <svg width={100} height={50}>
+        <path d="M0 0 L10 10" stroke="red" fill="none" />
+      </svg>
+    </div>
+  );
+}
+
+export default Counter;

--- a/packages/core/test/jsx-types.test.js
+++ b/packages/core/test/jsx-types.test.js
@@ -1,0 +1,75 @@
+// Type-level regression test for the shipped JSX runtime declarations
+// (packages/core/jsx-runtime.d.ts + jsx-dev-runtime.d.ts, re-exported by
+// what-framework). Guards against the "JSX has no type checking" DX gap:
+// before these declarations, authoring JSX with
+//   "jsx": "react-jsx", "jsxImportSource": "what-framework"
+// failed under strict mode with TS7026 (no JSX.IntrinsicElements) and TS7016
+// (no declaration for `what-framework/jsx-runtime`).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, 'fixtures', 'jsx');
+
+/** Compile a single fixture and return its pre-emit diagnostics. */
+function compile(file, importSource, jsx = ts.JsxEmit.ReactJSX) {
+  const options = {
+    strict: true,
+    noEmit: true,
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    jsx,
+    jsxImportSource: importSource,
+    types: [],
+  };
+  const program = ts.createProgram([join(FIXTURES, file)], options);
+  return ts.getPreEmitDiagnostics(program);
+}
+
+function messages(diags) {
+  return diags.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
+}
+
+test('valid What JSX type-checks clean via what-framework/jsx-runtime', () => {
+  const diags = compile('good.tsx', 'what-framework');
+  assert.equal(
+    diags.length,
+    0,
+    `expected no diagnostics, got:\n${messages(diags).join('\n')}`,
+  );
+});
+
+test('valid What JSX type-checks clean via what-core/jsx-runtime', () => {
+  const diags = compile('good.tsx', 'what-core');
+  assert.equal(
+    diags.length,
+    0,
+    `expected no diagnostics, got:\n${messages(diags).join('\n')}`,
+  );
+});
+
+test('valid What JSX type-checks clean under jsx:"preserve" (the create-what scaffold config)', () => {
+  const diags = compile('good.tsx', 'what-framework', ts.JsxEmit.Preserve);
+  assert.equal(
+    diags.length,
+    0,
+    `expected no diagnostics, got:\n${messages(diags).join('\n')}`,
+  );
+});
+
+test('invalid JSX is rejected — types are not blanket any', () => {
+  const diags = compile('bad.tsx', 'what-framework');
+  assert.ok(diags.length > 0, 'expected a type error for a string onclick handler');
+  // TS2322: Type 'string' is not assignable to type 'EventHandler<...>'.
+  assert.ok(
+    diags.some((d) => d.code === 2322),
+    `expected TS2322 assignability error, got: ${messages(diags).join('\n')}`,
+  );
+});

--- a/packages/what/jsx-dev-runtime.d.ts
+++ b/packages/what/jsx-dev-runtime.d.ts
@@ -1,0 +1,2 @@
+// what-framework re-exports the JSX dev-runtime types from what-core.
+export * from 'what-core/jsx-dev-runtime';

--- a/packages/what/jsx-runtime.d.ts
+++ b/packages/what/jsx-runtime.d.ts
@@ -1,0 +1,2 @@
+// what-framework re-exports the JSX runtime types from what-core.
+export * from 'what-core/jsx-runtime';

--- a/packages/what/package.json
+++ b/packages/what/package.json
@@ -13,10 +13,12 @@
       "import": "./src/index.js"
     },
     "./jsx-runtime": {
+      "types": "./jsx-runtime.d.ts",
       "production": "./dist/jsx-runtime.min.js",
       "import": "./src/jsx-runtime.js"
     },
     "./jsx-dev-runtime": {
+      "types": "./jsx-dev-runtime.d.ts",
       "production": "./dist/jsx-dev-runtime.min.js",
       "import": "./src/jsx-dev-runtime.js"
     },
@@ -45,6 +47,8 @@
     "src",
     "dist/**/*.min.js",
     "index.d.ts",
+    "jsx-runtime.d.ts",
+    "jsx-dev-runtime.d.ts",
     "render.d.ts",
     "router.d.ts",
     "server.d.ts",


### PR DESCRIPTION
## Problem

Authoring JSX with `jsxImportSource: \"what-framework\"` (the create-what scaffold's config) failed to type-check under `strict`. Every element produced:

- **TS7026** — JSX element implicitly has type `any` because no interface `JSX.IntrinsicElements` exists
- **TS7016** — could not find a declaration file for module `what-framework/jsx-runtime`

The `./jsx-runtime` and `./jsx-dev-runtime` subpath exports shipped **no `types`**, and no `JSX` namespace existed anywhere in the packages. For a JSX-first React alternative, that meant TypeScript users got zero type-checking (or a wall of red) on their primary authoring surface.

## Fix

- Add `jsx-runtime.d.ts` / `jsx-dev-runtime.d.ts` to **what-core** with a full `JSX` namespace (`IntrinsicElements` for HTML + SVG, `Element`, event handlers, reactive attribute values) plus the `jsx`/`jsxs`/`jsxDEV`/`Fragment` runtime signatures.
- Re-export both from **what-framework**.
- Wire up the `types` export condition and the `files` allowlist in both packages so the declarations actually ship in the npm tarball.

Types mirror What's **lenient runtime**: both `class`/`className`, camelCase and lowercase `on*` handlers (bound via `key.slice(2).toLowerCase()`), reactive `() => value` attribute values, and `data-`/`aria-`/custom attributes stay valid — while genuinely wrong props (e.g. a string `onclick`) are still rejected (not blanket `any`).

## Tests

`packages/core/test/jsx-types.test.js` drives the TypeScript compiler API over real What JSX fixtures and asserts:

- clean under `react-jsx`, `react-jsxdev`, and `preserve` (the scaffold config)
- clean for both `what-framework` and `what-core` import sources
- an invalid handler produces **TS2322** (proves types aren't `any`)

Adds `typescript` as a root devDependency so the test runs deterministically under `npm ci`.

## Verification

- Full suite green: **1419 tests pass** (1416 + 3 new; the 4th mode added after) + 40 stress.
- `hygiene:publish`, `build`, `check:size`, `test:prod` all pass locally.