### PR TITLE
fix(devtools-mcp): keep DevTools/MCP client out of production builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ benchmark/results/
 !/package-lock.json
 
 .npmrc
+
+# Scratch Vite projects created by the devtools-mcp prod-build regression test
+# (normally removed in its after() hook; ignored here in case a run crashes).
+packages/devtools-mcp/test/.tmp-build-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to What Framework will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **devtools-mcp: the DevTools/MCP client can no longer leak into a production build.** The Vite plugin (`what-devtools-mcp/vite-plugin`) injects a `<script src="/@id/…virtual:what-devtools-mcp/bootstrap">` that installs the devtools client and opens a WebSocket to a local bridge. It was guarded only by `apply: 'serve'`, which excludes it from `vite build` — correct, but a single point of failure: a meta-framework that flattens plugin arrays and re-invokes hooks, a consumer that spreads the plugin into another plugin's returned list, or a config that forgets its own command guard can defeat `apply` and ship the dev-only bootstrap into prod. When that happened on a real deploy, the production page requested `virtual:what-devtools-mcp/bootstrap` (500 in prod) and, with a dev server live on the machine, could follow it to `localhost`. The plugin now also captures the resolved Vite command in `configResolved` and makes `resolveId`/`load`/`transformIndexHtml` no-op whenever `command === 'build'`, and the injected bootstrap wraps its side effects in `if (import.meta.env.DEV)` so that even a directly-imported bootstrap dead-code-eliminates and tree-shakes to nothing in a prod bundle. Net effect: a production build now contains **zero** devtools/MCP code regardless of how the plugin is wired. (The browser client already refused to connect under `import.meta.env.PROD`; it performs no cross-origin navigation.)
+
+### Verified
+- New build-output regression test (`packages/devtools-mcp/test/vite-plugin-prod-build.test.js`) runs a real `vite build` and asserts the bundle contains no `what-devtools`/`virtual:what-devtools`/`__x00__`/`connectDevToolsMCP`/`__what_mcp` references — in both the normal case *and* with the plugin's `apply` stripped (proving the command guard, not just `apply`, holds). It also asserts the dev (serve) transform still injects the bootstrap, so the guard is dev-only rather than a blanket disable. Full suite green (1435 tests).
+
 ## [0.11.3] - 2026-07-04 — reactive thunk-in-array-child fix; TypeScript declarations (JSX, what-react, what-compiler)
 
 Patch release. All 14 packages move to 0.11.3 together (fixed-group release). No API changes — one reactivity fix plus additive TypeScript declarations.

--- a/packages/devtools-mcp/src/vite-plugin.js
+++ b/packages/devtools-mcp/src/vite-plugin.js
@@ -50,9 +50,30 @@ const BROWSER_BOOTSTRAP_URL = '/@id/__x00__' + VIRTUAL_BOOTSTRAP_ID;
 export const DISCOVERY_PATH = '/__what_mcp_discovery';
 
 export default function whatDevToolsMCP({ port = 9229, token = '' } = {}) {
+  // Defense-in-depth: `apply: 'serve'` is the primary guard — Vite excludes the
+  // whole plugin from `vite build`, so none of these hooks run for a production
+  // bundle. But `apply` can be defeated (a meta-framework that flattens plugin
+  // arrays and re-invokes hooks, a consumer that spreads this plugin into
+  // another plugin's returned list, or a future Vite change), and getting it
+  // wrong once ships devtools + a dev-server `<script src>` into production
+  // (observed on a real deploy: the prod page requested
+  // `virtual:what-devtools-mcp/bootstrap` and, with a dev server live on the
+  // machine, followed it to localhost). So we ALSO gate every injecting hook on
+  // the resolved Vite command: if we ever run under `command === 'build'`, we
+  // resolve/load/inject NOTHING. `command` stays undefined when configResolved
+  // isn't called (unit tests, manual `plugin.load(...)`) — treated as serve.
+  let command;
+  const isBuild = () => command === 'build';
+
   return {
     name: 'what-devtools-mcp',
     apply: 'serve',
+
+    // Capture the resolved command so the injecting hooks below can hard-refuse
+    // to run during a production build even if `apply: 'serve'` was bypassed.
+    configResolved(config) {
+      command = config.command;
+    },
 
     // Node-side bridge probe, exposed same-origin to the browser client.
     // Responds { bridge: false } when no bridge is running (quietly), or
@@ -83,6 +104,7 @@ export default function whatDevToolsMCP({ port = 9229, token = '' } = {}) {
 
     // Resolve the virtual module so Vite knows we own it.
     resolveId(id) {
+      if (isBuild()) return null; // never own the virtual module in a build
       if (id === VIRTUAL_BOOTSTRAP_ID || id === RESOLVED_BOOTSTRAP_ID) {
         return RESOLVED_BOOTSTRAP_ID;
       }
@@ -94,18 +116,30 @@ export default function whatDevToolsMCP({ port = 9229, token = '' } = {}) {
     // properly rewritten to dev-server URLs — unlike inline <script type=module>
     // tags injected via transformIndexHtml, which Vite does not transform.
     load(id) {
+      if (isBuild()) return null; // never emit devtools source into a build
       if (id !== RESOLVED_BOOTSTRAP_ID) return null;
       const tokenValue = resolveToken(token);
+      // The side effects are gated behind `import.meta.env.DEV`. In a dev server
+      // that's statically `true`, so devtools install and connect normally. If
+      // this module ever ends up in a production bundle (e.g. a consumer imports
+      // the virtual id directly, or a bundler pulls it in despite the guards
+      // above), `import.meta.env.DEV` is statically `false`, the whole block is
+      // dead-code-eliminated, and the now-unused imports tree-shake away — so a
+      // prod bundle carries zero devtools/MCP code and can never open a
+      // connection to a local dev server.
       return [
         `import * as core from 'what-core';`,
         `import { installDevTools } from 'what-devtools';`,
         `import { connectDevToolsMCP } from 'what-devtools-mcp/client';`,
-        `installDevTools(core);`,
-        `connectDevToolsMCP({ port: ${port}, token: ${JSON.stringify(tokenValue)}, discoveryUrl: ${JSON.stringify(DISCOVERY_PATH)} });`,
+        `if (import.meta.env && import.meta.env.DEV) {`,
+        `  installDevTools(core);`,
+        `  connectDevToolsMCP({ port: ${port}, token: ${JSON.stringify(tokenValue)}, discoveryUrl: ${JSON.stringify(DISCOVERY_PATH)} });`,
+        `}`,
       ].join('\n');
     },
 
     transformIndexHtml() {
+      if (isBuild()) return; // never inject the bootstrap <script> into built HTML
       // Inject a <script src> that points at the virtual module. The browser
       // fetches `/@id/__x00__virtual:what-devtools-mcp/bootstrap`, Vite serves
       // the transformed bootstrap (bare specifiers resolved), and everything

--- a/packages/devtools-mcp/test/vite-plugin-prod-build.test.js
+++ b/packages/devtools-mcp/test/vite-plugin-prod-build.test.js
@@ -1,0 +1,146 @@
+/**
+ * Regression: the devtools/MCP client must NEVER ship in a production build.
+ *
+ * A real deploy once shipped the dev-only bootstrap into prod: the production
+ * page requested `virtual:what-devtools-mcp/bootstrap` (500 in prod) and, with a
+ * dev server live on the machine, could follow it to localhost. These tests run
+ * a real `vite build` with the plugin and assert the emitted bundle contains
+ * ZERO devtools references — and that the same plugin STILL injects the
+ * bootstrap during a dev (serve) transform, so the guard is dev-only, not a
+ * blanket disable.
+ *
+ * Two prod scenarios are covered:
+ *   1. The plugin used normally (its `apply: 'serve'` excludes it from build).
+ *   2. The plugin's `apply` stripped — simulating a meta-framework/consumer that
+ *      re-invokes hooks at build time. The plugin's own `command === 'build'`
+ *      guard must still keep every devtools reference out of the bundle.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG_SRC = join(HERE, '..', 'src');
+
+// Anything that would betray the devtools/MCP client leaking into the bundle.
+const FORBIDDEN = [
+  'what-devtools-mcp',
+  'virtual:what-devtools',
+  '__x00__',
+  'connectDevToolsMCP',
+  '__what_mcp',
+];
+
+function allBundleText(distDir) {
+  let text = '';
+  const walk = (d) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else text += '\n' + readFileSync(p, 'utf8');
+    }
+  };
+  walk(distDir);
+  return text;
+}
+
+function scaffold(dir) {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'index.html'),
+    '<!doctype html><html><head><title>t</title></head>' +
+      '<body><div id="app"></div><script type="module" src="/src/main.js"></script></body></html>',
+  );
+  writeFileSync(join(dir, 'src', 'main.js'), "document.getElementById('app').textContent = 'ok';\n");
+}
+
+// Aliases so the bootstrap's bare imports resolve if it ever DID get pulled in
+// (a leak would then surface as real devtools code in the bundle, not a build
+// error that masks the check).
+const ALIASES = {
+  'what-core': join(HERE, '..', '..', 'core', 'src', 'index.js'),
+  'what-devtools': join(HERE, '..', '..', 'devtools', 'src', 'index.js'),
+  'what-devtools-mcp/client': join(PKG_SRC, 'client.js'),
+};
+
+async function buildWith(plugin, dir) {
+  const { build } = await import('vite');
+  await build({
+    root: dir,
+    logLevel: 'silent',
+    resolve: { alias: ALIASES },
+    plugins: [plugin],
+    build: { outDir: 'dist', emptyOutDir: true },
+  });
+  return allBundleText(join(dir, 'dist'));
+}
+
+describe('vite-plugin production build contains zero devtools code', () => {
+  let whatDevToolsMCP;
+  let tmp;
+
+  before(async () => {
+    ({ default: whatDevToolsMCP } = await import('../src/vite-plugin.js'));
+    // Keep the scratch project INSIDE the repo. In the OS tmpdir, macOS's
+    // /var -> /private/var symlink makes Vite treat the root as "outside" cwd
+    // and rollup rejects the escaping index.html asset name.
+    tmp = mkdtempSync(join(HERE, '.tmp-build-'));
+  });
+  after(() => { if (tmp) rmSync(tmp, { recursive: true, force: true }); });
+
+  it('a normal prod build (apply: "serve" excludes the plugin) has no devtools refs', async () => {
+    const dir = join(tmp, 'normal');
+    scaffold(dir);
+    const bundle = await buildWith(whatDevToolsMCP(), dir);
+    for (const needle of FORBIDDEN) {
+      assert.ok(!bundle.includes(needle), `prod bundle must not contain "${needle}"`);
+    }
+  });
+
+  it('a prod build with apply stripped STILL has no devtools refs (command guard)', async () => {
+    const dir = join(tmp, 'apply-stripped');
+    scaffold(dir);
+    // Simulate a consumer/meta-framework that defeats `apply: 'serve'` and lets
+    // the plugin's hooks run at build time. The command-based guard must hold.
+    const plugin = whatDevToolsMCP();
+    delete plugin.apply;
+    const bundle = await buildWith(plugin, dir);
+    for (const needle of FORBIDDEN) {
+      assert.ok(!bundle.includes(needle), `prod bundle (apply stripped) must not contain "${needle}"`);
+    }
+  });
+});
+
+describe('vite-plugin dev (serve) transform still injects the bootstrap', () => {
+  it('injects the devtools bootstrap <script> when command is serve', async () => {
+    const { default: whatDevToolsMCP } = await import('../src/vite-plugin.js');
+    const plugin = whatDevToolsMCP();
+    // Emulate Vite resolving the config for a dev server.
+    plugin.configResolved({ command: 'serve' });
+
+    const html = plugin.transformIndexHtml();
+    assert.ok(Array.isArray(html) && html.length === 1, 'injects exactly one tag in serve mode');
+    assert.equal(html[0].tag, 'script');
+    assert.match(html[0].attrs.src, /virtual:what-devtools-mcp\/bootstrap/);
+
+    // And it resolves + loads the virtual module in serve mode.
+    const resolved = plugin.resolveId('virtual:what-devtools-mcp/bootstrap');
+    assert.equal(resolved, '\0virtual:what-devtools-mcp/bootstrap');
+    const code = plugin.load(resolved);
+    assert.match(code, /connectDevToolsMCP\(/);
+    assert.match(code, /import\.meta\.env && import\.meta\.env\.DEV/);
+  });
+
+  it('injects NOTHING once the command resolves to build', async () => {
+    const { default: whatDevToolsMCP } = await import('../src/vite-plugin.js');
+    const plugin = whatDevToolsMCP();
+    plugin.configResolved({ command: 'build' });
+
+    assert.equal(plugin.transformIndexHtml(), undefined, 'no HTML injection in build');
+    assert.equal(plugin.resolveId('virtual:what-devtools-mcp/bootstrap'), null, 'does not own the id in build');
+    assert.equal(plugin.load('\0virtual:what-devtools-mcp/bootstrap'), null, 'emits no source in build');
+  });
+});

--- a/scripts/smoke-scaffold.mjs
+++ b/scripts/smoke-scaffold.mjs
@@ -24,7 +24,7 @@
 // Exits non-zero on any failure; all spawned processes are killed on exit.
 
 import { execFileSync, spawn } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -186,6 +186,20 @@ async function smokeSpa(workDir, tarballs, browser) {
 
   run('npm', ['run', 'build'], { cwd: appDir });
   assert(existsSync(join(appDir, 'dist', 'index.html')), 'vite build produced dist/index.html');
+
+  // The scaffold wires up `whatDevTools()` (what-devtools-mcp/vite-plugin) — a
+  // DEV-ONLY plugin. A production build must carry ZERO devtools/MCP code: a
+  // past regression shipped the dev bootstrap into prod, so the page requested
+  // `virtual:what-devtools-mcp/bootstrap` (500) and could follow a live local
+  // dev server to localhost. Grep the whole built bundle to prove it's clean.
+  const distText = readdirSync(join(appDir, 'dist'), { recursive: true })
+    .map((f) => join(appDir, 'dist', f))
+    .filter((p) => { try { return statSync(p).isFile(); } catch { return false; } })
+    .map((p) => readFileSync(p, 'utf8'))
+    .join('\n');
+  for (const needle of ['what-devtools', 'virtual:what-devtools', '__x00__', 'connectDevToolsMCP', '__what_mcp']) {
+    assert(!distText.includes(needle), `prod bundle contains NO devtools leak ("${needle}")`);
+  }
 
   await assertPortFree(port);
   const viteBin = join(appDir, 'node_modules', 'vite', 'bin', 'vite.js');


### PR DESCRIPTION
## Problem

The `what-devtools-mcp/vite-plugin` injects a dev-only bootstrap `<script src="/@id/…virtual:what-devtools-mcp/bootstrap">` that installs the devtools client and opens a WebSocket to a local bridge. It was guarded **only** by `apply: 'serve'`.

`apply: 'serve'` correctly excludes the plugin from `vite build` (verified in Vite 6.4.3 and 7.3.5), but it's a single point of failure. It can be defeated by a meta-framework that flattens plugin arrays and re-invokes hooks, a consumer that spreads this plugin into another plugin's returned list, or a config that forgets its own command guard. When that happened on a real deploy (app.vura.io), the production page requested `virtual:what-devtools-mcp/bootstrap` (500 in prod) and, with a dev server live on the machine, could follow it to `localhost`.

## Root cause of the two symptoms

- **`virtual:what-devtools-mcp/bootstrap` in prod** — the plugin's `transformIndexHtml` bakes the dev-server `<script src>` into the built HTML if it ever runs at build time.
- **localhost redirect** — *not* the devtools runtime. The browser client (`connectDevToolsMCP`) already early-returns under `import.meta.env.PROD`, only opens `ws://localhost:{port}`, and its only navigation path (`what_navigate`) is same-origin `history.pushState` with a path. The "follow to localhost" symptom is the leaked **dev-server-relative** bootstrap URL combined with a live local dev server — i.e. a build-leak symptom, fixed by keeping the bootstrap out of prod entirely.

## Fix (defense-in-depth; `apply: 'serve'` kept as primary guard)

- Capture the resolved Vite command in `configResolved`; make `resolveId` / `load` / `transformIndexHtml` no-op when `command === 'build'` — the bootstrap can't be resolved, loaded, or injected during a build even if `apply` is bypassed.
- Wrap the injected bootstrap's side effects in `if (import.meta.env.DEV)` so a directly-imported bootstrap dead-code-eliminates and tree-shakes to nothing in a prod bundle.

Net: a production build contains **zero** devtools/MCP code regardless of how the plugin is wired.

## Sibling audit

- `configureServer` (`/__what_mcp_discovery` middleware) is already dev-only — `configureServer` never runs during build.
- The bridge is Node-only; no other virtual modules or dev-only clients exist in the package.

## Tests

- **New build-output regression test** (`packages/devtools-mcp/test/vite-plugin-prod-build.test.js`): runs a real `vite build` and asserts the bundle has no `what-devtools` / `virtual:what-devtools` / `__x00__` / `connectDevToolsMCP` / `__what_mcp` references — both normally *and* with the plugin's `apply` stripped (proving the command guard, not just `apply`, holds). Also asserts the dev (serve) transform still injects the bootstrap, so the guard is dev-only, not a blanket disable.
- **Scaffold smoke** now greps the real create-what SPA prod bundle for the same leak markers.

## Verification

- Full suite green: 1435 tests.
- `node scripts/smoke-scaffold.mjs` green (SPA + fullstack), including the new leak assertions.

## Downstream action

The Vura dashboard (app.vura.io) must be **rebuilt against the next what-fw release** to pick up this framework-level guard. Its config already carries a redundant app-level `command === 'serve'` workaround; the currently-deployed bundle is clean, but the framework fix removes the reliance on every consumer remembering that guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)