### PR TITLE
ci: make bench-gate and benchmarks-cron deploy non-blocking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,6 +47,12 @@ jobs:
 
       - name: Deploy to Vercel
         if: steps.diff.outputs.changed == 'true'
+        # Non-blocking: VERCEL_TOKEN is not configured on this repo, so the
+        # deploy step is expected to fail. Marking it continue-on-error keeps the
+        # benchmark-refresh commit (the real product of this cron) from being
+        # reported as a red run over an expected, non-correctness deploy failure.
+        # When VERCEL_TOKEN is added, remove this and let real failures surface.
+        continue-on-error: true
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: node scripts/deploy-vercel.mjs --targets "sites/benchmarks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,11 +312,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Benchmark gate
+      - name: Benchmark gate (perf — non-blocking signal)
+        # Non-blocking, matching the bench:gate step in release-and-deploy.yml:
+        # the checked-in perf baselines are recorded on fast local hardware
+        # (M3 Max), and GitHub shared runners are several× slower/noisier on some
+        # microbenchmarks (e.g. `batch() 100 writes`), so this gate false-fails
+        # unpredictably. Kept as its own visible job (a signal, not a blocker);
+        # perf is gated strictly by `release:verify` on local hardware.
+        continue-on-error: true
         env:
-          # GitHub-hosted runners are substantially slower/noisier than the
-          # checked-in local baselines; keep CI as a catastrophic regression
-          # guard while preserving stricter defaults for local release checks.
           WHAT_BENCH_TOLERANCE_CORE: 0.80
           WHAT_BENCH_TOLERANCE_DX: 0.85
         run: npm run -s bench:gate

--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -58,8 +58,9 @@ jobs:
         # checked-in perf baselines are recorded on fast local hardware (M3 Max);
         # GitHub shared runners are several× slower on some microbenchmarks
         # (e.g. `batch() 100 writes`), so bench:gate false-fails here and must
-        # not block a publish. Perf is still gated strictly by the dedicated
-        # `bench-gate` job in ci.yml and by `release:verify` on local hardware.
+        # not block a publish. On CI the `bench-gate` job in ci.yml runs the same
+        # gate as a visible-but-non-blocking signal; perf is gated strictly by
+        # `release:verify` on local hardware.
         run: |
           npm run -s hygiene:publish
           npm run -s test


### PR DESCRIPTION
## What & why

Two CI signals report red for non-correctness reasons, training reviewers to ignore red. This makes both non-blocking while keeping them visible.

### 1. `benchmarks.yml` — "Deploy to Vercel" step
`VERCEL_TOKEN` is not configured on this repo, so the deploy step always fails. That masked the real product of the cron — the committed benchmark-data refresh — behind an expected-red run. Now `continue-on-error: true` with a comment noting the token is unset (and to remove the flag once it's added, so real failures surface).

### 2. `ci.yml` — `bench-gate` job
The checked-in perf baselines are recorded on fast local hardware (M3 Max); GitHub shared runners are several× slower/noisier on some microbenchmarks (e.g. `batch() 100 writes`), so the gate false-fails unpredictably. Now `continue-on-error: true`, kept as its own **visible** job (a signal, not a blocker) — mirroring the `bench:gate` step already non-blocking in `release-and-deploy.yml`.

Also corrects a now-stale comment in `release-and-deploy.yml` that described ci.yml's bench-gate as strict/blocking.

## Safety
No correctness gate is weakened. Perf is still gated **strictly** by `release:verify` on local hardware. Only shared-runner perf variance and an unconfigured deploy token are made non-blocking.

All three workflow files validated as well-formed YAML.