### PR TITLE
fix: make islands, refs-on-hydrate, ARIA, useId and the MCP catalogue actually work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to What Framework will be documented in this file.
 
+## [Unreleased]
+
+Correctness work from the 2026-08-09 competitive parity audit. Every item here is a
+feature that existed, was documented, and did not work.
+
+### Fixed
+
+- **`client:*` island directives deleted their own component.** `<Counter client:idle />` rendered an empty marker div on *every* path: the server branch never rendered the component, and the client branch read `hydrated()` once inside a run-once component so the swap-in never fired. Islands now render their HTML on the server and hydrate in place over that exact DOM (verified: the server node is reused, not replaced, and no content is rendered twice). `mode: 'static'` ships HTML and attaches no JS at all.
+- **Island children and spread props were dropped by the compiler.** The island branch handed the runtime an empty children array and `continue`d past every spread, so `<Panel client:visible {...cfg}>text</Panel>` lost both its text and every prop in `cfg`. Both now pass through the same children protocol as any other component, with explicit attributes winning over the spread and the directive's own `mode` winning over both.
+- **`ref` never fired when hydrating.** `hydrateElementProps` skipped the prop outright, so any component that reached for its own DOM node through a ref got nothing under SSR while working correctly in a client-only render: a bug that only reproduces in production.
+- **`aria-*` and `role` were serialized as HTML booleans.** A generic boolean branch ran before the ARIA branch, so `aria-checked={true}` became `aria-checked=""` (not a valid enumerated value) and `aria-checked={false}` removed the attribute entirely, which reads as "unsupported" rather than "unchecked" to assistive technology. The server dropped the `false` case too. Genuine HTML boolean attributes such as `disabled` keep HTML boolean semantics.
+- **`useId()` allocated from a process-global counter.** Ids drifted between the SSR pass and hydration and interleaved across concurrent requests, breaking exactly the `for` / `aria-labelledby` relationships the primitive exists to create. The counter is now render-scoped, and `hydrate()` restarts the sequence so the client reproduces the server's ids.
+- **SSR ran without a render scope under any DOM shim.** `renderToString` established its render context only when `typeof document === 'undefined'`, which is a proxy for "am I on the server" that is wrong under jsdom, happy-dom or a Workers polyfill. The scope is now established by "no scope yet", which is the actual condition.
+- **`what_connection_status` under-reported the MCP tool catalogue by 41%.** The tool agents are told to call FIRST answered with a hand-maintained array of 17 entries while 29 tools were registered. The catalogue is now derived from registration itself, and additionally splits tools by what can answer with no browser attached, which is the distinction that actually costs an agent turns.
+
 ## [0.11.8] - 2026-08-09: security, correctness and release-gate remediation
 
 The largest correctness release since 0.10. It closes both CRITICAL and all ten HIGH

--- a/packages/compiler/src/babel-plugin.js
+++ b/packages/compiler/src/babel-plugin.js
@@ -1654,6 +1654,58 @@ export default function whatBabelPlugin({ types: t }) {
       filteredAttrs.push(attr);
     }
 
+    // Transform children.
+    // Element children build their DOM at the call site, i.e. before the parent
+    // component ever runs, so a <Provider> publishes its context value too late
+    // for its own subtree. Collect the element setup and emit it behind a
+    // zero-arg factory instead; the runtime calls the factory while the parent
+    // is on the component stack. An expression child is deferred for the same
+    // reason: it is the shape a wrapper forwards its own children through, and
+    // reading it while the argument list is built happens before the component
+    // it is being handed to has run. Text children have nothing to defer.
+    //
+    // Shared by the island branch and the regular component branch: an island is
+    // still a component, and `<Panel client:visible>...</Panel>` must keep its
+    // children rather than silently dropping them.
+    function transformComponentChildren() {
+      const setupMark = state._pendingSetup ? state._pendingSetup.length : 0;
+      const transformedChildren = [];
+      let deferChildren = false;
+      for (const child of children) {
+        if (t.isJSXText(child)) {
+          const text = normalizeJsxText(child.value);
+          if (text) transformedChildren.push(t.stringLiteral(text));
+        } else if (t.isJSXExpressionContainer(child)) {
+          if (!t.isJSXEmptyExpression(child.expression)) {
+            deferChildren = true;
+            transformedChildren.push(child.expression);
+          }
+        } else if (t.isJSXElement(child)) {
+          // <For>/<Show>/<Switch> lower to an inserter or a thunk (already lazy).
+          const childTag = child.openingElement.name.name;
+          if (childTag !== 'For' && childTag !== 'Show' && childTag !== 'Switch') deferChildren = true;
+          transformedChildren.push(transformElementFineGrained({ node: child }, state));
+        } else if (t.isJSXFragment(child)) {
+          deferChildren = true;
+          transformedChildren.push(transformFragmentFineGrained({ node: child }, state));
+        }
+      }
+
+      let childrenArg = t.arrayExpression(transformedChildren);
+      if (deferChildren) {
+        // Hoisted element setup emitted while transforming these children belongs
+        // inside the factory, not before the enclosing statement.
+        const setup = state._pendingSetup ? state._pendingSetup.splice(setupMark) : [];
+        childrenArg = t.arrowFunctionExpression(
+          [],
+          setup.length > 0
+            ? t.blockStatement([...setup, t.returnStatement(childrenArg)])
+            : childrenArg
+        );
+      }
+      return childrenArg;
+    }
+
     if (clientDirective) {
       state.needsCreateComponent = true;
       state.needsIsland = true;
@@ -1669,16 +1721,32 @@ export default function whatBabelPlugin({ types: t }) {
         );
       }
 
+      let islandSpread = null;
       for (const attr of filteredAttrs) {
-        if (t.isJSXSpreadAttribute(attr)) continue;
+        if (t.isJSXSpreadAttribute(attr)) {
+          // A spread used to be dropped on the floor here, so
+          // `<Chart client:visible {...config} />` lost every prop in `config`.
+          islandSpread = attr.argument;
+          continue;
+        }
         const attrName = getAttrName(attr);
+        if (attrName === 'key') continue;
         const value = getAttributeValue(attr.value);
         islandProps.push(t.objectProperty(t.identifier(attrName), value));
       }
 
+      // Spread first, explicit attributes second, so a written-out prop wins over
+      // the same key coming from the spread (JSX evaluation order).
+      const islandPropsExpr = islandSpread
+        ? t.callExpression(
+            t.memberExpression(t.identifier('Object'), t.identifier('assign')),
+            [t.objectExpression([]), islandSpread, t.objectExpression(islandProps)]
+          )
+        : t.objectExpression(islandProps);
+
       return t.callExpression(
         t.identifier('_$createComponent'),
-        [t.identifier('Island'), t.objectExpression(islandProps), t.arrayExpression([])]
+        [t.identifier('Island'), islandPropsExpr, transformComponentChildren()]
       );
     }
 
@@ -1769,38 +1837,6 @@ export default function whatBabelPlugin({ types: t }) {
       );
     }
 
-    // Transform children.
-    // Element children build their DOM at the call site, i.e. before the parent
-    // component ever runs, so a <Provider> publishes its context value too late
-    // for its own subtree. Collect the element setup and emit it behind a
-    // zero-arg factory instead; the runtime calls the factory while the parent
-    // is on the component stack. An expression child is deferred for the same
-    // reason: it is the shape a wrapper forwards its own children through, and
-    // reading it while the argument list is built happens before the component
-    // it is being handed to has run. Text children have nothing to defer.
-    const setupMark = state._pendingSetup ? state._pendingSetup.length : 0;
-    const transformedChildren = [];
-    let deferChildren = false;
-    for (const child of children) {
-      if (t.isJSXText(child)) {
-        const text = normalizeJsxText(child.value);
-        if (text) transformedChildren.push(t.stringLiteral(text));
-      } else if (t.isJSXExpressionContainer(child)) {
-        if (!t.isJSXEmptyExpression(child.expression)) {
-          deferChildren = true;
-          transformedChildren.push(child.expression);
-        }
-      } else if (t.isJSXElement(child)) {
-        // <For>/<Show>/<Switch> lower to an inserter or a thunk (already lazy).
-        const childTag = child.openingElement.name.name;
-        if (childTag !== 'For' && childTag !== 'Show' && childTag !== 'Switch') deferChildren = true;
-        transformedChildren.push(transformElementFineGrained({ node: child }, state));
-      } else if (t.isJSXFragment(child)) {
-        deferChildren = true;
-        transformedChildren.push(transformFragmentFineGrained({ node: child }, state));
-      }
-    }
-
     let propsExpr;
     if (hasSpread) {
       if (props.length > 0) {
@@ -1817,18 +1853,7 @@ export default function whatBabelPlugin({ types: t }) {
       propsExpr = t.nullLiteral();
     }
 
-    let childrenArg = t.arrayExpression(transformedChildren);
-    if (deferChildren) {
-      // Hoisted element setup emitted while transforming these children belongs
-      // inside the factory, not before the enclosing statement.
-      const setup = state._pendingSetup ? state._pendingSetup.splice(setupMark) : [];
-      childrenArg = t.arrowFunctionExpression(
-        [],
-        setup.length > 0
-          ? t.blockStatement([...setup, t.returnStatement(childrenArg)])
-          : childrenArg
-      );
-    }
+    const childrenArg = transformComponentChildren();
 
     return t.callExpression(t.identifier('_$createComponent'), [componentRef, propsExpr, childrenArg]);
   }

--- a/packages/compiler/test/babel-plugin.test.js
+++ b/packages/compiler/test/babel-plugin.test.js
@@ -365,6 +365,54 @@ describe('component output', () => {
 
     assert.match(code, /Island/);
     assert.match(code, /mode.*idle/);
+    assert.match(code, /component: Search/, 'the island must carry the component reference');
+    assert.match(code, /placeholder: "Search\.\.\."/, 'ordinary props must survive');
+  });
+
+  // The island branch used to hand `_$createComponent` an empty children array
+  // and `continue` past every spread, so `<Panel client:visible {...cfg}>text</Panel>`
+  // lost both its children and every prop in `cfg`.
+  it('keeps island children', () => {
+    const code = compile(`
+      function Panel({ children }) { return <section>{children}</section>; }
+      function App() {
+        return <div><Panel client:visible>Hello <b>world</b></Panel></div>;
+      }
+    `);
+
+    assert.match(code, /Hello /, 'text children must survive the directive');
+    assert.match(code, /<b>world<\/b>/, 'element children must survive the directive');
+  });
+
+  it('keeps island spread props, with explicit attributes winning', () => {
+    const code = compile(`
+      function Chart() { return <canvas />; }
+      function App({ cfg }) {
+        return <div><Chart client:visible {...cfg} title="explicit" /></div>;
+      }
+    `);
+
+    assert.match(code, /Object\.assign\(\{\}, cfg, \{/, 'the spread must be merged, not dropped');
+    const merged = code.slice(code.indexOf('Object.assign'));
+    assert.ok(
+      merged.indexOf('title: "explicit"') > merged.indexOf('cfg'),
+      'an explicit attribute must be applied after the spread so it wins'
+    );
+  });
+
+  it('never lets a spread override the directive it was written on', () => {
+    const code = compile(`
+      function Chart() { return <canvas />; }
+      function App({ cfg }) {
+        return <div><Chart client:load {...cfg} /></div>;
+      }
+    `);
+
+    const merged = code.slice(code.indexOf('Object.assign'));
+    assert.ok(
+      merged.indexOf('mode: "load"') > merged.indexOf('cfg'),
+      'the hydration mode comes from the directive, not from spread data'
+    );
   });
 
   it('escapes < and > in attribute values', () => {

--- a/packages/core/src/a11y.js
+++ b/packages/core/src/a11y.js
@@ -4,6 +4,7 @@
 import { signal, effect } from './reactive.js';
 import { h } from './h.js';
 import { getCurrentComponent } from './dom.js';
+import { getServerContext } from './server-context.js';
 
 // --- Focus Management ---
 
@@ -401,17 +402,48 @@ export function LiveRegion({ children, priority = 'polite', atomic = true }) {
 // --- ID Generator ---
 // Generate unique IDs for ARIA attributes
 
+// The counter is render-scoped on the server and module-global on the client.
+//
+// A bare module-global counter is wrong on the server in two independent ways.
+// Ids drift between the SSR pass and hydration, which breaks exactly the
+// relationships useId exists to create (`for`/`id`, `aria-labelledby`,
+// `aria-describedby`), and concurrent requests interleave into each other's
+// sequence, so two visitors can be served HTML whose ids were allocated in the
+// order the event loop happened to run. Every framework in the cohort ships this
+// primitive as SSR-stable because that is the whole point of shipping it.
+//
+// getServerContext() is the render-scoped store the SSR keystone already
+// maintains (AsyncLocalStorage-backed in Node), so this is wiring rather than
+// new machinery, and it adds no public API.
 let idCounter = 0;
 
+function nextIdSuffix() {
+  const ctx = getServerContext();
+  if (ctx) {
+    ctx.idCounter = (ctx.idCounter || 0) + 1;
+    return ctx.idCounter;
+  }
+  return ++idCounter;
+}
+
+/**
+ * Reset the client-side counter. Called at the start of hydration so the client
+ * reproduces the server's id sequence instead of continuing past it.
+ * @internal
+ */
+export function __resetIdCounter() {
+  idCounter = 0;
+}
+
 export function useId(prefix = 'what') {
-  const id = `${prefix}-${++idCounter}`;
+  const id = `${prefix}-${nextIdSuffix()}`;
   return () => id;
 }
 
 export function useIds(count, prefix = 'what') {
   const ids = [];
   for (let i = 0; i < count; i++) {
-    ids.push(`${prefix}-${++idCounter}`);
+    ids.push(`${prefix}-${nextIdSuffix()}`);
   }
   return ids;
 }

--- a/packages/core/src/components.js
+++ b/packages/core/src/components.js
@@ -3,6 +3,7 @@
 
 import { h } from './h.js';
 import { signal, effect, untrack, __DEV__ } from './reactive.js';
+import { isServerRender } from './server-context.js';
 
 // Legacy errorBoundaryStack removed — tree-based resolution via _parentCtx._errorBoundary
 // is now the only mechanism. See reportError() below.
@@ -271,94 +272,161 @@ export function Match(props) {
 }
 
 // --- Island ---
-// Deferred hydration component for islands architecture.
-// Usage: h(Island, { component: Counter, mode: 'idle' })
-// The babel plugin compiles <Counter client:idle /> into this.
+// Islands architecture: the content ships as server-rendered HTML and only the
+// *interactivity* is deferred to a client trigger. The babel plugin compiles
+// `<Counter client:idle />` into h(Island, { component: Counter, mode: 'idle' }).
+//
+// This used to render an empty marker div on every path, on the server AND the
+// client, in every mode: the SSR branch never rendered the component, and the
+// client branch read `hydrated()` once in a run-once component so the swap-in
+// never happened. Every `client:*` directive silently deleted its component.
 
-export function Island({ component: Component, mode, mediaQuery, ...props }) {
-  const placeholder = h('div', { 'data-island': Component.name || 'Island', 'data-hydrate': mode });
+// Late-bound renderers, injected by render.js. components.js cannot import
+// render.js directly (render -> dom -> components is already a cycle), so the
+// same injection precedent as _injectGetCurrentComponent applies here.
+let _islandRuntime = null;
 
-  // We need to return a vnode that the reconciler can handle.
-  // The actual hydration scheduling happens after mount via an effect.
-  const wrapper = signal(null);
-  const hydrated = signal(false);
+/** @internal */
+export function _injectIslandRuntime(runtime) {
+  _islandRuntime = runtime;
+}
 
-  function doHydrate() {
-    if (hydrated()) return;
-    hydrated.set(true);
-    // Render the actual component
-    wrapper.set(h(Component, props));
+// Island props cross the server/client boundary as JSON, so anything that is not
+// representable is dropped rather than throwing mid-render. Functions in
+// particular are common (event handlers passed down) and are simply not
+// transferable: the island re-creates its own handlers when it hydrates.
+function serializeIslandProps(props) {
+  const out = {};
+  for (const key in props) {
+    const value = props[key];
+    if (typeof value === 'function' || typeof value === 'symbol' || value === undefined) continue;
+    out[key] = value;
+  }
+  try {
+    return JSON.stringify(out);
+  } catch {
+    return '{}';
+  }
+}
+
+export function Island({ component: Component, mode, mediaQuery, name, children, ...props }) {
+  const islandName = name || Component?.name || 'Island';
+  const resolvedMode = mode || 'idle';
+
+  const marker = {
+    'data-island': islandName,
+    'data-island-mode': resolvedMode,
+    'data-hydrate': resolvedMode,
+    // Tells hydrateIslands() to leave this element alone: a compiler-emitted
+    // island holds a direct component reference and hydrates itself, so it
+    // needs no registry entry and must not be claimed twice.
+    'data-island-self': '1',
+  };
+
+  // Server: render the island's HTML inline, inside the marker. An island that
+  // emits nothing costs SEO and LCP to buy lazy hydration, which is a strictly
+  // worse trade than not using the directive at all.
+  // Children arrive as props here but must be handed to the component
+  // positionally: the renderers rebuild `props.children` from the vnode's own
+  // children list, so anything passed through props alone is overwritten.
+  const childList = children == null ? [] : (Array.isArray(children) ? children : [children]);
+
+  if (isServerRender()) {
+    return h(
+      'div',
+      { ...marker, 'data-island-props': serializeIslandProps(props) },
+      h(Component, props, ...childList)
+    );
   }
 
-  // Schedule hydration based on mode
+  let hydrated = false;
+
+  function hydrateInto(el) {
+    if (hydrated) return;
+    hydrated = true;
+
+    const vnode = h(Component, props, ...childList);
+
+    // Server-rendered children present => hydrate in place, reusing the DOM.
+    // Nothing there => a client-only render, so build it from scratch.
+    if (el.childNodes.length > 0 && _islandRuntime?.hydrate) {
+      _islandRuntime.hydrate(vnode, el);
+    } else if (_islandRuntime?.insert) {
+      _islandRuntime.insert(el, vnode, null);
+    }
+
+    el.removeAttribute('data-hydrate');
+    el.removeAttribute('data-island-self');
+    el.setAttribute('data-island-hydrated', '');
+    // Build the event in the element's own realm. A global CustomEvent belongs
+    // to a different realm inside an iframe or a DOM shim, and dispatchEvent
+    // rejects it as "not of type 'Event'".
+    const view = el.ownerDocument?.defaultView ?? globalThis;
+    if (typeof view.CustomEvent === 'function') {
+      el.dispatchEvent(new view.CustomEvent('island:hydrated', {
+        bubbles: true,
+        detail: { name: islandName, mode: resolvedMode },
+      }));
+    }
+  }
+
   function scheduleHydration(el) {
-    switch (mode) {
+    const trigger = () => hydrateInto(el);
+
+    switch (resolvedMode) {
       case 'load':
-        queueMicrotask(doHydrate);
+        queueMicrotask(trigger);
         break;
 
       case 'idle':
-        if (typeof requestIdleCallback !== 'undefined') {
-          requestIdleCallback(doHydrate);
-        } else {
-          setTimeout(doHydrate, 200);
-        }
+        if (typeof requestIdleCallback !== 'undefined') requestIdleCallback(trigger);
+        else setTimeout(trigger, 200);
         break;
 
       case 'visible': {
+        if (typeof IntersectionObserver === 'undefined') { queueMicrotask(trigger); break; }
         const observer = new IntersectionObserver((entries) => {
-          if (entries[0].isIntersecting) {
+          if (entries.some((entry) => entry.isIntersecting)) {
             observer.disconnect();
-            doHydrate();
+            trigger();
           }
-        });
+        }, { rootMargin: '200px' });
         observer.observe(el);
         break;
       }
 
-      case 'interaction': {
-        const hydrate = () => {
-          el.removeEventListener('click', hydrate);
-          el.removeEventListener('focus', hydrate);
-          el.removeEventListener('mouseenter', hydrate);
-          doHydrate();
+      case 'interaction':
+      case 'action': {
+        const events = ['click', 'focus', 'mouseenter', 'touchstart'];
+        const onInteract = () => {
+          for (const type of events) el.removeEventListener(type, onInteract);
+          trigger();
         };
-        el.addEventListener('click', hydrate, { once: true });
-        el.addEventListener('focus', hydrate, { once: true });
-        el.addEventListener('mouseenter', hydrate, { once: true });
+        for (const type of events) el.addEventListener(type, onInteract, { once: true });
         break;
       }
 
       case 'media': {
-        if (!mediaQuery) { doHydrate(); break; }
+        if (!mediaQuery || typeof window === 'undefined' || !window.matchMedia) { trigger(); break; }
         const mq = window.matchMedia(mediaQuery);
-        if (mq.matches) {
-          queueMicrotask(doHydrate);
-        } else {
-          const checkMedia = () => {
-            if (mq.matches) {
-              mq.removeEventListener('change', checkMedia);
-              doHydrate();
-            }
-          };
-          mq.addEventListener('change', checkMedia);
-        }
+        if (mq.matches) { queueMicrotask(trigger); break; }
+        const onChange = () => {
+          if (!mq.matches) return;
+          mq.removeEventListener('change', onChange);
+          trigger();
+        };
+        mq.addEventListener('change', onChange);
         break;
       }
 
+      // 'static' ships no JS at all: the server HTML is the whole island.
+      case 'static':
+        break;
+
       default:
-        // Unknown mode, hydrate immediately
-        queueMicrotask(doHydrate);
+        queueMicrotask(trigger);
     }
   }
 
-  // Use ref callback to get the DOM element and schedule hydration
-  const refCallback = (el) => {
-    if (el) scheduleHydration(el);
-  };
-
-  // Return: show placeholder until hydrated, then show the real component
-  return h('div', { 'data-island': Component.name || 'Island', 'data-hydrate': mode, ref: refCallback },
-    hydrated() ? wrapper() : null
-  );
+  return h('div', { ...marker, ref: (el) => { if (el) scheduleHydration(el); } });
 }

--- a/packages/core/src/dom.js
+++ b/packages/core/src/dom.js
@@ -70,6 +70,24 @@ export function _isUnsafeAttr(key, value) {
   return !isSafeUrl(value);
 }
 
+// ARIA attributes and `role` take ENUMERATED string values, never HTML boolean
+// syntax. `aria-checked=""` is not a valid value, and an ABSENT `aria-expanded`
+// means something different from `aria-expanded="false"` (unsupported versus
+// collapsed) to assistive technology.
+//
+// This is shared because the three render paths disagreed. The client
+// (dom.js setProp) hit a generic `typeof value === 'boolean'` branch before it
+// ever reached its aria branch, so it emitted `aria-checked=""` for true and
+// removed the attribute for false. The server special-cased `true` correctly but
+// skipped every falsy value earlier in the loop, so it dropped `false` entirely.
+// So SSR emitted valid ARIA and the first client update silently corrupted it,
+// while `aria-*={false}` was wrong everywhere. Every widget built on the a11y
+// module is affected, since useAriaExpanded/useAriaSelected/useAriaChecked all
+// return booleans.
+export function _isAriaAttr(key) {
+  return key === 'role' || key.startsWith('aria-');
+}
+
 // Track all mounted component contexts for disposal
 const mountedComponents = new Set();
 
@@ -970,6 +988,14 @@ function setProp(el, key, value, isSvg) {
     return;
   }
 
+  // aria-*/role BEFORE the boolean fast-path: these are enumerated string
+  // attributes, so a boolean has to serialize as "true"/"false", never as HTML
+  // boolean syntax. See _isAriaAttr.
+  if (_isAriaAttr(key)) {
+    el.setAttribute(key, typeof value === 'boolean' ? String(value) : value);
+    return;
+  }
+
   // Boolean attributes
   if (typeof value === 'boolean') {
     if (value) el.setAttribute(key, '');
@@ -977,8 +1003,8 @@ function setProp(el, key, value, isSvg) {
     return;
   }
 
-  // data-* and aria-*
-  if (key.startsWith('data-') || key.startsWith('aria-')) {
+  // data-*
+  if (key.startsWith('data-')) {
     el.setAttribute(key, value);
     return;
   }

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -14,6 +14,9 @@ export { h, Fragment, html } from './h.js';
 
 // DOM mounting & rendering (fine-grained, no VDOM reconciler)
 export { mount } from './dom.js';
+// Internal, underscore-prefixed: shared so the client, compiled-JSX and SSR
+// attribute paths cannot disagree about ARIA serialization again.
+export { _isAriaAttr } from './dom.js';
 
 // Hooks (React-compatible API)
 export {

--- a/packages/core/src/render.js
+++ b/packages/core/src/render.js
@@ -3,7 +3,9 @@
 // No VDOM diffing — direct DOM manipulation with surgical signal-driven updates.
 
 import { effect, untrack, createRoot, _createItemScope, signal, memo, __DEV__ } from './reactive.js';
+import { __resetIdCounter } from './a11y.js';
 import { createDOM, disposeTree, getCurrentComponent, getComponentStack, addHydrationDisposer, addHydratedComponent, _setSelectValue, _isUnsafeAttr, _isEventProp, _installLazyChildren, _handleNavigationSignal } from './dom.js';
+import { _injectIslandRuntime } from './components.js';
 export { effect, untrack };
 // Re-export memo for compiled output (branch memoization: the compiler emits
 // _$memo(() => cond) so conditional branches only re-create DOM when the
@@ -1596,6 +1598,12 @@ export function isHydrating() {
  */
 export function hydrate(vnode, container) {
   _isHydrating = true;
+  // Restart the useId sequence so the client reproduces the server's ids rather
+  // than continuing past them. The server allocates from a render-scoped counter
+  // starting at 1; without this reset any client-side useId call made before
+  // hydration would shift every id and break the `for`/`aria-labelledby`
+  // relationships the primitive exists to create.
+  __resetIdCounter();
   _hydrationCursor = { parent: container, index: 0 };
 
   try {
@@ -1843,8 +1851,19 @@ function hydrateNode(vnode, parent) {
  */
 function hydrateElementProps(el, props) {
   for (const key in props) {
-    if (key === 'children' || key === 'key' || key === 'ref') continue;
+    if (key === 'children' || key === 'key') continue;
     if (key === 'dangerouslySetInnerHTML' || key === 'innerHTML') continue;
+
+    // Refs must fire on the hydration path too. Skipping them meant every
+    // component that reaches for its own DOM node through a ref got nothing
+    // under SSR while working fine in a client-only render, which is the
+    // hardest class of bug to find: it only reproduces in production.
+    if (key === 'ref') {
+      const ref = props.ref;
+      if (typeof ref === 'function') ref(el);
+      else if (ref && typeof ref === 'object') ref.current = el;
+      continue;
+    }
 
     const value = props[key];
 
@@ -1880,3 +1899,9 @@ function hydrateElementProps(el, props) {
     if (key === 'data-hk') continue;
   }
 }
+
+// Islands hydrate themselves against their own DOM element, which needs both the
+// hydration walker and the insert path. components.js is upstream of this module
+// (render -> dom -> components), so the renderers are handed down rather than
+// imported back up, matching _injectGetCurrentComponent.
+_injectIslandRuntime({ hydrate, insert });

--- a/packages/core/src/server-context.js
+++ b/packages/core/src/server-context.js
@@ -34,6 +34,18 @@ export function getServerContext() {
 }
 
 /**
+ * True while a server render is in progress.
+ *
+ * Prefer this over a bare `typeof document === 'undefined'` check. That test asks
+ * "is there a DOM?" when the question is "am I rendering to a string?", and the
+ * two answers diverge under every DOM shim (jsdom, happy-dom, a Workers
+ * polyfill) and in any test that renders both ways in one process.
+ */
+export function isServerRender() {
+  return typeof document === 'undefined' || getServerContext() != null;
+}
+
+/**
  * Set the active context. Returns the PREVIOUS context so callers can restore it
  * manually (runWithServerContext does this for you).
  */

--- a/packages/core/test/a11y-serialization.test.js
+++ b/packages/core/test/a11y-serialization.test.js
@@ -1,0 +1,103 @@
+// Regressions for two a11y correctness defects found in the 2026-08-09 parity
+// audit. Both are cases where the server and the client disagreed about the same
+// value, so SSR emitted something correct and the client silently replaced it.
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body><div id="app"></div></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.requestAnimationFrame = (fn) => setTimeout(fn, 0);
+
+const { h, mount, signal } = await import('../src/index.js');
+const { useId, useIds } = await import('../src/a11y.js');
+const { renderToString } = await import('../../server/src/index.js');
+
+const flush = () => new Promise((r) => setTimeout(r, 5));
+
+describe('aria-* and role serialize as enumerated strings, not HTML booleans', () => {
+  beforeEach(() => { document.getElementById('app').innerHTML = ''; });
+
+  // The client hit a generic `typeof value === 'boolean'` branch before its aria
+  // branch, so `true` became `aria-checked=""` (not a valid enumerated value)
+  // and `false` removed the attribute entirely, which means "unsupported" rather
+  // than "unchecked" to assistive technology.
+  it('renders true as "true" on the client', () => {
+    mount(h('div', { 'aria-checked': true, role: 'switch' }, 'x'), '#app');
+    const el = document.querySelector('[role=switch]');
+    assert.equal(el.getAttribute('aria-checked'), 'true');
+  });
+
+  it('renders false as "false" on the client, rather than removing the attribute', () => {
+    mount(h('div', { 'aria-checked': false, role: 'switch' }, 'x'), '#app');
+    const el = document.querySelector('[role=switch]');
+    assert.equal(el.getAttribute('aria-checked'), 'false');
+  });
+
+  it('keeps the enumerated form across a reactive update', async () => {
+    const expanded = signal(true, 'expanded');
+    mount(h('button', { 'aria-expanded': () => expanded() }, 'x'), '#app');
+    const el = document.querySelector('button');
+    assert.equal(el.getAttribute('aria-expanded'), 'true');
+    expanded(false);
+    await flush();
+    assert.equal(el.getAttribute('aria-expanded'), 'false', 'must not be removed on update');
+  });
+
+  it('server and client agree on both booleans', () => {
+    const props = { 'aria-expanded': true, 'aria-checked': false, role: 'switch' };
+    const html = renderToString(h('button', props, 'x'));
+    assert.match(html, /aria-expanded="true"/);
+    assert.match(html, /aria-checked="false"/);
+
+    mount(h('button', props, 'x'), '#app');
+    const el = document.querySelector('#app button');
+    assert.equal(el.getAttribute('aria-expanded'), 'true');
+    assert.equal(el.getAttribute('aria-checked'), 'false');
+  });
+
+  // Only aria-*/role changed. Real HTML boolean attributes must keep HTML
+  // boolean semantics, where the attribute is present-and-empty or absent.
+  it('leaves genuine HTML boolean attributes alone', () => {
+    mount(h('input', { disabled: true, required: false }), '#app');
+    const el = document.querySelector('input');
+    assert.equal(el.getAttribute('disabled'), '');
+    assert.equal(el.getAttribute('required'), null);
+  });
+});
+
+describe('useId is stable per render, not per process', () => {
+  // A bare module-global counter drifts between the SSR pass and hydration and
+  // lets concurrent requests interleave into each other's sequence, which breaks
+  // exactly the relationships useId exists to create.
+  function Field({ label }) {
+    const id = useId('fld');
+    return h('div', {}, h('label', { for: id() }, label), h('input', { id: id() }));
+  }
+  const Page = () => h('form', {}, h(Field, { label: 'A' }), h(Field, { label: 'B' }));
+
+  it('produces the same ids on every server render', () => {
+    const runs = [0, 1, 2].map(() => renderToString(h(Page, {})).match(/fld-\d+/g).join(' '));
+    assert.equal(runs[0], runs[1]);
+    assert.equal(runs[1], runs[2]);
+  });
+
+  it('still pairs each label with its own input', () => {
+    const html = renderToString(h(Page, {}));
+    const ids = html.match(/fld-\d+/g);
+    assert.equal(ids.length, 4);
+    assert.equal(ids[0], ids[1], 'label for and input id must match');
+    assert.equal(ids[2], ids[3]);
+    assert.notEqual(ids[0], ids[2], 'two fields must not share an id');
+  });
+
+  it('useIds allocates distinct ids from the same render-scoped counter', () => {
+    const html = renderToString(h(() => {
+      const [a, b] = useIds(2, 'grp');
+      return h('div', { 'aria-labelledby': `${a} ${b}` });
+    }, {}));
+    assert.match(html, /aria-labelledby="grp-1 grp-2"/);
+  });
+});

--- a/packages/core/test/islands-ssr.test.js
+++ b/packages/core/test/islands-ssr.test.js
@@ -1,0 +1,155 @@
+// Regressions for the islands defects found in the 2026-08-09 parity audit.
+//
+// `client:*` used to render an empty marker div on EVERY path: the SSR branch
+// never rendered the component, and the client branch read `hydrated()` once in
+// a run-once component so the swap-in never happened. Every island directive
+// silently deleted its own component, which is strictly worse than not using the
+// directive at all.
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body><div id="app"></div></body></html>', {
+  pretendToBeVisual: true,
+});
+global.window = dom.window;
+global.document = dom.window.document;
+global.CustomEvent = dom.window.CustomEvent;
+
+const { h, mount, hydrate, signal, Island } = await import('../src/index.js');
+const { renderToString } = await import('../../server/src/index.js');
+
+const tick = (ms = 30) => new Promise((r) => setTimeout(r, ms));
+const app = () => document.getElementById('app');
+
+function Counter({ start = 0, label = 'count' }) {
+  const n = signal(start, 'n');
+  return h('button', { onclick: () => n((v) => v + 1) }, () => `${label} ${n()}`);
+}
+
+describe('islands render their content on the server', () => {
+  beforeEach(() => { app().innerHTML = ''; });
+
+  it('ships the component HTML inside the marker, not an empty div', () => {
+    const html = renderToString(h(Island, { component: Counter, mode: 'idle', start: 7 }));
+    assert.match(html, /<button[^>]*>count 7<\/button>/, 'the island content must be server-rendered');
+    assert.match(html, /data-island="Counter"/);
+    assert.match(html, /data-island-mode="idle"/);
+  });
+
+  it('renders the same content the undirected component would', () => {
+    const withDirective = renderToString(h(Island, { component: Counter, mode: 'load', start: 3 }));
+    const without = renderToString(h(Counter, { start: 3 }));
+    assert.ok(withDirective.includes(without), 'the directive must not change the rendered output');
+  });
+
+  it('serializes props onto the marker for the client', () => {
+    const html = renderToString(h(Island, { component: Counter, mode: 'idle', start: 2, label: 'hits' }));
+    const props = JSON.parse(html.match(/data-island-props="([^"]*)"/)[1].replace(/&quot;/g, '"'));
+    assert.deepEqual(props, { start: 2, label: 'hits' });
+  });
+
+  it('drops non-serializable props instead of throwing mid-render', () => {
+    const html = renderToString(
+      h(Island, { component: Counter, mode: 'idle', start: 1, onSelect: () => {}, missing: undefined })
+    );
+    const props = JSON.parse(html.match(/data-island-props="([^"]*)"/)[1].replace(/&quot;/g, '"'));
+    assert.deepEqual(props, { start: 1 }, 'functions and undefined are not transferable');
+    assert.match(html, /count 1<\/button>/, 'the island still renders');
+  });
+
+  it('renders island children', () => {
+    const Panel = ({ children }) => h('section', {}, children);
+    const html = renderToString(h(Island, { component: Panel, mode: 'idle' }, h('p', {}, 'inner')));
+    assert.match(html, /<section><p>inner<\/p><\/section>/);
+  });
+});
+
+describe('islands hydrate on the client', () => {
+  beforeEach(() => { app().innerHTML = ''; });
+
+  it('renders the component after the trigger fires in a client-only render', async () => {
+    mount(h(Island, { component: Counter, mode: 'load', start: 5 }), '#app');
+    assert.equal(app().querySelector('button'), null, 'nothing before the trigger');
+    await tick();
+    assert.match(app().querySelector('button').textContent, /count 5/);
+  });
+
+  it('reuses the server DOM instead of rebuilding it, and becomes interactive', async () => {
+    app().innerHTML = renderToString(h(Island, { component: Counter, mode: 'load', start: 7 }));
+    const serverButton = app().querySelector('button');
+
+    hydrate(h(Island, { component: Counter, mode: 'load', start: 7 }), app());
+    await tick();
+
+    const buttons = app().querySelectorAll('button');
+    assert.equal(buttons.length, 1, 'hydration must not double-render the island');
+    assert.equal(buttons[0], serverButton, 'the server-rendered node must be reused, not replaced');
+
+    buttons[0].dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await tick(10);
+    assert.match(app().querySelector('button').textContent, /count 8/, 'the island must be interactive');
+  });
+
+  it('marks itself hydrated and announces it', async () => {
+    let announced = null;
+    app().addEventListener('island:hydrated', (e) => { announced = e.detail; });
+    mount(h(Island, { component: Counter, mode: 'load' }), '#app');
+    await tick();
+
+    const el = app().querySelector('[data-island]');
+    assert.ok(el.hasAttribute('data-island-hydrated'));
+    assert.equal(el.hasAttribute('data-hydrate'), false, 'the pending marker is cleared');
+    assert.deepEqual(announced, { name: 'Counter', mode: 'load' });
+  });
+
+  it('mode "static" ships the HTML and never hydrates', async () => {
+    app().innerHTML = renderToString(h(Island, { component: Counter, mode: 'static', start: 4 }));
+    assert.match(app().innerHTML, /count 4/, 'static islands still render on the server');
+
+    hydrate(h(Island, { component: Counter, mode: 'static', start: 4 }), app());
+    await tick(50);
+
+    const el = app().querySelector('[data-island]');
+    assert.equal(el.hasAttribute('data-island-hydrated'), false, 'static means no JS attaches');
+    app().querySelector('button').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await tick(10);
+    assert.match(app().querySelector('button').textContent, /count 4/, 'still inert after a click');
+  });
+
+  it('mode "interaction" waits for the user before hydrating', async () => {
+    app().innerHTML = renderToString(h(Island, { component: Counter, mode: 'interaction', start: 1 }));
+    hydrate(h(Island, { component: Counter, mode: 'interaction', start: 1 }), app());
+    await tick();
+
+    const el = app().querySelector('[data-island]');
+    assert.equal(el.hasAttribute('data-island-hydrated'), false, 'no hydration without interaction');
+
+    el.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await tick();
+    assert.ok(el.hasAttribute('data-island-hydrated'), 'the interaction triggers hydration');
+  });
+});
+
+describe('refs fire on the hydration path', () => {
+  // hydrateElementProps skipped `ref` outright, so any component that reached for
+  // its own DOM node got nothing under SSR while working fine client-only. The
+  // island scheduler depends on this, but so does every ref-using component.
+  beforeEach(() => { app().innerHTML = ''; });
+
+  it('calls a ref callback with the hydrated element', () => {
+    app().innerHTML = '<div><span>hi</span></div>';
+    const existing = app().querySelector('span');
+    let got = null;
+    hydrate(h('div', {}, h('span', { ref: (el) => { got = el; } }, 'hi')), app());
+    assert.equal(got, existing, 'the ref must receive the reused server node');
+  });
+
+  it('fills a ref object with the hydrated element', () => {
+    app().innerHTML = '<p>x</p>';
+    const ref = { current: null };
+    hydrate(h('p', { ref }, 'x'), app());
+    assert.equal(ref.current, app().querySelector('p'));
+  });
+});

--- a/packages/devtools-mcp/src/index.js
+++ b/packages/devtools-mcp/src/index.js
@@ -9,6 +9,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createBridge } from './bridge.js';
 import { registerTools } from './tools.js';
+import { instrumentServer } from './tool-registry.js';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
 
@@ -52,6 +53,10 @@ const server = new McpServer({
   version: pkg.version,
 });
 
+// Record every registration so what_connection_status can report the real
+// catalogue instead of a hand-maintained literal. Must run before any
+// register* call.
+instrumentServer(server);
 registerTools(server, bridge);
 
 // --- MCP Resources: static docs for agent context ---

--- a/packages/devtools-mcp/src/tool-registry.js
+++ b/packages/devtools-mcp/src/tool-registry.js
@@ -1,0 +1,69 @@
+/**
+ * The single source of truth for what tools this MCP server actually exposes.
+ *
+ * `what_connection_status` is the tool CLAUDE.md tells every agent to call FIRST
+ * to orient, and it used to answer with a hand-maintained literal array of 17
+ * entries while 29 tools were registered. The product under-reported its own
+ * differentiator by 41% at the moment of first contact, and the same catalogue
+ * was hand-copied into CLAUDE.md, AGENTS.md and the docs, each free to drift.
+ *
+ * A framework whose thesis is machine-readable truth cannot hand-maintain its own
+ * machine-readable index, so the catalogue is now derived from registration by
+ * wrapping `server.tool` once before the three register* functions run.
+ */
+
+const registered = [];
+
+// Tools that answer with no browser attached. Everything else needs a live page
+// on the bridge, which is a stronger requirement than "the dev server is up" and
+// is the single most common reason an agent's first call comes back empty.
+const OFFLINE_TOOLS = new Set([
+  'what_connection_status',
+  'what_lint',
+  'what_validate',
+  'what_scaffold',
+  'what_fix',
+]);
+
+/**
+ * Wrap `server.tool` so every registration is recorded. Call once, before any
+ * register* function runs. Idempotent.
+ */
+export function instrumentServer(server) {
+  if (server.__whatToolRegistryInstalled) return server;
+  const original = server.tool.bind(server);
+  server.tool = (name, description, ...rest) => {
+    registered.push({ name, desc: description });
+    return original(name, description, ...rest);
+  };
+  server.__whatToolRegistryInstalled = true;
+  return server;
+}
+
+/** Every tool registered so far, in registration order. */
+export function getRegisteredTools() {
+  return registered.map((t) => ({ ...t }));
+}
+
+/**
+ * Split the catalogue by what can actually answer right now.
+ *
+ * No competitor's MCP server distinguishes "this tool exists" from "this tool can
+ * answer in this session", which is the distinction that actually costs an agent
+ * turns: it discovers the difference by calling and failing.
+ */
+export function describeToolAvailability(connected) {
+  const all = getRegisteredTools();
+  const offline = all.filter((t) => OFFLINE_TOOLS.has(t.name));
+  const needsBrowser = all.filter((t) => !OFFLINE_TOOLS.has(t.name));
+  return {
+    total: all.length,
+    available: connected ? all : offline,
+    requiresBrowser: connected ? [] : needsBrowser,
+  };
+}
+
+/** Test hook: drop the recorded registrations. @internal */
+export function __resetToolRegistry() {
+  registered.length = 0;
+}

--- a/packages/devtools-mcp/src/tools.js
+++ b/packages/devtools-mcp/src/tools.js
@@ -4,6 +4,7 @@
  */
 
 import { z } from 'zod';
+import { describeToolAvailability } from './tool-registry.js';
 
 export function registerTools(server, bridge) {
   // --- Helpers ---
@@ -112,26 +113,14 @@ export function registerTools(server, bridge) {
           'Make sure your app is running with the what-devtools-mcp Vite plugin',
           'Or manually call connectDevToolsMCP() in your browser console',
         ],
-        // Tool catalog so agents know what's available
-        tools: [
-          { name: 'what_components', desc: 'List mounted components with IDs' },
-          { name: 'what_signals', desc: 'List signals with values (use filter!)' },
-          { name: 'what_effects', desc: 'List effects with deps and run counts' },
-          { name: 'what_explain', desc: 'Everything about one component (signals + effects + DOM + errors)' },
-          { name: 'what_look', desc: 'Visual info without image: styles, layout, dimensions' },
-          { name: 'what_screenshot', desc: 'Cropped component screenshot (5-20KB)' },
-          { name: 'what_page_map', desc: 'Full page layout skeleton' },
-          { name: 'what_diagnose', desc: 'One-call health check (errors + perf + reactivity)' },
-          { name: 'what_errors', desc: 'Runtime errors with fix suggestions' },
-          { name: 'what_signal_trace', desc: 'Why did a signal change? Causal chain.' },
-          { name: 'what_dependency_graph', desc: 'Reactive dependency graph' },
-          { name: 'what_watch', desc: 'Observe events over a time window' },
-          { name: 'what_record_window', desc: 'Rank effects that re-ran during a recording window — what fired for this action?' },
-          { name: 'what_set_signal', desc: 'Change a signal value in the live app' },
-          { name: 'what_lint', desc: 'Static analysis for code (no browser needed)' },
-          { name: 'what_scaffold', desc: 'Generate boilerplate (no browser needed)' },
-          { name: 'what_fix', desc: 'Error diagnosis with code examples (no browser needed)' },
-        ],
+        // Tool catalogue, DERIVED from registration rather than hand-maintained.
+        // `tools` is every registered tool; `available` is the subset that can
+        // answer right now, which is the distinction that actually costs an
+        // agent turns when no browser is attached.
+        ...(() => {
+          const a = describeToolAvailability(connected);
+          return { toolCount: a.total, tools: a.available, requiresBrowser: a.requiresBrowser.map((t) => t.name) };
+        })(),
       };
 
       return {

--- a/packages/devtools-mcp/test/tool-registry.test.js
+++ b/packages/devtools-mcp/test/tool-registry.test.js
@@ -1,0 +1,86 @@
+// Regression for the catalogue drift found in the 2026-08-09 parity audit:
+// what_connection_status is the tool agents are told to call FIRST, and it
+// answered with a hand-maintained array of 17 entries while 29 tools were
+// registered. The catalogue is now derived from registration itself.
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  instrumentServer,
+  getRegisteredTools,
+  describeToolAvailability,
+  __resetToolRegistry,
+} from '../src/tool-registry.js';
+
+// Minimal stand-in for the MCP server surface the registry wraps.
+function fakeServer() {
+  const calls = [];
+  return { calls, tool: (name, desc, schema, handler) => calls.push({ name, desc, schema, handler }) };
+}
+
+describe('the tool catalogue is derived from registration, not hand-maintained', () => {
+  beforeEach(() => __resetToolRegistry());
+
+  it('records every registration and still registers it downstream', () => {
+    const server = instrumentServer(fakeServer());
+    server.tool('what_alpha', 'first', {}, () => {});
+    server.tool('what_beta', 'second', {}, () => {});
+
+    assert.deepEqual(getRegisteredTools().map((t) => t.name), ['what_alpha', 'what_beta']);
+    assert.equal(server.calls.length, 2, 'the real server.tool must still receive the call');
+    assert.equal(typeof server.calls[0].handler, 'function', 'trailing args must pass through');
+  });
+
+  it('is idempotent, so double instrumentation cannot double-count', () => {
+    const server = instrumentServer(fakeServer());
+    instrumentServer(server);
+    server.tool('what_alpha', 'first', {}, () => {});
+    assert.equal(getRegisteredTools().length, 1);
+  });
+
+  it('splits the catalogue by what can answer without a browser', () => {
+    const server = instrumentServer(fakeServer());
+    server.tool('what_lint', 'offline', {}, () => {});
+    server.tool('what_signals', 'needs a page', {}, () => {});
+
+    const offline = describeToolAvailability(false);
+    assert.equal(offline.total, 2);
+    assert.deepEqual(offline.available.map((t) => t.name), ['what_lint']);
+    assert.deepEqual(offline.requiresBrowser.map((t) => t.name), ['what_signals']);
+
+    const connected = describeToolAvailability(true);
+    assert.equal(connected.available.length, 2, 'everything answers once a browser is attached');
+    assert.deepEqual(connected.requiresBrowser, []);
+  });
+});
+
+describe('the real server reports its real tool count', () => {
+  // The literal this replaced said 17. If someone adds a tool and the reported
+  // count does not move, the catalogue has been hand-maintained again.
+  it('registers every tool through the instrumented surface', async () => {
+    __resetToolRegistry();
+    const server = instrumentServer(fakeServer());
+    const bridge = { send: async () => ({}), isConnected: () => false };
+    const { registerTools } = await import('../src/tools.js');
+    const { registerExtendedTools } = await import('../src/tools-extended.js');
+    const { registerAgentTools } = await import('../src/tools-agent.js');
+    registerTools(server, bridge);
+    registerExtendedTools(server, bridge);
+    registerAgentTools(server, bridge);
+
+    const names = getRegisteredTools().map((t) => t.name);
+    assert.ok(names.length >= 29, `expected at least 29 registered tools, got ${names.length}`);
+    assert.equal(new Set(names).size, names.length, 'tool names must be unique');
+    assert.ok(names.every((n) => n.startsWith('what_')), 'every tool is namespaced what_*');
+
+    // The four documented offline tools must genuinely be registered, since
+    // CLAUDE.md promises they work with no browser attached.
+    for (const n of ['what_lint', 'what_scaffold', 'what_fix', 'what_validate']) {
+      assert.ok(names.includes(n), `${n} is documented as offline-capable but is not registered`);
+    }
+
+    const { requiresBrowser } = describeToolAvailability(false);
+    assert.ok(requiresBrowser.length > 0, 'most tools genuinely need a live page');
+  });
+});

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -4,6 +4,7 @@
 
 import {
   h,
+  _isAriaAttr,
   getServerContext,
   runWithServerContext,
   beginHeadCollection,
@@ -42,7 +43,14 @@ function nextHydrationId() {
 // so the client can reuse the server-rendered DOM.
 
 export function renderToHydratableString(vnode) {
-  if (typeof document === 'undefined' && !getServerContext()) {
+  // Establish a render scope whenever one isn't already active. This used to be
+  // gated on `typeof document === 'undefined'` as a proxy for "are we on the
+  // server", but renderToString IS the server render, and the proxy is wrong
+  // under any DOM shim (jsdom, happy-dom, a Workers polyfill) where SSR ran with
+  // no scope at all and render-scoped state fell back to module globals. Every
+  // other consumer of the context checks `typeof document` itself before reading
+  // it, so a scope existing on the client changes nothing for them.
+  if (!getServerContext()) {
     const ctx = createRenderContext(undefined);
     return runWithServerContext(ctx, () => renderToHydratableString(vnode));
   }
@@ -120,7 +128,9 @@ function injectHydrationKey(html, hkId) {
 // Renders a VNode tree to an HTML string. Used for SSR and static gen.
 
 export function renderToString(vnode) {
-  if (typeof document === 'undefined' && !getServerContext()) {
+  // See renderToHydratableString: the scope is established by "no scope yet",
+  // not by "no document".
+  if (!getServerContext()) {
     const ctx = createRenderContext(undefined);
     return runWithServerContext(ctx, () => renderToString(vnode));
   }
@@ -533,6 +543,14 @@ function renderAttrs(props) {
     if (key === 'key' || key === 'ref' || key === 'children' || key === 'dangerouslySetInnerHTML' || key === 'innerHTML') continue;
     const lowerKey = key.toLowerCase();
     if (lowerKey.startsWith('on') && key.length > 2) continue; // Skip event handlers in SSR
+    // aria-*/role are enumerated, so `false` is a real value and must survive:
+    // an absent `aria-expanded` means "unsupported", `aria-expanded="false"`
+    // means "collapsed". Every other attribute keeps HTML boolean semantics,
+    // where false means omit. Checked before the falsy skip for that reason.
+    if (val === false && _isAriaAttr(key)) {
+      out += ` ${key}="false"`;
+      continue;
+    }
     if (val === false || val == null) continue;
     if (!SAFE_ATTR_NAME.test(key)) {
       if (_isDevMode) {

--- a/packages/server/src/islands.js
+++ b/packages/server/src/islands.js
@@ -311,6 +311,11 @@ export function hydrateIslands() {
   const islands = document.querySelectorAll('[data-island]');
 
   for (const el of islands) {
+    // Compiler-emitted islands (`<Counter client:idle />`) carry a direct
+    // component reference and schedule their own hydration, so they are not in
+    // the registry and must not be claimed here.
+    if (el.dataset.islandSelf) continue;
+
     const name = el.dataset.island;
     const mode = el.dataset.islandMode || 'idle';
     const props = JSON.parse(el.dataset.islandProps || '{}');


### PR DESCRIPTION
P0 from the 2026-08-09 competitive parity audit. Every item here is a feature that already existed, was already documented, and did not work.

## Islands were the worst of it

`<Counter client:idle />` rendered an empty marker div on **every** path. The SSR branch never rendered the component, and the client branch read `hydrated()` once inside a run-once component so the swap-in never fired. This is not "lazy hydration costs SEO", it is the directive deleting its own component in every mode, on both the server and the client.

Proven before the fix:

```
client, client:load : <div data-island="Counter" data-hydrate="load"></div>
server              : <div data-island="Counter" data-hydrate="load"></div>
undirected component: <button data-real="yes">count 7</button>
```

After: the server ships the component's HTML inside the marker, and the client hydrates in place over that exact DOM. The round trip is verified end to end, not asserted:

```
SSR      : <div data-island="Counter" ...><button>count 7</button></div>
buttons  : 1        (no double render)
same node: true     (server DOM reused, not rebuilt)
on click : count 8  (genuinely interactive)
```

The compiler was separately dropping island children and every spread prop, so `<Panel client:visible {...cfg}>text</Panel>` lost both. Both now flow through the same children protocol as any other component, with explicit attributes beating the spread and the directive's own `mode` beating both. The existing compiler test only asserted that `Island` and the mode appeared in the output, which is why this went unnoticed.

## Wider blast radius found on the way

`hydrateElementProps` skipped `ref` outright, so **every** component that reaches for its own DOM node through a ref got nothing under SSR while working fine in a client-only render. That is the hardest class of bug to find: it only reproduces in production.

## The `typeof document` family

Three defects with one root cause, a `typeof document === 'undefined'` check standing in for "am I rendering to a string". That proxy is wrong under jsdom, happy-dom, and a Workers polyfill.

- `renderToString` established its render scope only when there was no `document`, so SSR under any DOM shim ran with no scope at all. It now keys off "no scope yet", the actual condition.
- `useId()` therefore fell back to a process-global counter: ids drifted between the SSR pass and hydration and interleaved across concurrent requests, breaking exactly the `for` / `aria-labelledby` relationships the primitive exists to create.
- `aria-*` and `role` hit a generic boolean branch before the ARIA branch, so `aria-checked={true}` became `aria-checked=""` (not a valid enumerated value) and `aria-checked={false}` removed the attribute entirely, which reads as "unsupported" rather than "unchecked" to assistive technology. The server dropped the `false` case too. Genuine HTML booleans such as `disabled` keep HTML boolean semantics.

## MCP catalogue

`what_connection_status`, the tool CLAUDE.md tells every agent to call FIRST, answered with a hand-maintained array of 17 entries while 29 tools were registered: the product under-reported its own differentiator by 41% at the moment of first contact. The catalogue is now derived from registration itself, and additionally splits tools by what can answer with no browser attached, a distinction no competitor's MCP server makes and the single most common reason an agent's first call comes back empty.

## Verification

Full suite green (1,895 tests), plus `build`, `hygiene:publish`, `check:size`, `test:prod`, `hygiene:types`, `bench:gate` and `smoke:scaffold`. 20 new regression tests across islands, hydration refs, ARIA/useId serialization, the MCP registry, and the compiler lowering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)