### PR TITLE
fix(release): retry npm registry verify with backoff on propagation lag

### DIFF
--- a/scripts/lib/retry.mjs
+++ b/scripts/lib/retry.mjs
@@ -1,0 +1,51 @@
+// Generic retry-with-backoff helper.
+//
+// Built for scripts/verify-registry-install.mjs: `npm install <pkg>@<version>`
+// immediately after `npm publish` reliably 404s for a few minutes while the
+// npm registry/CDN propagates the freshly published tarball and dist-tag —
+// this is not a real failure, just replication lag. Retrying the same
+// operation a handful of times with backoff self-heals without masking a
+// genuine publish failure (which still fails after the final attempt).
+//
+// Kept generic (no npm-specific code) so it's independently unit-testable.
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * @template T
+ * @param {(attempt: number) => T | Promise<T>} task - the operation to retry.
+ *   Receives the 1-based attempt number. Throw to signal failure.
+ * @param {object} [options]
+ * @param {number} [options.attempts=5] - total attempts (>= 1) before giving up.
+ * @param {number[]} [options.delaysMs=[30000,60000,90000,120000]] - delay before
+ *   each retry, indexed by (attempt - 1). The last entry is reused if there are
+ *   more retries than entries.
+ * @param {(info: { attempt: number, attempts: number, delayMs: number, error: unknown }) => void | Promise<void>} [options.onRetry]
+ *   called after a failed attempt, before sleeping — use for logging.
+ * @param {(ms: number) => Promise<void>} [options.sleep] - injectable for tests.
+ * @returns {Promise<T>}
+ */
+export async function retryWithBackoff(task, options = {}) {
+  const attempts = options.attempts ?? 5;
+  const delaysMs = options.delaysMs ?? [30_000, 60_000, 90_000, 120_000];
+  const onRetry = options.onRetry ?? (() => {});
+  const sleep = options.sleep ?? defaultSleep;
+
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error(`retryWithBackoff: attempts must be a positive integer, got ${attempts}`);
+  }
+
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await task(attempt);
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) break;
+      const delayMs = delaysMs[Math.min(attempt - 1, delaysMs.length - 1)];
+      await onRetry({ attempt, attempts, delayMs, error });
+      await sleep(delayMs);
+    }
+  }
+  throw lastError;
+}

--- a/scripts/lib/test/retry.test.mjs
+++ b/scripts/lib/test/retry.test.mjs
@@ -1,0 +1,115 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { retryWithBackoff } from '../retry.mjs';
+
+function fakeSleep(record) {
+  return async (ms) => {
+    record.push(ms);
+  };
+}
+
+describe('retryWithBackoff', () => {
+  it('returns the result on first success without sleeping or retrying', async () => {
+    const sleeps = [];
+    let calls = 0;
+    const result = await retryWithBackoff(
+      async (attempt) => {
+        calls += 1;
+        assert.equal(attempt, 1);
+        return 'ok';
+      },
+      { sleep: fakeSleep(sleeps) },
+    );
+    assert.equal(result, 'ok');
+    assert.equal(calls, 1);
+    assert.deepEqual(sleeps, []);
+  });
+
+  it('retries with the configured backoff and succeeds once the task recovers', async () => {
+    const sleeps = [];
+    const retries = [];
+    let calls = 0;
+    const result = await retryWithBackoff(
+      async (attempt) => {
+        calls += 1;
+        if (attempt < 3) throw new Error(`fail ${attempt}`);
+        return 'recovered';
+      },
+      {
+        attempts: 5,
+        delaysMs: [10, 20, 30, 40],
+        sleep: fakeSleep(sleeps),
+        onRetry: (info) => retries.push(info),
+      },
+    );
+    assert.equal(result, 'recovered');
+    assert.equal(calls, 3);
+    assert.deepEqual(sleeps, [10, 20]);
+    assert.deepEqual(
+      retries.map((r) => [r.attempt, r.attempts, r.delayMs, r.error.message]),
+      [
+        [1, 5, 10, 'fail 1'],
+        [2, 5, 20, 'fail 2'],
+      ],
+    );
+  });
+
+  it('throws the final error after exhausting all attempts, without an extra sleep', async () => {
+    const sleeps = [];
+    let calls = 0;
+    await assert.rejects(
+      () =>
+        retryWithBackoff(
+          async () => {
+            calls += 1;
+            throw new Error(`boom ${calls}`);
+          },
+          { attempts: 3, delaysMs: [5, 5], sleep: fakeSleep(sleeps) },
+        ),
+      /boom 3/,
+    );
+    assert.equal(calls, 3);
+    // Only 2 sleeps: no sleep after the final, non-retried attempt.
+    assert.deepEqual(sleeps, [5, 5]);
+  });
+
+  it('reuses the last delay entry when there are more retries than delay entries', async () => {
+    const sleeps = [];
+    let calls = 0;
+    await assert.rejects(() =>
+      retryWithBackoff(
+        async () => {
+          calls += 1;
+          throw new Error('always fails');
+        },
+        { attempts: 4, delaysMs: [100], sleep: fakeSleep(sleeps) },
+      ),
+    );
+    assert.equal(calls, 4);
+    assert.deepEqual(sleeps, [100, 100, 100]);
+  });
+
+  it('runs exactly once and never sleeps when attempts is 1', async () => {
+    const sleeps = [];
+    let calls = 0;
+    await assert.rejects(() =>
+      retryWithBackoff(
+        async () => {
+          calls += 1;
+          throw new Error('single shot');
+        },
+        { attempts: 1, sleep: fakeSleep(sleeps) },
+      ),
+    );
+    assert.equal(calls, 1);
+    assert.deepEqual(sleeps, []);
+  });
+
+  it('rejects a non-positive-integer attempts option', async () => {
+    await assert.rejects(
+      () => retryWithBackoff(async () => 'unreachable', { attempts: 0 }),
+      /attempts must be a positive integer/,
+    );
+  });
+});

--- a/scripts/run-all-tests.mjs
+++ b/scripts/run-all-tests.mjs
@@ -35,7 +35,7 @@ function testFilesIn(dir) {
 }
 
 const files = [];
-for (const groupDir of ['packages', 'examples']) {
+for (const groupDir of ['packages', 'examples', 'scripts']) {
   const base = join(root, groupDir);
   if (!isDir(base)) continue;
   for (const name of readdirSync(base).sort()) {

--- a/scripts/verify-registry-install.mjs
+++ b/scripts/verify-registry-install.mjs
@@ -5,6 +5,8 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
+import { retryWithBackoff } from './lib/retry.mjs';
+
 const packages = [
   'what-core',
   'what-text',
@@ -24,10 +26,44 @@ const packages = [
 
 const root = process.cwd();
 const version = process.env.WHAT_REGISTRY_VERSION || readVersion();
-const tag = process.env.WHAT_REGISTRY_TAG || 'latest';
-const selector = process.env.WHAT_REGISTRY_VERSION ? version : tag;
+// Default to pinning the exact expected version rather than resolving
+// `@latest`. Right after a publish, npm's dist-tag update and the CDN
+// serving the tarball can both lag by a few minutes; resolving `@latest`
+// during that window can either 404 OR silently resolve to the *previous*
+// version, which would let this check pass without ever having verified the
+// release that was just published. Pinning to the version we just bumped to
+// (and combining it with the retry below) verifies the actual release.
+// `WHAT_REGISTRY_TAG` remains available for an explicit opt-in to dist-tag
+// verification (e.g. confirming `latest` was moved correctly).
+const tag = process.env.WHAT_REGISTRY_TAG || '';
+const selector = tag || version;
 const artifactPath = process.env.WHAT_REGISTRY_SMOKE_ARTIFACT || 'artifacts/registry-smoke.json';
 const completedChecks = [];
+const retryLog = [];
+
+// npm install right after publish reliably 404s for a short window while the
+// registry/CDN propagates — see scripts/lib/retry.mjs. Retry only the two
+// install calls that actually hit the registry; everything else here is
+// local/deterministic and a failure there is a real bug, not lag.
+const RETRY_ATTEMPTS = envInt('WHAT_REGISTRY_RETRY_ATTEMPTS', 5);
+const RETRY_DELAYS_MS = envDelays('WHAT_REGISTRY_RETRY_DELAYS_MS', [30_000, 60_000, 90_000, 120_000]);
+
+function envInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function envDelays(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = raw
+    .split(',')
+    .map((s) => Number.parseInt(s.trim(), 10))
+    .filter((n) => Number.isFinite(n) && n >= 0);
+  return parsed.length ? parsed : fallback;
+}
 
 function readVersion() {
   const res = run(process.execPath, ['-p', "JSON.parse(require('node:fs').readFileSync('packages/core/package.json','utf8')).version"], { cwd: root });
@@ -35,7 +71,7 @@ function readVersion() {
 }
 
 function packageSpec(name) {
-  return process.env.WHAT_REGISTRY_VERSION ? `${name}@${version}` : `${name}@${selector}`;
+  return `${name}@${selector}`;
 }
 
 function run(cmd, args, opts = {}) {
@@ -50,6 +86,24 @@ function run(cmd, args, opts = {}) {
     throw new Error(`${cmd} ${args.join(' ')} failed with ${res.status}\n${details}`);
   }
   return res;
+}
+
+// Wraps a registry-hitting `npm install` in retry-with-backoff. Only for the
+// two call sites that install from the live registry right after publish —
+// see the RETRY_ATTEMPTS/RETRY_DELAYS_MS comment above for why.
+async function runInstallWithRetry(cmd, args, opts, label) {
+  return retryWithBackoff(
+    () => run(cmd, args, opts),
+    {
+      attempts: RETRY_ATTEMPTS,
+      delaysMs: RETRY_DELAYS_MS,
+      onRetry: ({ attempt, attempts, delayMs, error }) => {
+        const note = `${label}: attempt ${attempt}/${attempts} failed (likely npm registry propagation lag), retrying in ${Math.round(delayMs / 1000)}s`;
+        console.warn(`[verify-registry] ${note}\n${error.message}`);
+        retryLog.push({ label, attempt, attempts, delayMs, error: error.message });
+      },
+    },
+  );
 }
 
 function binPath(cwd, bin) {
@@ -77,6 +131,7 @@ async function writeArtifact(status, specs, extra = {}) {
     packageCount: specs.length,
     packages: specs,
     checks: completedChecks,
+    retries: retryLog,
     ...extra,
   };
   await mkdir(dirname(artifactPath), { recursive: true });
@@ -88,7 +143,12 @@ let specs = [];
 try {
   specs = packages.map(packageSpec);
   run('npm', ['init', '-y'], { cwd: tmp });
-  run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund', ...specs], { cwd: tmp });
+  await runInstallWithRetry(
+    'npm',
+    ['install', '--ignore-scripts', '--no-audit', '--no-fund', ...specs],
+    { cwd: tmp },
+    'npm install (registry packages)',
+  );
   completedChecks.push('npm install --ignore-scripts --no-audit --no-fund');
 
   const importCheck = `
@@ -121,7 +181,12 @@ try {
   completedChecks.push('create-what --yes');
 
   const appDir = join(tmp, 'registry-smoke-app');
-  run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund'], { cwd: appDir });
+  await runInstallWithRetry(
+    'npm',
+    ['install', '--ignore-scripts', '--no-audit', '--no-fund'],
+    { cwd: appDir },
+    'npm install (generated app)',
+  );
   run('npm', ['run', 'build'], { cwd: appDir });
   completedChecks.push('generated app install/build');
 


### PR DESCRIPTION
## Summary
- `verify:registry` has false-failed on the 0.11.3, 0.11.4, and 0.11.5 release runs. Diagnosed via `gh run view 28767048630 --log-failed` and `28725064939 --log-failed`: `npm install <pkg>@latest` starts within ~3 seconds of a successful `npm publish` completing and fails (status 1) before the registry/CDN has propagated the freshly published tarball / dist-tag update. The false failure skips the "Deploy Vercel targets" step entirely (that step's default `if:` implicitly requires `success()`).
- Added `scripts/lib/retry.mjs`: a small, unit-tested generic retry-with-backoff helper (5 attempts / ~5 minutes total by default, configurable via `WHAT_REGISTRY_RETRY_ATTEMPTS` / `WHAT_REGISTRY_RETRY_DELAYS_MS`).
- Wrapped **both** registry-hitting `npm install` calls in `scripts/verify-registry-install.mjs` — the top-level packages install and the generated scaffold app's install (the latter had no protection before and is exposed to the same lag since `create-what` pins a semver range against the just-published version).
- Changed the default verify selector from the `latest` dist-tag to the exact expected version (still read from `packages/core/package.json`, same source as before). This is a real correctness fix, not just anti-flake: resolving `@latest` during the propagation window can silently resolve to the *previous* published version and pass without ever having verified the release that was just cut. `WHAT_REGISTRY_TAG` is kept as an explicit opt-in for dist-tag verification.
- Registered `scripts/lib/test` in `run-all-tests.mjs` (alongside `packages/*/test` and `examples/*/test`) so `npm test` covers the new retry helper.
- Confirmed the "Deploy Vercel targets" step's dependency on `verify:registry` is otherwise sensible (gating web deploys behind a green package verification is correct) — no change needed there.

## Test plan
- [x] `node --test scripts/lib/test/retry.test.mjs` — 6/6 pass
- [x] `node scripts/run-all-tests.mjs` — full suite, 1468/1468 pass (confirms `scripts/lib/test` wiring doesn't break discovery)
- [x] `npm run -s verify:registry` against the **live** npm registry — passes on attempt 1 (0.11.5 has since propagated), pinned to `what-framework@0.11.5` etc., `retries: []` in the artifact
- [x] Forced-failure check: `WHAT_REGISTRY_VERSION=0.0.0-nonexistent-smoke-test WHAT_REGISTRY_RETRY_ATTEMPTS=2 WHAT_REGISTRY_RETRY_DELAYS_MS=500 npm run -s verify:registry` — retries once as expected, then fails for real with a clean, correct error (proves retries don't mask a genuine failure)
- [x] `npm run -s hygiene:publish` — passes

Does not cut a release; rides the next one.