### PR TITLE
chore(ci): Depot CI for ci/size/benchmarks

### DIFF
--- a/.depot/workflows/benchmarks.yml
+++ b/.depot/workflows/benchmarks.yml
@@ -1,0 +1,54 @@
+# Depot CI Migration
+# Source: .github/workflows/benchmarks.yml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Update Benchmarks
+on:
+  schedule:
+    # Every 3 days at 06:00 UTC
+    - cron: '0 6 */3 * *'
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  update-benchmarks:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build packages
+        run: npm run -s build
+      - name: Regenerate benchmark page
+        run: npm run -s bench:update
+      - name: Check for changes
+        id: diff
+        run: |
+          git diff --quiet sites/benchmarks/ && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+      - name: Commit updated benchmarks
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add sites/benchmarks/
+          git commit -m "chore: refresh benchmark data ($(date -u +%Y-%m-%d))"
+          git push
+      - name: Deploy to Vercel
+        if: steps.diff.outputs.changed == 'true'
+        # Non-blocking: VERCEL_TOKEN is not configured on this repo, so the
+        # deploy step is expected to fail. Marking it continue-on-error keeps the
+        # benchmark-refresh commit (the real product of this cron) from being
+        # reported as a red run over an expected, non-correctness deploy failure.
+        # When VERCEL_TOKEN is added, remove this and let real failures surface.
+        continue-on-error: true
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: node scripts/deploy-vercel.mjs --targets "sites/benchmarks"

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -1,0 +1,289 @@
+# Depot CI Migration
+# Source: .github/workflows/ci.yml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+# One run per ref — a new push cancels the in-flight run for the same branch/PR.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Resolve Playwright version (cache key)
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+      - name: Install Playwright Chromium (for devtools-mcp e2e)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system deps (browser cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - name: Test
+        run: npm run -s test
+  react-compat-libs:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      # The lib fixture is gitignored and not a workspace member — install it here so
+      # the compat pillar is actually exercised (the test FAILS, not skips, with the flag set).
+      # --legacy-peer-deps: the tests alias bare 'react'/'react-dom' imports to what-react
+      # (test/_helpers/react-alias-loader.mjs), so the real react package is never used and
+      # strict peer resolution over the ~100-lib unlocked fixture only breaks on upstream
+      # churn (e.g. react-intl@8.1.4 pins peer react@19 while react-beautiful-dnd caps at 18).
+      - name: Install compat-lib fixture
+        working-directory: packages/react-compat/test/app
+        run: npm install --no-save --legacy-peer-deps zustand @tanstack/react-query react-hook-form react-hot-toast @headlessui/react framer-motion
+      - name: Run guarded compat-lib tests
+        working-directory: packages/react-compat
+        env:
+          WHAT_REQUIRE_COMPAT_LIBS: '1'
+        run: node --test 'test/libs.test.js'
+  build:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run -s build
+      - name: Production build smoke gate (no blank-screen regression)
+        run: npm run -s test:prod
+  scaffold-smoke:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      # The SPA production build resolves the `production` export condition
+      # to dist/*.min.js inside the packed tarballs, so build first.
+      - name: Build packages
+        run: npm run -s build
+      - name: Resolve Playwright version (cache key)
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+      - name: Install Playwright Chromium (hydration checks)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system deps (browser cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - name: Scaffold smoke (create-what -> install -> run -> hydrate, both templates)
+        env:
+          WHAT_SMOKE_REQUIRE_BROWSER: 1
+        run: npm run -s smoke:scaffold
+  # Executes GETTING-STARTED.md "Manual Setup (Vite + Compiler)" verbatim in a
+  # fresh directory, with what-* deps pointed at local tarballs (same technique
+  # as scaffold-smoke). Guards the doc path: npm init -y, "type": "module",
+  # install, the doc's 3 files, and `vite build` must succeed.
+  manual-setup-smoke:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      # `vite build` resolves the `production` export condition to dist/*.min.js
+      # inside the packed tarballs, so build first (same as scaffold-smoke).
+      - name: Build packages
+        run: npm run -s build
+      - name: Manual setup smoke (GETTING-STARTED.md, Manual Setup)
+        run: |
+          set -euo pipefail
+          REPO="$PWD"
+          WORK="$(mktemp -d)"
+          TARS="$WORK/tarballs"
+          mkdir -p "$TARS"
+
+          # Pack what-framework + its deps + the compiler from the local tree.
+          for dir in what core router server compiler; do
+            npm pack "$REPO/packages/$dir" --pack-destination "$TARS" --silent
+          done
+
+          # --- GETTING-STARTED Manual Setup, step by step ---
+          mkdir -p "$WORK/my-app"
+          cd "$WORK/my-app"
+          npm init -y > /dev/null
+
+          # Doc step: set "type": "module" + dev/build scripts.
+          # CI-only addition: overrides pin every TRANSITIVE what-* dep to the
+          # local tarballs (the unpublished version can't resolve from npm).
+          # Directly-installed packages are excluded — npm rejects overrides
+          # that conflict with direct dependencies (EOVERRIDE).
+          node -e '
+            const fs = require("fs"), path = require("path");
+            const tarDir = process.argv[1];
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            pkg.type = "module";
+            pkg.scripts = { dev: "vite", build: "vite build" };
+            pkg.overrides = {};
+            const direct = new Set(["what-framework", "what-compiler"]);
+            for (const f of fs.readdirSync(tarDir)) {
+              const name = f.replace(/-\d+\.\d+\.\d+.*\.tgz$/, "");
+              if (direct.has(name)) continue;
+              pkg.overrides[name] = "file:" + path.join(tarDir, f);
+            }
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));
+          ' "$TARS"
+
+          # Doc step: npm install what-framework what-compiler (local tarballs)
+          npm install "$TARS"/what-framework-*.tgz "$TARS"/what-compiler-*.tgz
+          # Doc step: npm install -D vite
+          npm install -D vite
+
+          # Doc file 1/3: vite.config.js
+          cat > vite.config.js <<'EOF'
+          import { defineConfig } from 'vite';
+          import what from 'what-compiler/vite';
+
+          export default defineConfig({
+            plugins: [what()],
+          });
+          EOF
+
+          # Doc file 2/3: index.html
+          cat > index.html <<'EOF'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+              <title>What App</title>
+            </head>
+            <body>
+              <div id="app"></div>
+              <script type="module" src="/src/main.jsx"></script>
+            </body>
+          </html>
+          EOF
+
+          # Doc file 3/3: src/main.jsx
+          mkdir -p src
+          cat > src/main.jsx <<'EOF'
+          import { mount, useSignal, useComputed } from 'what-framework';
+
+          function App() {
+            const count = useSignal(0);
+            const doubled = useComputed(() => count() * 2);
+
+            return (
+              <div>
+                <h1>Hello What</h1>
+                <p>Count: {count()}</p>
+                <p>Doubled: {doubled()}</p>
+                <button onClick={() => count.set(c => c + 1)}>+</button>
+                <button onClick={() => count.set(c => c - 1)}>-</button>
+              </div>
+            );
+          }
+
+          mount(<App />, '#app');
+          EOF
+
+          # Doc step: build for production with `npx vite build`
+          npx vite build
+
+          # The build must produce a real app shell + bundle.
+          test -f dist/index.html
+          grep -q '<div id="app">' dist/index.html
+          ls dist/assets/*.js > /dev/null
+          echo "manual-setup smoke OK"
+  audit:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Publish surface hygiene
+        run: npm run -s hygiene:publish
+      - name: Security audit
+        run: npm audit --audit-level=moderate
+  bench-gate:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Benchmark gate (perf — non-blocking signal)
+        # Non-blocking, matching the bench:gate step in release-and-deploy.yml:
+        # the checked-in perf baselines are recorded on fast local hardware
+        # (M3 Max), and GitHub shared runners are several× slower/noisier on some
+        # microbenchmarks (e.g. `batch() 100 writes`), so this gate false-fails
+        # unpredictably. Kept as its own visible job (a signal, not a blocker);
+        # perf is gated strictly by `release:verify` on local hardware.
+        continue-on-error: true
+        env:
+          WHAT_BENCH_TOLERANCE_CORE: 0.80
+          WHAT_BENCH_TOLERANCE_DX: 0.85
+        run: npm run -s bench:gate

--- a/.depot/workflows/size.yml
+++ b/.depot/workflows/size.yml
@@ -1,0 +1,31 @@
+# Depot CI Migration
+# Source: .github/workflows/size.yml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Size
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  size:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build (production dist)
+        run: node scripts/build.js
+      - name: Check size budgets
+        run: node scripts/check-size.mjs


### PR DESCRIPTION
Depot CI migration (Kirby directive 07-11, org wbjkqlz33v), same pattern validated on vura-platform. The npm publisher stays on GitHub Actions for provenance (pending decision). Follow-up strips GitHub triggers after one green Depot run.