### PR TITLE
chore(ci): drop the dead Vercel CLI deploy step from the release workflow

### DIFF
--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -8,16 +8,6 @@ on:
         required: true
         default: true
         type: boolean
-      deploy_web:
-        description: Deploy configured web surfaces to Vercel
-        required: true
-        default: true
-        type: boolean
-      deploy_targets:
-        description: Comma-separated deploy targets (empty = defaults in script)
-        required: false
-        default: ""
-        type: string
       npm_tag:
         description: npm dist-tag for publish
         required: false
@@ -103,16 +93,7 @@ jobs:
           path: artifacts/registry-smoke.json
           if-no-files-found: error
 
-      - name: Deploy Vercel targets
-        if: ${{ inputs.deploy_web }}
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          ARGS=()
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            ARGS+=(--dry-run)
-          fi
-          if [ -n "${{ inputs.deploy_targets }}" ]; then
-            ARGS+=(--targets "${{ inputs.deploy_targets }}")
-          fi
-          node scripts/deploy-vercel.mjs "${ARGS[@]}"
+      # Web surfaces (docs-site, benchmarks, playground, react-compat) deploy via
+      # Vercel's Git integration on push — no VERCEL_TOKEN secret exists in this
+      # repo and the .vercel project links are gitignored, so a CLI deploy step
+      # can never work here. scripts/deploy-vercel.mjs remains for local use.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -180,7 +180,7 @@ Files that contain version strings:
 
 - [ ] Trigger `Release And Deploy` workflow from GitHub Actions:
   - Go to Actions > Release And Deploy > Run workflow
-  - Set `publish_packages: true`, `deploy_web: true`, `npm_tag: latest`
+  - Set `publish_packages: true`, `npm_tag: latest`
   - The workflow runs `release:verify` automatically before publish/deploy
 
 ---

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,10 +11,12 @@ Canonical workflow:
 Manual trigger inputs:
 
 1. `publish_packages` (boolean)
-2. `deploy_web` (boolean)
-3. `deploy_targets` (optional comma-separated override)
-4. `npm_tag` (default `latest`)
-5. `dry_run` (boolean)
+2. `npm_tag` (default `latest`)
+3. `dry_run` (boolean)
+
+Web surfaces (docs-site, benchmarks, playground, react-compat) deploy through
+Vercel's Git integration on push — there is no CI deploy step. `scripts/deploy-vercel.mjs`
+remains available for local, token-in-hand deploys.
 
 The workflow always runs `npm run -s release:verify` before publish/deploy.
 When packages are published, it also runs `npm run -s verify:registry` and uploads
@@ -26,7 +28,6 @@ smoke passes against npm.
 Set these repository secrets in GitHub:
 
 1. `NPM_TOKEN` (npm publish token with package publish permissions)
-2. `VERCEL_TOKEN` (Vercel token with access to linked projects)
 
 ## Local Verification
 


### PR DESCRIPTION
The "Deploy Vercel targets" step could never run in CI: the repo has no VERCEL_TOKEN secret and every target's .vercel project link is gitignored. Web surfaces (docs-site, benchmarks, playground, react-compat) actually deploy via Vercel's Git integration on push — confirmed by the automatic preview deploys on every PR.

- Remove the dead step + its `deploy_web`/`deploy_targets` workflow inputs
- Document the Git-integration deploy path in the workflow and docs/RELEASE.md
- Drop VERCEL_TOKEN from the required-secrets list; keep scripts/deploy-vercel.mjs for local use

Follow-up flagged by PR #20's investigation.