### PR TITLE
Keep server actions isolated across runtimes and reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to What Framework will be documented in this file.
 
+## [0.11.7] - 2026-07-16
+
+Patch release. All 14 packages move together to 0.11.7.
+
+### Fixed
+
+- **server: Node request and island state remain isolated across concurrent async rendering without leaking Node built-ins into browser or edge bundles.** `AsyncLocalStorage` now lives behind the Node server export condition; the default server entry stays browser-safe while Node SSR preserves request-local action and island state.
+- **compiler: removed server actions no longer survive Vite hot reload.** The action registry now clears IDs owned by an updated or unlinked module before registering its current exports, preventing stale action dispatch after edits.
+- **compiler: server action transforms keep stable, collision-resistant IDs and preserve the complete production Node server API.** Browser-bundle and packed-package regressions exercise the same public entry points consumers install.
+
+### Verified
+
+- Node 20 and 22: 1,493 regular tests plus 40 adversarial stress tests.
+- Build, all 37 public subpath checks, packed declarations, production smoke, and packed SPA/full-stack scaffold smoke.
+
 ## [0.11.6] - 2026-07-11 — runtime `<Show>`/`<For>`/`<Switch>` are reactive
 
 Patch release. All 14 packages move to 0.11.6 together (fixed-group release). One correctness fix (#22) surfaced by production app work, plus release-workflow hygiene (#20, #21). No API changes.

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-isr",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "What Framework - Origin-first ISR cache engine: stale-while-revalidate, on-demand & poll regeneration, no CDN required",
   "type": "module",
   "main": "src/index.js",
@@ -30,7 +30,7 @@
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",
   "peerDependencies": {
-    "what-server": "^0.11.6"
+    "what-server": "^0.11.7"
   },
   "peerDependenciesMeta": {
     "what-server": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-framework-cli",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "What Framework CLI - Dev server, build, and deployment tools",
   "type": "module",
   "bin": {
@@ -22,7 +22,7 @@
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",
   "dependencies": {
-    "what-framework": "^0.11.6"
+    "what-framework": "^0.11.7"
   },
   "repository": {
     "type": "git",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-compiler",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "JSX compiler for What Framework - transforms JSX to optimized DOM operations",
   "main": "src/index.js",
   "types": "index.d.ts",
@@ -49,7 +49,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/core": "^7.0.0",
-    "what-core": "^0.11.6"
+    "what-core": "^0.11.7"
   },
   "files": [
     "src",

--- a/packages/compiler/src/babel-plugin.js
+++ b/packages/compiler/src/babel-plugin.js
@@ -47,6 +47,32 @@ const SIGNAL_CREATORS = new Set([
   'createResource', 'useSWR', 'useQuery', 'useInfiniteQuery',
 ]);
 
+const SERVER_ACTION_SOURCES = new Set([
+  'what-framework/server',
+  'what-server',
+  'what-server/actions',
+]);
+
+function stableActionHash(value) {
+  let hash = 0xcbf29ce484222325n;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= BigInt(value.charCodeAt(i));
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(36);
+}
+
+function normalizeActionFilename(filename, projectRoot) {
+  const clean = String(filename || '<unknown>')
+    .replace(/\\/g, '/')
+    .replace(/[?#].*$/, '');
+  const root = String(projectRoot || '')
+    .replace(/\\/g, '/')
+    .replace(/\/+$/, '');
+  if (root && clean.startsWith(`${root}/`)) return clean.slice(root.length + 1);
+  return clean.replace(/^\.\//, '');
+}
+
 // Normalize JSX text per React/Babel rules:
 //  - Split on newlines, treat tabs as spaces.
 //  - For interior lines: trim leading and trailing horizontal whitespace.
@@ -2042,6 +2068,114 @@ export default function whatBabelPlugin({ types: t }) {
     }
   }
 
+  function actionBindingName(callPath) {
+    const parent = callPath.parentPath;
+    if (parent?.isVariableDeclarator() && t.isIdentifier(parent.node.id)) {
+      return parent.node.id.name;
+    }
+    if (parent?.isAssignmentExpression() && t.isIdentifier(parent.node.left)) {
+      return parent.node.left.name;
+    }
+    if (parent?.isExportDefaultDeclaration()) return 'default';
+    if (parent?.isObjectProperty() && !parent.node.computed) {
+      if (t.isIdentifier(parent.node.key)) return parent.node.key.name;
+      if (t.isStringLiteral(parent.node.key)) return parent.node.key.value;
+    }
+    return null;
+  }
+
+  function isServerActionCall(callPath, state) {
+    const callee = callPath.node.callee;
+    if (t.isIdentifier(callee)) return state.serverActionBindings.has(callee.name);
+    return t.isMemberExpression(callee)
+      && !callee.computed
+      && t.isIdentifier(callee.object)
+      && t.isIdentifier(callee.property, { name: 'action' })
+      && state.serverActionNamespaces.has(callee.object.name);
+  }
+
+  function staticActionId(optionsNode) {
+    if (!t.isObjectExpression(optionsNode)) return { property: null, value: null };
+    for (const property of optionsNode.properties) {
+      if (!t.isObjectProperty(property)) continue;
+      const key = t.isIdentifier(property.key) && !property.computed ? property.key.name
+        : t.isStringLiteral(property.key) ? property.key.value
+          : null;
+      if (key !== 'id') continue;
+      if (t.isStringLiteral(property.value)) return { property, value: property.value.value };
+      if (t.isTemplateLiteral(property.value) && property.value.expressions.length === 0) {
+        return { property, value: property.value.quasis[0]?.value.cooked || '' };
+      }
+      return { property, value: null };
+    }
+    return { property: null, value: null };
+  }
+
+  function registerActionId(callPath, state, id, bindingName, relativeFilename) {
+    const loc = callPath.node.loc?.start || { line: 0, column: 0 };
+    const source = `${relativeFilename}:${loc.line}:${loc.column + 1}`;
+    const key = `${relativeFilename}#${bindingName}`;
+    const existing = state.serverActionIds.get(id);
+    if (existing) {
+      throw callPath.buildCodeFrameError(
+        `Duplicate server action ID "${id}". ` +
+        `First declared by "${existing.bindingName}" at ${existing.source}; ` +
+        `conflicts with "${bindingName}" at ${source}.`
+      );
+    }
+    const metadata = { id, key, bindingName, filename: relativeFilename, source, loc };
+    state.serverActionIds.set(id, metadata);
+    if (typeof state.opts?.onActionId === 'function') {
+      try {
+        state.opts.onActionId(metadata);
+      } catch (error) {
+        throw callPath.buildCodeFrameError(error instanceof Error ? error.message : String(error));
+      }
+    }
+  }
+
+  function transformServerAction(callPath, state) {
+    if (!isServerActionCall(callPath, state)) return;
+
+    const bindingName = actionBindingName(callPath);
+    if (!bindingName) {
+      if (!state.opts?.production) {
+        console.warn(
+          `[what-compiler] Could not derive a stable server action ID at ` +
+          `${state.serverActionFilename}:${callPath.node.loc?.start.line || 0}. ` +
+          'Assign action(...) to a named local or export, or pass { id } explicitly.'
+        );
+      }
+      return;
+    }
+
+    const optionsNode = callPath.node.arguments[1];
+    const explicit = staticActionId(optionsNode);
+    if (explicit.property) {
+      if (explicit.value !== null) {
+        registerActionId(callPath, state, explicit.value, bindingName, state.serverActionFilename);
+      }
+      return;
+    }
+
+    const id = `wa1_${stableActionHash(`${state.serverActionFilename}#${bindingName}`)}`;
+    registerActionId(callPath, state, id, bindingName, state.serverActionFilename);
+    const idProperty = t.objectProperty(t.identifier('id'), t.stringLiteral(id));
+
+    if (!optionsNode) {
+      callPath.node.arguments.push(t.objectExpression([idProperty]));
+    } else if (t.isObjectExpression(optionsNode)) {
+      optionsNode.properties.unshift(idProperty);
+    } else {
+      // Put the generated default before the caller's dynamic options so a
+      // runtime `options.id` remains authoritative.
+      callPath.node.arguments[1] = t.objectExpression([
+        idProperty,
+        t.spreadElement(optionsNode),
+      ]);
+    }
+  }
+
   // =====================================================
   // Plugin entry
   // =====================================================
@@ -2080,6 +2214,14 @@ export default function whatBabelPlugin({ types: t }) {
           state.nextVarId = () => `_el$${state._varCounter++}`;
           state.nextMemoId = () => `_c$${state._memoCounter++}`;
 
+          state.serverActionBindings = new Set();
+          state.serverActionNamespaces = new Set();
+          state.serverActionIds = new Map();
+          state.serverActionFilename = normalizeActionFilename(
+            state.file?.opts?.filename,
+            state.opts?.projectRoot || state.file?.opts?.cwd
+          );
+
           // Collect signal names for smart reactivity detection
           state.signalNames = new Set();
 
@@ -2117,11 +2259,26 @@ export default function whatBabelPlugin({ types: t }) {
                     state.importedIdentifiers.add(localName);
                   }
                 }
+
+                if (SERVER_ACTION_SOURCES.has(source)) {
+                  if (
+                    t.isImportSpecifier(spec)
+                    && t.isIdentifier(spec.imported, { name: 'action' })
+                    && t.isIdentifier(spec.local)
+                  ) {
+                    state.serverActionBindings.add(spec.local.name);
+                  } else if (t.isImportNamespaceSpecifier(spec) && t.isIdentifier(spec.local)) {
+                    state.serverActionNamespaces.add(spec.local.name);
+                  }
+                }
               }
             }
           }
 
           path.traverse({
+            CallExpression(callPath) {
+              transformServerAction(callPath, state);
+            },
             VariableDeclarator(declPath) {
               const init = declPath.node.init;
               if (!init || !t.isCallExpression(init)) return;

--- a/packages/compiler/src/vite-plugin.js
+++ b/packages/compiler/src/vite-plugin.js
@@ -16,6 +16,18 @@ import { setupErrorOverlay } from './error-overlay.js';
 
 const VIRTUAL_ROUTES_ID = 'virtual:what-routes';
 const RESOLVED_VIRTUAL_ID = '\0' + VIRTUAL_ROUTES_ID;
+const SERVER_ACTION_MODULE_RE = /(?:from\s*['"](?:what-framework\/server|what-server(?:\/actions)?)['"]|import\s*['"](?:what-framework\/server|what-server(?:\/actions)?)['"])/;
+const SCRIPT_MODULE_RE = /\.[cm]?[jt]sx?$/;
+
+function patternMatches(pattern, value) {
+  if (!pattern) return false;
+  if (Array.isArray(pattern)) return pattern.some((entry) => patternMatches(entry, value));
+  if (pattern instanceof RegExp) {
+    pattern.lastIndex = 0;
+    return pattern.test(value);
+  }
+  return typeof pattern === 'function' ? pattern(value) : false;
+}
 
 /**
  * Shape the "preserve JSX" transform config for the running Vite version.
@@ -82,6 +94,32 @@ export default function whatVitePlugin(options = {}) {
   let pagesDir = '';
   let server = null;
   let isDevMode = false;
+  const actionIdRegistry = new Map();
+
+  function registerActionId(metadata) {
+    const existing = actionIdRegistry.get(metadata.id);
+    if (existing && existing.key !== metadata.key) {
+      throw new Error(
+        `Duplicate server action ID "${metadata.id}". ` +
+        `First declared by "${existing.bindingName}" at ${existing.source}; ` +
+        `conflicts with "${metadata.bindingName}" at ${metadata.source}.`
+      );
+    }
+    actionIdRegistry.set(metadata.id, metadata);
+  }
+
+  function clearActionIdsForFile(filename) {
+    for (const [id, metadata] of actionIdRegistry) {
+      if (metadata.filename === filename) actionIdRegistry.delete(id);
+    }
+  }
+
+  function actionFilenameForFile(filename) {
+    const cleanFilename = filename.replace(/[?#].*$/, '');
+    return rootDir
+      ? path.relative(rootDir, cleanFilename).split(path.sep).join('/')
+      : cleanFilename;
+  }
 
   return {
     name: 'vite-plugin-what',
@@ -111,6 +149,9 @@ export default function whatVitePlugin(options = {}) {
       });
 
       devServer.watcher.on('unlink', (file) => {
+        // Vite will never transform an unlinked module again, so explicitly
+        // release its IDs before handling the narrower pages refresh path.
+        clearActionIdsForFile(actionFilenameForFile(file));
         if (file.startsWith(pagesDir)) {
           const mod = devServer.moduleGraph.getModuleById(RESOLVED_VIRTUAL_ID);
           if (mod) {
@@ -137,9 +178,20 @@ export default function whatVitePlugin(options = {}) {
 
     // Transform JSX files
     transform(code, id) {
-      // Check if we should process this file
-      if (!include.test(id)) return null;
-      if (exclude && exclude.test(id)) return null;
+      const cleanId = id.replace(/[?#].*$/, '');
+      const hasJsx = patternMatches(include, cleanId);
+      const isScriptModule = SCRIPT_MODULE_RE.test(cleanId);
+      const hasServerActions = isScriptModule && SERVER_ACTION_MODULE_RE.test(code);
+      if (exclude && patternMatches(exclude, cleanId)) return null;
+
+      // Clear before either transforming the replacement or returning early.
+      // Otherwise a .ts/.js module that removes its final action import leaves
+      // an ID reserved forever and produces false duplicate-ID failures.
+      if (isScriptModule) clearActionIdsForFile(actionFilenameForFile(cleanId));
+      // Server action metadata is required in plain .js/.ts modules too, so
+      // those modules pass through the same hermetic Babel transform even when
+      // they contain no JSX.
+      if (!hasJsx && !hasServerActions) return null;
 
       try {
         const result = transformSync(code, {
@@ -153,7 +205,11 @@ export default function whatVitePlugin(options = {}) {
           configFile: false,
           babelrc: false,
           plugins: [
-            [whatBabelPlugin, { production }]
+            [whatBabelPlugin, {
+              production,
+              projectRoot: rootDir || process.cwd(),
+              onActionId: registerActionId,
+            }]
           ],
           parserOpts: {
             plugins: ['jsx', 'typescript']

--- a/packages/compiler/test/server-action-id.test.js
+++ b/packages/compiler/test/server-action-id.test.js
@@ -1,0 +1,166 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { transformSync } from '@babel/core';
+import babelPlugin from '../src/babel-plugin.js';
+import whatVitePlugin from '../src/vite-plugin.js';
+
+function compile(source, filename = '/workspace/src/actions/users.ts') {
+  const result = transformSync(source, {
+    filename,
+    plugins: [[babelPlugin, { production: false, projectRoot: '/workspace' }]],
+    parserOpts: { plugins: ['typescript'] },
+    configFile: false,
+    babelrc: false,
+    compact: false,
+  });
+  return result?.code || '';
+}
+
+function generatedActionId(code) {
+  const match = code.match(/id:\s*["'](wa1_[a-z0-9]+)["']/);
+  assert.ok(match, `expected a compiler-generated action ID in:\n${code}`);
+  return match[1];
+}
+
+describe('stable server action IDs', () => {
+  it('matches across independently initialized client and server compilers', () => {
+    const source = `
+      import { action } from 'what-framework/server';
+      export const saveUser = action(async (user) => user);
+    `;
+
+    const clientBundle = compile(source);
+    const serverBundle = compile(source);
+
+    assert.equal(generatedActionId(clientBundle), generatedActionId(serverBundle));
+  });
+
+  it('derives IDs from both the project-relative path and local binding', () => {
+    const saveUser = generatedActionId(compile(`
+      import { action } from 'what-framework/server';
+      export const saveUser = action(async () => true);
+    `));
+    const deleteUser = generatedActionId(compile(`
+      import { action } from 'what-framework/server';
+      export const deleteUser = action(async () => true);
+    `));
+    const otherFile = generatedActionId(compile(`
+      import { action } from 'what-framework/server';
+      export const saveUser = action(async () => true);
+    `, '/workspace/src/actions/admin.ts'));
+
+    assert.notEqual(saveUser, deleteUser);
+    assert.notEqual(saveUser, otherFile);
+  });
+
+  it('keeps an explicit action ID authoritative', () => {
+    const code = compile(`
+      import { action } from 'what-framework/server';
+      export const saveUser = action(async () => true, { id: 'public-save-user' });
+    `);
+
+    assert.match(code, /id:\s*["']public-save-user["']/);
+    assert.doesNotMatch(code, /wa1_/);
+  });
+
+  it('lets dynamic options override the generated default ID', () => {
+    const code = compile(`
+      import { action } from 'what-framework/server';
+      const options = { id: 'runtime-explicit' };
+      export const saveUser = action(async () => true, options);
+      export const deleteUser = action(async () => true, { ...options });
+    `);
+
+    assert.match(code, /saveUser = action\([\s\S]*?\{\s*id:\s*["']wa1_[a-z0-9]+["'],\s*\.\.\.options\s*\}/);
+    assert.match(code, /deleteUser = action\([\s\S]*?\{\s*id:\s*["']wa1_[a-z0-9]+["'],\s*\.\.\.options\s*\}/);
+  });
+
+  it('fails a build when two actions declare the same explicit ID', () => {
+    assert.throws(() => compile(`
+      import { action } from 'what-framework/server';
+      export const one = action(async () => 1, { id: 'duplicate' });
+      export const two = action(async () => 2, { id: 'duplicate' });
+    `), /Duplicate server action ID "duplicate".*one.*two/s);
+  });
+
+  it('transforms non-JSX action modules and detects cross-file collisions in Vite', () => {
+    const plugin = whatVitePlugin();
+    plugin.configResolved({ root: '/workspace', command: 'build' });
+    const first = plugin.transform(`
+      import { action } from 'what-server/actions';
+      export const one = action(async () => 1, { id: 'shared-explicit' });
+    `, '/workspace/src/actions/one.ts');
+
+    assert.ok(first?.code, 'a .ts action module should be transformed without JSX');
+    assert.throws(() => plugin.transform(`
+      import { action } from 'what-server/actions';
+      export const two = action(async () => 2, { id: 'shared-explicit' });
+    `, '/workspace/src/actions/two.ts'), /Duplicate server action ID "shared-explicit"/);
+  });
+
+  it('releases old per-file IDs when Vite hot-updates an action module', () => {
+    const plugin = whatVitePlugin();
+    plugin.configResolved({ root: '/workspace', command: 'serve' });
+    plugin.transform(`
+      import { action } from 'what-framework/server';
+      export const one = action(async () => 1, { id: 'before-hmr' });
+    `, '/workspace/src/actions/one.ts');
+    plugin.transform(`
+      import { action } from 'what-framework/server';
+      export const one = action(async () => 1, { id: 'after-hmr' });
+    `, '/workspace/src/actions/one.ts?t=123');
+
+    assert.doesNotThrow(() => plugin.transform(`
+      import { action } from 'what-framework/server';
+      export const two = action(async () => 2, { id: 'before-hmr' });
+    `, '/workspace/src/actions/two.ts'));
+  });
+
+  it('releases a file ID when its last server action import is removed', () => {
+    const plugin = whatVitePlugin();
+    plugin.configResolved({ root: '/workspace', command: 'serve' });
+    plugin.transform(`
+      import { action } from 'what-framework/server';
+      export const one = action(async () => 1, { id: 'removed-action' });
+    `, '/workspace/src/actions/one.ts');
+
+    assert.equal(
+      plugin.transform('export const one = async () => 1;', '/workspace/src/actions/one.ts?t=456'),
+      null
+    );
+    assert.doesNotThrow(() => plugin.transform(`
+      import { action } from 'what-framework/server';
+      export const two = action(async () => 2, { id: 'removed-action' });
+    `, '/workspace/src/actions/two.ts'));
+  });
+
+  it('releases a file ID when Vite reports that the module was unlinked', () => {
+    const plugin = whatVitePlugin();
+    let onUnlink;
+    const devServer = {
+      watcher: {
+        on(event, callback) {
+          if (event === 'unlink') onUnlink = callback;
+        },
+      },
+      moduleGraph: {
+        getModuleById() { return null; },
+        invalidateModule() {},
+      },
+      ws: { send() {} },
+    };
+    plugin.configResolved({ root: '/workspace', command: 'serve' });
+    plugin.configureServer(devServer);
+    plugin.transform(`
+      import { action } from 'what-framework/server';
+      export const one = action(async () => 1, { id: 'unlinked-action' });
+    `, '/workspace/src/actions/one.ts');
+
+    assert.equal(typeof onUnlink, 'function');
+    onUnlink('/workspace/src/actions/one.ts');
+    assert.doesNotThrow(() => plugin.transform(`
+      import { action } from 'what-framework/server';
+      export const two = action(async () => 2, { id: 'unlinked-action' });
+    `, '/workspace/src/actions/two.ts'));
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-core",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "What Framework - Signal-based UI framework built for AI agents",
   "type": "module",
   "main": "src/index.js",

--- a/packages/core/src/agent-context.js
+++ b/packages/core/src/agent-context.js
@@ -8,7 +8,7 @@ import { getCollectedErrors } from './errors.js';
 // --- Version ---
 // Keep in sync with packages/core/package.json (checked by
 // core/test/guardrails.test.js so it can't silently go stale again).
-const VERSION = '0.11.6';
+const VERSION = '0.11.7';
 
 // --- Component Registry ---
 // Tracks mounted components for agent inspection.

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -43,7 +43,12 @@ export { createStore, derived, storeComputed, atom } from './store.js';
 export { Head, clearHead, beginHeadCollection, endHeadCollection } from './head.js';
 
 // SSR render-scoped context (keystone for head collection, loaders, resources)
-export { getServerContext, setServerContext, runWithServerContext } from './server-context.js';
+export {
+  getServerContext,
+  setServerContext,
+  runWithServerContext,
+  __installServerContextStorage,
+} from './server-context.js';
 
 // Client hydration payload reader (loader data + resources)
 export { __readHydrationData, __resetHydrationData, getLoaderData, getResource } from './hydration-data.js';

--- a/packages/core/src/server-context.js
+++ b/packages/core/src/server-context.js
@@ -4,22 +4,33 @@
 // the head sink, the current page's loader data, and the resource cache.
 //
 // Concurrency model:
-//   - renderToString() is SYNCHRONOUS. A module-global set at the start of the
-//     render and cleared in a `finally` lives within one uninterrupted tick, so
-//     no other request's render can observe it (same reasoning React's
-//     server dispatcher uses). Use runWithServerContext() for that path.
-//   - ASYNC paths (renderToStream, async loaders, async createResource) must
-//     thread the ctx object explicitly through the call stack and NEVER read
-//     this module global across an `await` — two requests can interleave there.
+//   - Browser and synchronous-only consumers use the module-global fallback.
+//   - what-server installs an AsyncLocalStorage-compatible provider in Node so
+//     async components retain their request context across `await` without
+//     exposing it to concurrent renders.
 //
 // getServerContext() returns null on the client and outside of any render, so
 // `typeof document === 'undefined'` guards keep behaving correctly.
 
 let _current = null;
+let _asyncContextStorage = null;
+
+/**
+ * Install the async context provider used by the server renderer.
+ *
+ * This intentionally accepts the small AsyncLocalStorage surface instead of
+ * importing `node:async_hooks` from what-core: the core bundle remains browser
+ * compatible, while what-server owns its Node runtime dependency.
+ *
+ * @internal
+ */
+export function __installServerContextStorage(storage) {
+  if (!_asyncContextStorage) _asyncContextStorage = storage;
+}
 
 /** @returns the active render context, or null on the client / outside a render. */
 export function getServerContext() {
-  return _current;
+  return _asyncContextStorage?.getStore() ?? _current;
 }
 
 /**
@@ -38,6 +49,10 @@ export function setServerContext(ctx) {
  * synchronous render path; do not rely on it across `await` boundaries.
  */
 export function runWithServerContext(ctx, fn) {
+  if (_asyncContextStorage) {
+    return _asyncContextStorage.run(ctx, fn);
+  }
+
   const prev = _current;
   _current = ctx;
   try {

--- a/packages/create-what/package.json
+++ b/packages/create-what/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-what",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Scaffold a new What Framework project",
   "type": "module",
   "bin": {

--- a/packages/devtools-mcp/package.json
+++ b/packages/devtools-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-devtools-mcp",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "MCP server bridging AI agents to live What Framework app state via WebSocket",
   "type": "module",
   "bin": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-devtools",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Dev tools for What Framework — signal inspector, component tree, effect graph",
   "type": "module",
   "main": "src/index.js",
@@ -20,7 +20,7 @@
     "inspector"
   ],
   "peerDependencies": {
-    "what-core": "^0.11.6"
+    "what-core": "^0.11.7"
   },
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-what",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "ESLint rules for What Framework — catch signal bugs, enforce patterns",
   "type": "module",
   "main": "src/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-mcp",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "[DEPRECATED — use what-devtools-mcp instead] MCP Server for What Framework documentation and assistance",
   "type": "module",
   "main": "src/index.js",

--- a/packages/react-compat/package.json
+++ b/packages/react-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-react",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "React compatibility layer for What Framework — real React semantics (value hooks, re-renders, context) on a dedicated compat runtime",
   "type": "module",
   "sideEffects": false,
@@ -53,7 +53,7 @@
     "compatibility"
   ],
   "peerDependencies": {
-    "what-core": "^0.11.6"
+    "what-core": "^0.11.7"
   },
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",

--- a/packages/router/index.d.ts
+++ b/packages/router/index.d.ts
@@ -1,6 +1,6 @@
 // What Framework Router - TypeScript Definitions
 
-import { VNode, VNodeChild, Component, Signal, Computed } from '../core';
+import { VNode, VNodeChild, Component, Signal, Computed } from 'what-core';
 
 // --- Route State ---
 

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-router",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "What Framework - File-based & programmatic router with View Transitions",
   "type": "module",
   "main": "src/index.js",
@@ -34,7 +34,7 @@
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",
   "peerDependencies": {
-    "what-core": "^0.11.6"
+    "what-core": "^0.11.7"
   },
   "repository": {
     "type": "git",

--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -1,6 +1,6 @@
 // What Framework Server - TypeScript Definitions
 
-import { VNode, VNodeChild, Signal } from '../core';
+import { VNode, VNodeChild, Signal } from 'what-core';
 
 // --- SSR ---
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-server",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "What Framework - SSR, islands architecture, static generation",
   "type": "module",
   "main": "src/index.js",
@@ -47,8 +47,8 @@
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",
   "peerDependencies": {
-    "what-core": "^0.11.6",
-    "what-router": "^0.11.6"
+    "what-core": "^0.11.7",
+    "what-router": "^0.11.7"
   },
   "peerDependenciesMeta": {
     "what-router": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,6 +8,11 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
+      "node": {
+        "production": "./dist/node.min.js",
+        "import": "./src/node.js",
+        "default": "./src/node.js"
+      },
       "production": "./dist/index.min.js",
       "import": "./src/index.js",
       "default": "./src/index.js"
@@ -28,7 +33,10 @@
     "dist/**/*.min.js",
     "index.d.ts"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/node.js",
+    "./dist/node.min.js"
+  ],
   "keywords": [
     "ssr",
     "islands",

--- a/packages/server/src/actions.js
+++ b/packages/server/src/actions.js
@@ -78,11 +78,24 @@ export function csrfMetaTag(token) {
 // --- Define a server action ---
 
 let _actionCounter = 0;
+let _fallbackWarningShown = false;
 
 function generateActionId() {
-  // Generate a deterministic ID — prefer crypto.getRandomValues, fall back to a
-  // monotonic counter (never Math.random, which is not cryptographically safe and
-  // produces predictable IDs in some runtimes).
+  if (
+    !_fallbackWarningShown
+    && typeof process !== 'undefined'
+    && process.env?.NODE_ENV !== 'production'
+  ) {
+    _fallbackWarningShown = true;
+    console.warn(
+      '[what-server] action() is using a runtime-generated ID because compiler metadata is missing. ' +
+      'Build with what-compiler/vite-plugin-what or pass an explicit { id } so client and server bundles agree.'
+    );
+  }
+  // Compatibility fallback for direct, uncompiled script users. Normal builds
+  // receive a deterministic compiler ID derived from source path + binding.
+  // Never use Math.random here; crypto avoids predictable collisions, and the
+  // monotonic fallback keeps older runtimes functional.
   const rand = typeof crypto !== 'undefined' && crypto.getRandomValues
     ? Array.from(crypto.getRandomValues(new Uint8Array(6)), b => b.toString(16).padStart(2, '0')).join('')
     : `c${(++_actionCounter).toString(36)}_${Date.now().toString(36)}`;

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -2,7 +2,13 @@
 // SSR, static site generation, server components.
 // Zero-JS pages by default. Islands opt-in to client JS.
 
-import { h, runWithServerContext, beginHeadCollection, endHeadCollection } from 'what-core';
+import {
+  h,
+  getServerContext,
+  runWithServerContext,
+  beginHeadCollection,
+  endHeadCollection,
+} from 'what-core';
 import { serializeState } from './serialize.js';
 import { getIslandStoresSnapshot } from './islands.js';
 import { csrfMetaTag } from './actions.js';
@@ -13,6 +19,7 @@ function createRenderContext(loaderData) {
     head: beginHeadCollection(),
     loaderData,
     resources: new Map(),
+    islandStores: new Map(),
     resourceCounter: 0,
     boundaryCounter: 0,
     suspended: [],
@@ -35,6 +42,10 @@ function nextHydrationId() {
 // so the client can reuse the server-rendered DOM.
 
 export function renderToHydratableString(vnode) {
+  if (typeof document === 'undefined' && !getServerContext()) {
+    const ctx = createRenderContext(undefined);
+    return runWithServerContext(ctx, () => renderToHydratableString(vnode));
+  }
   resetHydrationId();
   return _renderHydratable(vnode);
 }
@@ -108,6 +119,10 @@ function injectHydrationKey(html, hkId) {
 // Renders a VNode tree to an HTML string. Used for SSR and static gen.
 
 export function renderToString(vnode) {
+  if (typeof document === 'undefined' && !getServerContext()) {
+    const ctx = createRenderContext(undefined);
+    return runWithServerContext(ctx, () => renderToString(vnode));
+  }
   if (vnode == null || vnode === false || vnode === true) return '';
 
   // Text
@@ -243,7 +258,7 @@ export async function renderDocument(pageModule, reqCtx = {}, options = {}) {
   const payload = {
     loaderData: loaderData ?? null,
     resources,
-    islandStores: getIslandStoresSnapshot(),
+    islandStores: getIslandStoresSnapshot(ctx),
   };
   return wrapHtmlDocument({ body, head, payload, options });
 }
@@ -283,14 +298,16 @@ export async function* renderToStream(vnode, ctx) {
 
   // Signal — unwrap by calling it
   if (typeof vnode === 'function' && vnode._signal) {
-    yield* renderToStream(vnode(), ctx);
+    const value = runWithServerContext(ctx, () => vnode());
+    yield* renderToStream(value, ctx);
     return;
   }
 
   // Reactive function child — call to get value
   if (typeof vnode === 'function') {
     try {
-      yield* renderToStream(vnode(), ctx);
+      const value = runWithServerContext(ctx, () => vnode());
+      yield* renderToStream(value, ctx);
     } catch (e) {
       if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
         console.warn('[what-server] Error rendering reactive function in stream SSR:', e.message);
@@ -333,7 +350,10 @@ export async function* renderToStream(vnode, ctx) {
 
   if (typeof vnode.tag === 'function') {
     try {
-      const result = vnode.tag({ ...vnode.props, children: vnode.children });
+      const result = runWithServerContext(
+        ctx,
+        () => vnode.tag({ ...vnode.props, children: vnode.children })
+      );
       // Support async components
       const resolved = result instanceof Promise ? await result : result;
       yield* renderToStream(resolved, ctx);
@@ -380,8 +400,11 @@ export function definePage(config) {
 
 // Generate static HTML for a page
 export function generateStaticPage(page, data = {}) {
-  const vnode = page.component(data);
-  const html = renderToString(vnode);
+  const ctx = createRenderContext(data);
+  const html = runWithServerContext(ctx, () => {
+    const vnode = page.component(data);
+    return renderToString(vnode);
+  });
   const islands = page.islands || [];
 
   return wrapDocument({
@@ -589,12 +612,11 @@ export {
   getRevalidationHandler,
 } from './revalidation-registry.js';
 
-// Deploy adapters — framework-agnostic core + Node / static / edge wrappers
+// Runtime-neutral deploy adapters. Node-only adapters are re-exported by the
+// package's conditional Node entry so browser/edge bundles never resolve Node
+// builtins merely because they import a client-safe server action.
 export { createRequestHandler } from './adapter/core.js';
-export { createServer, toNodeListener, whatMiddleware } from './adapter/node.js';
-export { exportStatic } from './adapter/static.js';
 export { createCloudflareHandler } from './adapter/cloudflare.js';
-export { createVercelHandler, buildVercelOutput } from './adapter/vercel.js';
 
 // Safe state serialization for inlining into <script> tags (AUDIT-2026-06-06 M13)
 export { serializeState } from './serialize.js';

--- a/packages/server/src/islands.js
+++ b/packages/server/src/islands.js
@@ -16,7 +16,7 @@
 //   'media'   - Hydrate when media query matches (e.g., mobile-only)
 //   'action'  - Hydrate on first user interaction (click, focus, hover)
 
-import { mount, hydrate, signal, batch } from 'what-core';
+import { mount, hydrate, signal, batch, getServerContext } from 'what-core';
 import { serializeState } from './serialize.js';
 
 const islandRegistry = new Map();
@@ -25,20 +25,41 @@ const hydrationQueue = [];
 let isProcessingQueue = false;
 
 // --- Shared Island State ---
-// Global reactive store that persists across islands and page navigations
+// Browser stores intentionally persist across islands and client navigations.
+// Server stores belong to the active render context so one request can never
+// observe another request's state. Module-scoped server declarations receive a
+// lightweight handle that resolves to the current request's concrete store.
 
-const sharedStores = new Map();
+const browserStores = new Map();
+const serverStoreDefinitions = new Map();
 
-export function createIslandStore(name, initialState) {
-  if (sharedStores.has(name)) {
-    return sharedStores.get(name);
+function cloneInitialState(value) {
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(value);
+    } catch {
+      // Fall through for values structuredClone cannot represent. Island
+      // state is expected to be serializable, but preserving a shallow copy is
+      // a safer compatibility fallback than sharing the original object.
+    }
   }
+  if (Array.isArray(value)) return value.map(cloneInitialState);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, cloneInitialState(item)])
+    );
+  }
+  return value;
+}
+
+function createConcreteStore(storeMap, name, initialState) {
+  if (storeMap.has(name)) return storeMap.get(name);
 
   const store = {};
   const signals = {};
 
   // Create signals for each key in initial state
-  for (const [key, value] of Object.entries(initialState)) {
+  for (const [key, value] of Object.entries(cloneInitialState(initialState))) {
     signals[key] = signal(value);
     Object.defineProperty(store, key, {
       get: () => signals[key](),
@@ -72,16 +93,86 @@ export function createIslandStore(name, initialState) {
     });
   };
 
-  sharedStores.set(name, store);
+  storeMap.set(name, store);
   return store;
+}
+
+function activeServerStoreMap(context) {
+  const ctx = context || getServerContext();
+  return ctx && ctx.islandStores instanceof Map ? ctx.islandStores : null;
+}
+
+function serverStoreHandle(name, initialState) {
+  if (serverStoreDefinitions.has(name)) {
+    return serverStoreDefinitions.get(name).handle;
+  }
+
+  const definition = {
+    initialState: cloneInitialState(initialState),
+    handle: null,
+  };
+
+  const resolve = () => {
+    const storeMap = activeServerStoreMap();
+    if (!storeMap) {
+      throw new Error(
+        `[what-server] Island store "${name}" was accessed outside an active server render. ` +
+        'Read or write module-scoped island stores from a component rendered by renderDocument/renderPage.'
+      );
+    }
+    return createConcreteStore(storeMap, name, definition.initialState);
+  };
+
+  definition.handle = new Proxy({}, {
+    get(_target, property) {
+      return Reflect.get(resolve(), property);
+    },
+    set(_target, property, value) {
+      return Reflect.set(resolve(), property, value);
+    },
+    has(_target, property) {
+      return Reflect.has(resolve(), property);
+    },
+    ownKeys() {
+      return Reflect.ownKeys(resolve());
+    },
+    getOwnPropertyDescriptor(_target, property) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(resolve(), property);
+      return descriptor ? { ...descriptor, configurable: true } : undefined;
+    },
+  });
+
+  serverStoreDefinitions.set(name, definition);
+  return definition.handle;
+}
+
+export function createIslandStore(name, initialState) {
+  if (typeof document !== 'undefined') {
+    return createConcreteStore(browserStores, name, initialState);
+  }
+
+  const storeMap = activeServerStoreMap();
+  if (storeMap) {
+    const definition = serverStoreDefinitions.get(name);
+    return createConcreteStore(storeMap, name, definition?.initialState ?? initialState);
+  }
+
+  return serverStoreHandle(name, initialState);
 }
 
 // Get or create a shared store
 export function useIslandStore(name, fallbackInitial = {}) {
-  if (sharedStores.has(name)) {
-    return sharedStores.get(name);
+  if (typeof document !== 'undefined') {
+    return createConcreteStore(browserStores, name, fallbackInitial);
   }
-  return createIslandStore(name, fallbackInitial);
+
+  const storeMap = activeServerStoreMap();
+  if (storeMap) {
+    const definition = serverStoreDefinitions.get(name);
+    return createConcreteStore(storeMap, name, definition?.initialState ?? fallbackInitial);
+  }
+
+  return serverStoreHandle(name, fallbackInitial);
 }
 
 // Serialize all shared stores for SSR.
@@ -94,9 +185,12 @@ export function serializeIslandStores() {
 
 // Raw (unserialized) snapshot of all shared island stores, so renderDocument can
 // merge it into the single consolidated #__what_data payload (one serialize pass).
-export function getIslandStoresSnapshot() {
+export function getIslandStoresSnapshot(context) {
+  const storeMap = typeof document !== 'undefined'
+    ? browserStores
+    : activeServerStoreMap(context);
   const data = {};
-  for (const [name, store] of sharedStores) {
+  for (const [name, store] of storeMap || []) {
     data[name] = store._getSnapshot();
   }
   return data;
@@ -428,12 +522,15 @@ export function enhanceForms(selector = 'form[data-enhance]') {
 // --- Debugging ---
 
 export function getIslandStatus() {
+  const stores = typeof document !== 'undefined'
+    ? [...browserStores.keys()]
+    : [...(activeServerStoreMap()?.keys() || serverStoreDefinitions.keys())];
   const status = {
     registered: [...islandRegistry.keys()],
     hydrated: hydratedIslands.size,
     pending: hydrationQueue.length,
     queue: hydrationQueue.map(t => ({ name: t.name, priority: t.priority })),
-    stores: [...sharedStores.keys()],
+    stores,
   };
   return status;
 }

--- a/packages/server/src/node.js
+++ b/packages/server/src/node.js
@@ -1,0 +1,18 @@
+// What Framework - Node server runtime.
+//
+// Keep Node async context and Node-only deployment adapters behind the
+// package's `node` export condition. The default entry remains safe to resolve
+// in browser and non-Node edge bundles, including client server-action builds.
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { __installServerContextStorage } from 'what-core';
+
+// Async components may access loader/resource/island state after an `await`.
+// One process-local provider keeps those reads bound to the request that
+// invoked the component even when multiple streams interleave.
+__installServerContextStorage(new AsyncLocalStorage());
+
+export * from './index.js';
+export { createServer, toNodeListener, whatMiddleware } from './adapter/node.js';
+export { exportStatic } from './adapter/static.js';
+export { createVercelHandler, buildVercelOutput } from './adapter/vercel.js';

--- a/packages/server/src/serialize.js
+++ b/packages/server/src/serialize.js
@@ -2,7 +2,7 @@
 //
 // Stateless on purpose: this module holds no shared state, so it is safe for
 // the bundler to inline into multiple server entry points without creating
-// divergent instances (unlike islands.js's sharedStores).
+// divergent instances. Island state itself is scoped by the render context.
 //
 // JSON.stringify alone is NOT safe to drop inside <script>...</script>: a value
 // containing "</script>" (or "<!--", "<script") breaks out of the element and

--- a/packages/server/test/actions.test.js
+++ b/packages/server/test/actions.test.js
@@ -40,6 +40,19 @@ function mockRes() {
 }
 
 describe('actions registry + handleActionRequest', () => {
+  it('warns when an uncompiled action falls back to a runtime-generated ID', () => {
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      const uncompiled = action(async () => true);
+      assert.match(uncompiled._actionId, /^a_/);
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.ok(warnings.some((message) => message.includes('compiler metadata is missing')));
+  });
+
   it('registers actions server-side', () => {
     assert.ok(getRegisteredActions().includes('sum'));
   });

--- a/packages/server/test/island-store-isolation.test.js
+++ b/packages/server/test/island-store-isolation.test.js
@@ -1,0 +1,183 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { h } from 'what-core';
+import { renderDocument, renderToString, renderToStream } from '../src/node.js';
+import { createIslandStore, useIslandStore } from '../src/islands.js';
+
+function hydrationPayload(html) {
+  const match = html.match(/id="__what_data"[^>]*>([^<]*)</);
+  assert.ok(match, 'renderDocument should emit a hydration payload');
+  return JSON.parse(match[1]);
+}
+
+describe('SSR island store isolation', () => {
+  it('retains one shared browser store across island lookups', () => {
+    const originalDocument = globalThis.document;
+    globalThis.document = {};
+    try {
+      const first = createIslandStore('browser-shared-store', { count: 0 });
+      first.count = 3;
+      const second = useIslandStore('browser-shared-store', { count: 99 });
+
+      assert.strictEqual(first, second);
+      assert.equal(second.count, 3);
+    } finally {
+      if (originalDocument === undefined) delete globalThis.document;
+      else globalThis.document = originalDocument;
+    }
+  });
+
+  it('creates a fresh same-name store for every request', async () => {
+    const stores = [];
+
+    function Page({ requestName }) {
+      const store = createIslandStore('request-session', {
+        requestName,
+        visits: 0,
+      });
+      store.visits += 1;
+      stores.push(store);
+      return h('p', {}, `${store.requestName}:${store.visits}`);
+    }
+
+    const first = await renderDocument({
+      default: () => h(Page, { requestName: 'first' }),
+    });
+    const second = await renderDocument({
+      default: () => h(Page, { requestName: 'second' }),
+    });
+
+    assert.notStrictEqual(stores[0], stores[1]);
+    assert.deepEqual(hydrationPayload(first).islandStores, {
+      'request-session': { requestName: 'first', visits: 1 },
+    });
+    assert.deepEqual(hydrationPayload(second).islandStores, {
+      'request-session': { requestName: 'second', visits: 1 },
+    });
+  });
+
+  it('keeps module-scoped store declarations request-local when components use them', async () => {
+    const moduleStore = createIslandStore('module-declared-session', {
+      requestName: null,
+      visits: 0,
+    });
+
+    function Page({ requestName }) {
+      moduleStore.requestName = requestName;
+      moduleStore.visits += 1;
+      return h('p', {}, `${moduleStore.requestName}:${moduleStore.visits}`);
+    }
+
+    const first = await renderDocument({
+      default: () => h(Page, { requestName: 'first' }),
+    });
+    const second = await renderDocument({
+      default: () => h(Page, { requestName: 'second' }),
+    });
+
+    assert.deepEqual(hydrationPayload(first).islandStores, {
+      'module-declared-session': { requestName: 'first', visits: 1 },
+    });
+    assert.deepEqual(hydrationPayload(second).islandStores, {
+      'module-declared-session': { requestName: 'second', visits: 1 },
+    });
+  });
+
+  it('keeps module-scoped stores usable in direct and streaming render APIs', async () => {
+    const directStore = createIslandStore('direct-render-store', { value: 'direct' });
+    const streamStore = createIslandStore('stream-render-store', { value: 'stream' });
+
+    assert.equal(
+      renderToString(h(() => h('p', {}, directStore.value), {})),
+      '<p>direct</p>'
+    );
+
+    let streamed = '';
+    for await (const chunk of renderToStream(h(() => h('p', {}, streamStore.value), {}))) {
+      streamed += chunk;
+    }
+    assert.equal(streamed, '<p>stream</p>');
+  });
+
+  it('preserves request-local module stores across awaits in concurrent stream components', async () => {
+    const moduleStore = createIslandStore('async-stream-request-store', {
+      requestName: null,
+      visits: 0,
+    });
+
+    function deferred() {
+      let resolve;
+      const promise = new Promise((done) => {
+        resolve = done;
+      });
+      return { promise, resolve };
+    }
+
+    const aStarted = deferred();
+    const bStarted = deferred();
+    const aWrite = deferred();
+    const bWrite = deferred();
+    const aFinish = deferred();
+    const bFinish = deferred();
+
+    async function Page({ requestName, started, write, finish }) {
+      started.resolve();
+      await write.promise;
+      moduleStore.requestName = requestName;
+      moduleStore.visits += 1;
+      await finish.promise;
+      return h('p', {}, `${moduleStore.requestName}:${moduleStore.visits}`);
+    }
+
+    async function collect(stream) {
+      let html = '';
+      for await (const chunk of stream) html += chunk;
+      return html;
+    }
+
+    const requestA = collect(renderToStream(h(Page, {
+      requestName: 'request-a',
+      started: aStarted,
+      write: aWrite,
+      finish: aFinish,
+    })));
+    const requestB = collect(renderToStream(h(Page, {
+      requestName: 'request-b',
+      started: bStarted,
+      write: bWrite,
+      finish: bFinish,
+    })));
+
+    await Promise.all([aStarted.promise, bStarted.promise]);
+    aWrite.resolve();
+    await Promise.resolve();
+    bWrite.resolve();
+    bFinish.resolve();
+    assert.equal(await requestB, '<p>request-b:1</p>');
+
+    aFinish.resolve();
+    assert.equal(await requestA, '<p>request-a:1</p>');
+  });
+
+  it('snapshots only stores created by the current render', async () => {
+    const first = await renderDocument({
+      default: () => {
+        createIslandStore('first-request-only', { secret: 'alpha' });
+        return h('p', {}, 'first');
+      },
+    });
+    const second = await renderDocument({
+      default: () => {
+        createIslandStore('second-request-only', { secret: 'beta' });
+        return h('p', {}, 'second');
+      },
+    });
+
+    assert.deepEqual(hydrationPayload(first).islandStores, {
+      'first-request-only': { secret: 'alpha' },
+    });
+    assert.deepEqual(hydrationPayload(second).islandStores, {
+      'second-request-only': { secret: 'beta' },
+    });
+  });
+});

--- a/packages/what-text/package.json
+++ b/packages/what-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-text",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Optional text engine for What Framework, powered by @chenglou/pretext",
   "type": "module",
   "main": "src/index.js",

--- a/packages/what/package.json
+++ b/packages/what/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-framework",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "The web framework built for AI agents — signals, components, islands, SSR",
   "type": "module",
   "main": "src/index.js",
@@ -84,9 +84,9 @@
   },
   "homepage": "https://whatfw.com",
   "dependencies": {
-    "what-core": "^0.11.6",
-    "what-router": "^0.11.6",
-    "what-server": "^0.11.6",
-    "what-compiler": "^0.11.6"
+    "what-core": "^0.11.7",
+    "what-router": "^0.11.7",
+    "what-server": "^0.11.7",
+    "what-compiler": "^0.11.7"
   }
 }

--- a/packages/what/test/server-actions-browser-bundle.test.js
+++ b/packages/what/test/server-actions-browser-bundle.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { build } from 'esbuild';
+
+const CLIENT_ACTION_ENTRY = `
+  import {
+    action,
+    formAction,
+    useAction,
+    useFormAction,
+    useOptimistic,
+    useMutation,
+  } from 'what-framework/server';
+
+  globalThis.__whatClientActionSurface = [
+    action,
+    formAction,
+    useAction,
+    useFormAction,
+    useOptimistic,
+    useMutation,
+  ];
+`;
+
+describe('what-framework/server browser bundle', () => {
+  const cases = [
+    { label: 'source', conditions: undefined, requiresBuild: false },
+    { label: 'production', conditions: ['browser', 'production'], requiresBuild: true },
+  ];
+
+  for (const bundleCase of cases) it(`keeps the ${bundleCase.label} client server-action surface free of Node builtins`, async (t) => {
+    if (bundleCase.requiresBuild && !existsSync(new URL('../dist/server.min.js', import.meta.url))) {
+      t.skip('dist/ not built; production bundle is checked after npm run build');
+      return;
+    }
+    const result = await build({
+      stdin: {
+        contents: CLIENT_ACTION_ENTRY,
+        resolveDir: process.cwd(),
+        sourcefile: 'client-server-actions.js',
+      },
+      bundle: true,
+      platform: 'browser',
+      format: 'esm',
+      ...(bundleCase.conditions ? { conditions: bundleCase.conditions } : {}),
+      metafile: true,
+      treeShaking: true,
+      write: false,
+      logLevel: 'silent',
+    });
+
+    const output = result.outputFiles.map((file) => file.text).join('\n');
+    const bundledInputs = Object.keys(result.metafile.inputs);
+
+    assert.doesNotMatch(output, /\bnode:[a-z_/-]+|AsyncLocalStorage/);
+    assert.equal(
+      bundledInputs.some((input) =>
+        /packages[/\\]server[/\\](?:src[/\\](?:node\.js|adapter[/\\](?:node|static|vercel)\.js)|dist[/\\]node(?:\.min)?\.js)$/.test(input)
+      ),
+      false,
+      `browser bundle retained a Node-only server entry:\n${bundledInputs.join('\n')}`
+    );
+  });
+});

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -51,12 +51,13 @@ export const packages = [
     name: 'server',
     entries: [
       { input: 'src/index.js', outputBase: 'index' },
+      { input: 'src/node.js', outputBase: 'node' },
       { input: 'src/islands.js', outputBase: 'islands' },
       { input: 'src/actions.js', outputBase: 'actions' },
     ],
     // what-router/what-isr are optional peers (kept external, not inlined); the
     // deploy adapters lazy-import Node builtins which must not be bundled.
-    external: ['what-core', 'what-router', 'what-router/match', 'what-isr', 'node:fs/promises', 'node:http', 'node:path'],
+    external: ['what-core', 'what-router', 'what-router/match', 'what-isr', 'node:async_hooks', 'node:fs/promises', 'node:http', 'node:path'],
   },
   {
     // Origin-first ISR engine. Zero runtime deps; Node-only builtins stay external.

--- a/scripts/check-publish-surface.mjs
+++ b/scripts/check-publish-surface.mjs
@@ -1,8 +1,17 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 
 import { packages as buildPackages } from './build.js';
@@ -217,3 +226,74 @@ if (distOrphans.length || distMissing.length) {
 console.log(
   `[publish-surface] OK: dist contents match the build config for ${distCheckedPackages}/${buildPackages.length} built packages (no orphans).`,
 );
+
+// ---------------------------------------------------------------------------
+// Packed declaration consumer
+//
+// Workspace typechecks can accidentally resolve sibling declarations through
+// relative repository paths that do not exist in published tarballs. Install
+// the three public packages involved in the router/server type graph into a
+// clean directory, then typecheck a consumer against those packed artifacts.
+// ---------------------------------------------------------------------------
+
+const packedTypesDir = mkdtempSync(join(tmpdir(), 'what-packed-types-'));
+try {
+  const tarballDir = join(packedTypesDir, 'tarballs');
+  const consumerDir = join(packedTypesDir, 'consumer');
+  mkdirSync(tarballDir, { recursive: true });
+  mkdirSync(consumerDir, { recursive: true });
+
+  const tarballs = [];
+  for (const packageDir of ['packages/core', 'packages/router', 'packages/server']) {
+    const output = execFileSync(
+      'npm',
+      ['pack', resolve(repoRoot, packageDir), '--pack-destination', tarballDir, '--silent'],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+    const filename = output.trim().split('\n').filter(Boolean).pop();
+    const tarball = resolve(tarballDir, filename || '');
+    if (!filename || !existsSync(tarball)) {
+      throw new Error(`npm pack did not produce a tarball for ${packageDir}`);
+    }
+    tarballs.push(tarball);
+  }
+
+  writeFileSync(
+    join(consumerDir, 'package.json'),
+    `${JSON.stringify({ private: true, type: 'module' }, null, 2)}\n`,
+  );
+  execFileSync(
+    'npm',
+    ['install', '--ignore-scripts', '--no-audit', '--no-fund', ...tarballs],
+    { cwd: consumerDir, encoding: 'utf8' },
+  );
+  writeFileSync(join(consumerDir, 'consumer.ts'), `
+    import { Router, type RouteConfig } from 'what-router';
+    import { renderToString, type IslandStore } from 'what-server';
+    import type { VNode } from 'what-core';
+
+    const routes: RouteConfig[] = [];
+    const vnode: VNode = Router({ routes });
+    renderToString(vnode);
+
+    declare const store: IslandStore<{ count: number }>;
+    store._signals.count.set(1);
+  `);
+
+  execFileSync(
+    process.execPath,
+    [
+      resolve(repoRoot, 'node_modules/typescript/bin/tsc'),
+      '--noEmit',
+      '--strict',
+      '--target', 'ES2022',
+      '--module', 'NodeNext',
+      '--moduleResolution', 'NodeNext',
+      'consumer.ts',
+    ],
+    { cwd: consumerDir, encoding: 'utf8' },
+  );
+  console.log('[publish-surface] OK: packed what-router/what-server declarations typecheck in a clean consumer.');
+} finally {
+  rmSync(packedTypesDir, { recursive: true, force: true });
+}

--- a/sites/benchmarks/index.html
+++ b/sites/benchmarks/index.html
@@ -209,7 +209,7 @@
   <div class="container">
     <h1>Performance Benchmarks</h1>
     <p class="subtitle">Real measured performance data from the What Framework test suite. All benchmarks run on Node.js v22.23.1.</p>
-    <p class="last-updated">Last updated <time datetime="2026-07-13T09:18:24.629Z">July 13, 2026</time> · v0.11.6 · linux</p>
+    <p class="last-updated">Last updated <time datetime="2026-07-13T09:18:24.629Z">July 13, 2026</time> · v0.11.7 · linux</p>
 
     <!-- Signals -->
     <div class="benchmark-section">
@@ -449,7 +449,7 @@
   </div>
 
   <footer>
-    <a href="https://whatfw.com">What Framework</a> v0.11.6 — <a href="https://react.whatfw.com">React Compat</a> — <a href="https://www.npmjs.com/package/what-framework">npm</a> — <a href="https://github.com/CelsianJs/what-framework">GitHub</a>
+    <a href="https://whatfw.com">What Framework</a> v0.11.7 — <a href="https://react.whatfw.com">React Compat</a> — <a href="https://www.npmjs.com/package/what-framework">npm</a> — <a href="https://github.com/CelsianJs/what-framework">GitHub</a>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Outcome\n- keeps Node AsyncLocalStorage behind the explicit Node server condition\n- prevents browser/edge bundles from importing Node built-ins\n- clears stale Vite server-action IDs on update/unlink\n- releases the fixed group as 0.11.7\n\n## Verification\n- Node 20/22: 1,493 tests + 40 stress tests\n- full release verification, packed declarations, 37 public subpaths\n- production, SPA, and full-stack scaffold smokes\n- benchmark gate