### PR TITLE
chore(ci): cut what-fw CI over to Depot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,9 @@
 name: CI
 
+# Runs on Depot CI (.depot/workflows/) as of 2026-07-11 (Kirby's directive).
+# This copy keeps workflow_dispatch as a manual fallback.
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 # One run per ref — a new push cancels the in-flight run for the same branch/PR.
 concurrency:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,12 +1,9 @@
 name: Size
 
+# Runs on Depot CI (.depot/workflows/) as of 2026-07-11 (Kirby's directive).
+# This copy keeps workflow_dispatch as a manual fallback.
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   size:


### PR DESCRIPTION
Follow-up to #24, mirroring vura-platform (#159) and vura (#64). Strips GitHub push/PR triggers from ci/size (dispatch fallback retained); benchmarks keeps its GitHub cron until Depot's schedule trigger is verified; the npm publisher stays on GitHub Actions for provenance.