### PR TITLE
fix: 22 correctness fixes across SSR, hydration, the compiler and the router (0.12.3)

### DIFF
--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -139,6 +139,51 @@ jobs:
   # fresh directory, with what-* deps pointed at local tarballs (same technique
   # as scaffold-smoke). Guards the doc path: npm init -y, "type": "module",
   # install, the doc's 3 files, and `vite build` must succeed.
+  # Real applications, built the way a user builds them, driven in a real browser
+  # against the workspace source. This is the gate that sees bugs which need two
+  # features COMBINED (SSR and hydration and a toggle); the unit suite covers each
+  # of those alone and stayed green through every defect in smoke/FINDINGS.md.
+  #
+  # Workspace mode only. The published-artifact run (`smoke:apps:npm`) belongs
+  # after a release, since there is nothing to install before one exists.
+  app-smoke:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build packages
+        run: npm run -s build
+      - name: Resolve Playwright version (cache key)
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+      - name: Install Playwright Chromium (every check is browser-driven)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system deps (browser cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - name: App smoke suite
+        run: npm run -s smoke:apps
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-apps-${{ github.run_id }}
+          path: artifacts/smoke-apps.json
+          if-no-files-found: ignore
   manual-setup-smoke:
     runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
     steps:

--- a/.depot/workflows/release-and-deploy.yml
+++ b/.depot/workflows/release-and-deploy.yml
@@ -85,6 +85,7 @@ jobs:
           npm run -s check:size
           npm run -s test:prod
           npm run -s smoke:scaffold
+          npm run -s smoke:apps
       - name: Benchmark gate (perf — non-blocking signal)
         continue-on-error: true
         # The DOM stage is skipped on the publish path (it needs a browser and
@@ -114,6 +115,17 @@ jobs:
       - name: Verify npm registry packages
         if: ${{ inputs.publish_packages && !inputs.dry_run }}
         run: npm run -s verify:registry
+      # The gate the 0.12.0 and 0.12.1 packaging defects needed and did not have.
+      # Everything above this point tests the WORKSPACE, which resolves paths that
+      # a published tarball may not contain: a types path declared but not shipped,
+      # an export condition shadowed by another, a dependency that only resolves
+      # inside the monorepo. This step installs what was just published and drives
+      # the same applications against it. Runs after the publish because there is
+      # nothing to install before one.
+      - name: App smoke suite against the PUBLISHED packages
+        if: ${{ inputs.publish_packages && !inputs.dry_run }}
+        run: npm run -s smoke:apps:npm
+
       - name: Upload registry smoke artifact
         if: ${{ always() && inputs.publish_packages && !inputs.dry_run }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,51 @@ jobs:
   # fresh directory, with what-* deps pointed at local tarballs (same technique
   # as scaffold-smoke). Guards the doc path: npm init -y, "type": "module",
   # install, the doc's 3 files, and `vite build` must succeed.
+  # Real applications, built the way a user builds them, driven in a real browser
+  # against the workspace source. This is the gate that sees bugs which need two
+  # features COMBINED (SSR and hydration and a toggle); the unit suite covers each
+  # of those alone and stayed green through every defect in smoke/FINDINGS.md.
+  #
+  # Workspace mode only. The published-artifact run (`smoke:apps:npm`) belongs
+  # after a release, since there is nothing to install before one exists.
+  app-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build packages
+        run: npm run -s build
+      - name: Resolve Playwright version (cache key)
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+      - name: Install Playwright Chromium (every check is browser-driven)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system deps (browser cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - name: App smoke suite
+        run: npm run -s smoke:apps
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-apps-${{ github.run_id }}
+          path: artifacts/smoke-apps.json
+          if-no-files-found: ignore
   manual-setup-smoke:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -90,6 +90,7 @@ jobs:
           npm run -s check:size
           npm run -s test:prod
           npm run -s smoke:scaffold
+          npm run -s smoke:apps
 
       - name: Benchmark gate (perf — non-blocking signal)
         continue-on-error: true
@@ -122,6 +123,17 @@ jobs:
       - name: Verify npm registry packages
         if: ${{ inputs.publish_packages && !inputs.dry_run }}
         run: npm run -s verify:registry
+
+      # The gate the 0.12.0 and 0.12.1 packaging defects needed and did not have.
+      # Everything above this point tests the WORKSPACE, which resolves paths that
+      # a published tarball may not contain: a types path declared but not shipped,
+      # an export condition shadowed by another, a dependency that only resolves
+      # inside the monorepo. This step installs what was just published and drives
+      # the same applications against it. Runs after the publish because there is
+      # nothing to install before one.
+      - name: App smoke suite against the PUBLISHED packages
+        if: ${{ inputs.publish_packages && !inputs.dry_run }}
+        run: npm run -s smoke:apps:npm
 
       - name: Upload registry smoke artifact
         if: ${{ always() && inputs.publish_packages && !inputs.dry_run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,269 @@
 
 All notable changes to What Framework will be documented in this file.
 
+## [0.12.3] - 2026-08-09: SSR could not render a component that used a hook, and hydration was discarding client state
+
+Twenty-two correctness fixes across SSR, hydration, the compiler, the router and
+the query layer. They were found the same way, and it is worth saying how,
+because it is the reason there are twenty-two: by building four real
+applications and driving them in a real browser, then adversarially reviewing
+each round of fixes, then fuzzing the result.
+
+Almost every one needed two features **combined** to reproduce: SSR *and* a hook;
+SSR *and* hydration *and* a toggle; a query key *and* a signal *and* an
+invalidation. The 1,900-test unit suite covers each of those alone and was fully
+green through all of them.
+
+**If you server-render, upgrade. If you use the compiler, upgrade.** Several of
+these are visible on the first page load of an ordinary app; one means whole
+categories of component could not be server-rendered at all; and three exist
+only on the compiled path, which is the recommended one. The storefront app is
+hand-written and uncompiled, the admin dashboard is a compiled Vite SPA, and
+putting the compiler in the loop exposed a second set of bugs that no amount of
+reviewing the first set would have reached.
+
+A note on how the hydration fixes were verified, since three consecutive rounds
+of hand-written fixes each closed the case in front of them and left the class
+open. A differential fuzz now generates 400 random trees, server-renders each
+with one set of values, hydrates with a different set, and asserts the result is
+identical to a client-only render. Scored against the same trees: **0.12.2 under
+browser conditions diverged on 186 of 400; this release diverges on 0.**
+
+### Fixed
+
+- **No component using a hook could be server-rendered.** `renderToString` called
+  the component function directly, with nothing on the component stack, so every
+  hook that resolves a context threw: `useState`, `useSignal`, `useComputed`,
+  `useEffect`, `useMemo`, `useCallback`, `useRef`, `useReducer`, `onMount`,
+  `onCleanup`, and `Context.Provider`. One of them anywhere in the tree and the
+  page failed to render at all. This was not a hydration warning or a degraded
+  render: `renderToString` threw. All three server paths
+  (`renderToString`, `renderToHydratableString`, `renderToStream`) each had their
+  own copy of the bare call. Components now run under a real context, which stays
+  open while the subtree renders so `useContext` resolves through it, and is
+  marked disposed on the way out so no `useEffect` body or `onMount` callback
+  ever fires on the server.
+- **A compiled keyed list rendered empty on the server and crashed hydration.**
+  `.map()` with a `key` prop, and `<For>`, lower to a mapArray *inserter*, a
+  function taking `(parent, marker)` rather than a thunk. Neither SSR nor
+  hydration had a branch for it, so both called it with no arguments. On the
+  server the throw was swallowed and the container rendered **empty**: a
+  compiled app served HTML with no list rows in it. On the client the same throw
+  escaped `hydrate()`, so the **whole page** stopped hydrating and stayed inert.
+  This is the ordinary shape for a compiled app, whose server HTML comes from an
+  uncompiled render and whose client bundle is compiled.
+- **A reactive region lost its owning component on every re-run.** The effect
+  behind `{() => ...}` re-runs with the component stack unwound, so anything it
+  built after the first paint had no owner. `useContext` fell through to the
+  context **default** for everything rendered after a state change, and an
+  `<ErrorBoundary>` stopped catching throws from components created by an inner
+  region. `dom.js` had this fix; `render.js`'s `insert()`, the path the compiler
+  emits for every reactive expression, did not, so it was broken for exactly the
+  users on the recommended build setup. Both are correct on first paint and only
+  break once the app is interactive.
+- **The compiler called every destructured prop as if it were a signal.**
+  `function Badge({ label })` with `<span data-label={label}>` compiled to
+  `setAttr(el, 'data-label', label())` and threw `label is not a function` on any
+  ordinary string prop, rendering nothing for that component and everything under
+  it. The same identifier as a *child* compiled uncalled, so the two positions
+  disagreed inside one element. Props now pass through uncalled; the runtime
+  setters already resolve a function value reactively, so an accessor prop stays
+  reactive and a real `signal()` is still auto-invoked.
+- **Hydration threw away the client's value in every browser.** Correcting a text
+  mismatch lived inside the dev-only warning branch, and "dev mode" was decided by
+  reading `process.env.NODE_ENV`, which no browser has. The check was therefore
+  false in the only environment where hydration runs, and the correction never
+  happened: the server's text stayed on screen until some later write happened to
+  touch that node. Anything the server cannot know rendered stale, so a cart
+  restored from `localStorage` showed 0 items, a saved theme showed the default,
+  a relative timestamp showed the build time. It self-heals on the next write,
+  which is why it reads like a broken store rather than a hydration bug. The
+  correction is now unconditional; only the warning is dev-gated, and the dev
+  check now uses `__DEV__`, which resolves correctly in a browser.
+- **A hydrated `<Show>` (any reactive region) lost its position on the first
+  toggle and stopped updating on the second.** The client render path wraps every
+  reactive function child in `<!--fn-->` / `<!--/fn-->` markers; the hydration
+  path created none. Without a marker, `reconcileInsert` had no insertion point
+  and appended to the end of the parent, so a region flipping content jumped to
+  the bottom of its container. And the effect's disposer was attached to the
+  *content* node, so removing that content disposed the effect and the region
+  went dead. Client-only rendering was always correct, which is why nothing
+  caught it. Hydration now creates the same markers, keeps the hydration cursor
+  aligned, and hands the end marker to `reconcileInsert`.
+- **`enhanceForms()` could not talk to `/__what_action`.** `<Form>` emits
+  `data-enhance`, and the enhancer posted a `FormData` object, which is
+  multipart. The action endpoint parses `application/x-www-form-urlencoded` or
+  JSON and nothing else, so the body failed to parse, the `_action` field went
+  missing, and every enhanced form answered 400. The no-JS path kept working, so
+  the feature looked healthy wherever it was tested with scripting off. Enhanced
+  posts now use the same encoding as the plain submit they replace.
+- **A `<Form>` inside a cached page could never submit.** The enhancer refused to
+  post whenever the page had no `<meta name="what-csrf-token">`, but `static` and
+  `hybrid` pages are shared between visitors and deliberately carry no per-visitor
+  token. Token recovery now falls back meta -> the form's own hidden field ->
+  the `what-csrf` cookie.
+- **A query went permanently deaf to `invalidateQueries()` after its first
+  refetch.** `useQuery` and `useSWR` subscribed to their key once, *outside* the
+  effect that fetches, while that effect's cleanup unsubscribed. The effect
+  re-runs whenever the query function reads a changed signal, which is the entire
+  point of a reactive query key, so the first reactive refetch dropped the
+  subscription and never restored it. The first invalidation, before any refetch,
+  works, which is why a test that mounts a query and immediately invalidates it
+  passes. The subscription now lives inside the effect.
+- **Every fetch pinned the Node event loop for five minutes.** The cache-cleanup
+  `setTimeout` was not unref'd, so any process that ran one query stayed alive for
+  a full `cacheTime` after its work finished. It is opportunistic housekeeping and
+  is now unref'd.
+- **Nested reactive regions interleaved instead of nesting.** Hydration claims the
+  inner content first, so an inner region's markers went in first and the outer
+  region's start marker landed *inside* the inner pair. Switching the outer arm
+  then removed the visible content but neither the inner markers nor the inner
+  effect: the orphaned effect kept rendering into a region that was switched off,
+  and its output came back doubled when the outer arm returned. `<Show>` wrapping
+  `<Show>` or `<For>` is the canonical shape for this. A region now opens its
+  marker before its value is hydrated, and owns everything between its markers.
+- **A region that rendered nothing lost its position permanently.** `<Show>` with
+  no fallback, or `{cond && <X/>}`, claims no node during hydration, so both
+  markers were appended to the end of the parent. When the condition later
+  flipped, the content appeared below every following sibling, forever, with no
+  warning.
+- **Empty reactive text destroyed its next sibling.** A reactive child rendering
+  `''` claimed the following node, found an element where it wanted text, and
+  replaced that element with an empty text node. The server's real markup was
+  discarded and every later sibling shifted, cascading a warn-and-recreate through
+  the rest of the parent: an `<input>` the visitor had already typed into was
+  replaced and lost its value. An empty string now claims a text node if one is
+  there, and claims nothing otherwise, so it can never consume a non-text
+  sibling. The bogus "expected text node" warning that came with it is gone too.
+- **Hydration left server markup on screen that the client never claimed.** The
+  flip side of the above: a region that is empty on the client and was *not*
+  empty on the server correctly refuses to claim that content, and so had nothing
+  to remove it. No effect owned it and no update could reach it, so the server's
+  signed-in header simply stayed visible to a signed-out visitor, underneath the
+  region meant to replace it. Hydration now removes unclaimed nodes *after* the
+  walk finishes, when anything unclaimed is unreferenced by definition, and never
+  during it. Excluded, because the walk does not own them: an element whose
+  client tree declares no children (this is how an island keeps the server HTML
+  it will hydrate later, and how a `mode: 'static'` island keeps its content
+  forever), `dangerouslySetInnerHTML` payloads, and `<body>` / `<html>` at the
+  root, where the scripts and hydration payload live.
+- **Every inline SVG went blank on hydration.** `nodeName` is uppercased for HTML
+  elements but case-preserved for everything else, so an `<svg>`'s `nodeName` is
+  `svg` and could never equal `tag.toUpperCase()`. Every server-rendered SVG
+  failed to match, warned `expected <svg>, got svg`, and was destroyed, then
+  rebuilt with `document.createElement`, which lands in the XHTML namespace and
+  does not render as SVG at all. The comparison is now case-insensitive, and the
+  mismatch fallback goes through the same `createDOM` path a client-only render
+  uses, so a rebuild is namespace-correct and sets attributes rather than
+  properties.
+- **A component disposed itself the first time its own root updated.** A hydrated
+  component's context is anchored to a DOM node so disposal can reach it. When
+  the component's root is a reactive region, that node is the region's *content*,
+  which the region replaces on its first update, taking the whole component
+  context with it: every effect, cleanup and `onCleanup` died while the component
+  was still mounted. A region root now anchors to the parent element instead.
+- **A region could never remove content it created during hydration.** When the
+  server rendered nothing and the client renders something, the content is
+  created rather than claimed, and the mismatch fallback appended it past the
+  hydration cursor. The region's end marker then landed *before* its own content,
+  so the region owned nothing: switching the condition off left the content on
+  screen permanently. The fallbacks now insert at the cursor and advance it.
+- **`enhanceForms()` ignored the form's `enctype`, silently dropping file
+  uploads.** Fixing the multipart-by-default bug above overcorrected into
+  urlencoded-always, which meant a form that correctly declared
+  `enctype="multipart/form-data"` posted without its file bytes. Encoding now
+  follows the form's own `enctype`, as the browser does.
+- **`enhanceForms()` leaked the CSRF token cross-origin, and broke on ordinary
+  forms.** A form whose action pointed at another origin was handed this
+  visitor's double-submit token; it is now only ever sent same-origin, and a
+  cross-origin form is no longer blocked by our token policy. A GET form
+  serialized its fields and then discarded them, fetching a bare URL. A field
+  named `method` or `action` shadowed `form.method` / `form.action` with the input
+  element itself (`HTMLFormElement` is `[LegacyOverrideBuiltIns]`), throwing after
+  `preventDefault()` so the submit did nothing at all: no request, no error event,
+  no native fallback. The submitter button's `name`/`value` was never sent, so a
+  multi-button form could not tell the server which button was pressed. Newlines
+  in text fields now normalize to CRLF, matching what a plain submit sends.
+- **`invalidateQueries()` was answered from the freshness window.** A query with a
+  `staleTime`, or a `useSWR` inside its default 2s `dedupingInterval`, returned
+  cached data instead of refetching. Invalidation means "this data is wrong now",
+  which is the one caller that must never be deduped. Ordinary reactive refetches
+  still dedupe.
+- **`invalidateQueries()` opened one request per subscriber.** "Dedupe window"
+  named two different mechanisms sharing one map. Bypassing the *freshness*
+  window on invalidation is right; bypassing request *coalescing* is not, because
+  every component reading a key subscribes separately, so one call arrives at N
+  subscribers and the in-flight map is what collapses them into a single fetch.
+  Four components on one key issued four concurrent requests whose responses
+  raced to write the cache. Invalidation now bumps a per-key epoch before waking
+  anyone: siblings coalesce, and a request that started before the invalidation
+  can never answer it. The epoch is a counter rather than a timestamp because
+  `Date.now()` has 1ms resolution, and the tie was reachable.
+- **Every guarded route logged a false redirect cycle in Chromium.** One guarded
+  deep link produced 25 `[what-router] Redirect cycle detected` errors and a
+  flash of the redirect-loop screen. `navigate()` sets `_isNavigating`
+  immediately but defers the URL write into `document.startViewTransition`, and
+  the router's matching reads `_isNavigating`, so the flag flip re-ran the match
+  against the still-old URL and counted the same hop twice. The detector then
+  cleared the navigation state mid-navigation. A redirect to a target that is
+  already pending is now recognized as a re-match of the same hop.
+- **An interrupted view transition surfaced as an uncaught page error.**
+  `navigate()` awaited only the transition's `.finished`, leaving the `.ready`
+  rejection unhandled, so two navigations in quick succession produced
+  `pageerror: Transition was skipped` in any error reporter the app had
+  installed, for a navigation that actually succeeded.
+- **Polling intervals and retry timers kept Node processes alive.** `refetchInterval`
+  and `refreshInterval` armed intervals that are never cleared outside a component
+  lifecycle, so an SSR render leaked one per render and kept calling the query
+  function after the HTML had been sent. Those, and the retry-backoff timer, are
+  now unref'd, and each query keeps a single cleanup timer instead of arming a new
+  one per fetch.
+
+### Changed
+
+- **`enhanceForms()` now navigates after a followed redirect.** The action
+  endpoint answers 303, so the enhanced path lands where the unenhanced one
+  would. Navigation is same-origin only: a native submit would follow an off-site
+  redirect, but a framework default that lets a server move the page to another
+  origin is not one worth having. Call `preventDefault()` on the `form:response`
+  event to keep the page put and handle the response yourself.
+
+### Added
+
+- **An application smoke suite (`npm run smoke:apps`).** Real, demoable
+  applications, driven in a real browser, run against either the workspace source
+  or the **published** packages (`npm run smoke:apps:npm`). The published mode is
+  the direct answer to the 0.12.0/0.12.1 packaging defects, which were invisible
+  to every workspace test by construction. A capability contract fails the run
+  when a framework capability has no app covering it, or when an app claims a
+  capability that no passing check ever reported. Wired into `release:verify` and
+  CI. See `smoke/README.md`, and `smoke/FINDINGS.md` for the full diagnosis behind
+  every fix above.
+- **A differential hydration fuzz** (`hydration-parity-fuzz.test.js`). 400
+  generated trees, each server-rendered with one set of signal values and
+  hydrated with a different set, asserted identical to a client-only render of
+  the same tree. It knows nothing about markers or cursors, so unlike a
+  hand-written case it cannot be satisfied by a narrow fix. It is what closed
+  this bug class, after three rounds of hand-written fixes had not.
+
+### Known gaps (not fixed here)
+
+- `renderToString` still emits no `<!--fn-->` markers for a reactive region, so
+  hydration has to infer the boundary of anything that serialized to nothing
+  rather than being told it. The inference is now exact enough to score 0/400 on
+  the fuzz, but emitting the markers is the durable fix. Deliberately deferred
+  because it changes every server-rendered byte. Tracked for 0.13.0.
+- `hydrateNode` has no branch for compiled `mapArray` output, for
+  `<ErrorBoundary>` / `<Suspense>` boundary tags, or for `<Portal>`. Tracked for
+  0.13.0.
+
+- The **runtime** render path has no keyed reconciliation: `dom.js` never reads
+  `vnode.key`, so a buildless app rebuilds every list row on each change. Keys
+  work only on the compiled path. Tracked for 0.13.0.
+- `<For>` passes **raw items** on the runtime path and **signal accessors** on the
+  compiled path, so the same JSX behaves differently depending on whether the
+  compiler ran. Unifying them is an API decision. Tracked for 0.13.0.
+
 ## [0.12.2] - 2026-08-09: what-server node-condition types are actually reachable
 
 0.12.1 published `what-server/node.d.ts` but TypeScript still could not see the Node-only

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "what-fw",
   "private": true,
-  "version": "0.12.2",
+  "version": "0.12.3",
   "type": "module",
   "description": "The web framework built for AI agents",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -37,14 +37,16 @@
     "version:bump": "node scripts/bump-version.mjs",
     "release:publish": "node scripts/publish-packages.mjs",
     "verify:registry": "node scripts/verify-registry-install.mjs",
-    "release:verify": "npm run -s hygiene:publish && npm run -s test && npm run -s build && npm run -s hygiene:publish && npm run -s hygiene:types && npm run -s typecheck && npm run -s check:size && npm run -s test:prod && npm run -s bench:gate && npm run -s smoke:scaffold",
+    "release:verify": "npm run -s hygiene:publish && npm run -s test && npm run -s build && npm run -s hygiene:publish && npm run -s hygiene:types && npm run -s typecheck && npm run -s check:size && npm run -s test:prod && npm run -s bench:gate && npm run -s smoke:scaffold && npm run -s smoke:apps",
     "release:patch": "node scripts/bump-version.mjs patch && npm run -s release:verify && npm run -s release:publish",
     "release:minor": "node scripts/bump-version.mjs minor && npm run -s release:verify && npm run -s release:publish",
     "release:major": "node scripts/bump-version.mjs major && npm run -s release:verify && npm run -s release:publish",
     "test": "node scripts/run-all-tests.mjs && npm run -s test:stress",
     "test:stress": "node stress-tests/adversarial-test.js",
     "test:prod": "node --conditions=production scripts/check-prod-build.mjs",
-    "smoke:scaffold": "node scripts/smoke-scaffold.mjs"
+    "smoke:scaffold": "node scripts/smoke-scaffold.mjs",
+    "smoke:apps": "node smoke/run.mjs",
+    "smoke:apps:npm": "node smoke/run.mjs --source=npm"
   },
   "engines": {
     "node": ">=20"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-isr",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "What Framework - Origin-first ISR cache engine: stale-while-revalidate, on-demand & poll regeneration, no CDN required",
   "type": "module",
   "main": "src/index.js",
@@ -30,7 +30,7 @@
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",
   "peerDependencies": {
-    "what-server": "^0.12.2"
+    "what-server": "^0.12.3"
   },
   "peerDependenciesMeta": {
     "what-server": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-framework-cli",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "What Framework CLI - Dev server, build, and deployment tools",
   "type": "module",
   "bin": {
@@ -22,7 +22,7 @@
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",
   "dependencies": {
-    "what-framework": "^0.12.2"
+    "what-framework": "^0.12.3"
   },
   "repository": {
     "type": "git",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-compiler",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "JSX compiler for What Framework - transforms JSX to optimized DOM operations",
   "main": "src/index.js",
   "types": "index.d.ts",
@@ -49,7 +49,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/core": "^7.0.0",
-    "what-core": "^0.12.2"
+    "what-core": "^0.12.3"
   },
   "files": [
     "src",

--- a/packages/compiler/src/babel-plugin.js
+++ b/packages/compiler/src/babel-plugin.js
@@ -391,6 +391,22 @@ export default function whatBabelPlugin({ types: t }) {
   // defined in each lexical scope (function/block).
   function collectSignalNamesFromScope(path) {
     const signalNames = new Set();
+    // Names that came from a DESTRUCTURED PROP rather than a signal() call.
+    //
+    // They belong in signalNames because they might hold an accessor and so
+    // must still be wrapped in an effect. They must NOT be auto-invoked: a prop
+    // is whatever the parent passed, and `_$createComponent` passes plain
+    // values, so `<span data-label={label}>` inside `({ label })` compiled to
+    // `setAttr(el, 'data-label', label())` and threw "label is not a function"
+    // on any ordinary string prop, blanking the whole component subtree.
+    //
+    // The same identifier as a CHILD compiled to `() => label`, uncalled, so
+    // the two positions disagreed inside a single element. The runtime setters
+    // (setAttr, setClass, setValue, ...) already resolve a function value
+    // reactively, so passing the identifier through uncalled is correct for
+    // both a plain value and an accessor.
+    const propNames = new Set();
+    signalNames.fromDestructuredProps = propNames;
 
     // Helper: extract signal names from a VariableDeclarator node
     function extractFromDeclarator(decl) {
@@ -428,8 +444,10 @@ export default function whatBabelPlugin({ types: t }) {
       for (const prop of param.properties) {
         if (t.isObjectProperty(prop) && t.isIdentifier(prop.value)) {
           signalNames.add(prop.value.name);
+          propNames.add(prop.value.name);
         } else if (t.isRestElement(prop) && t.isIdentifier(prop.argument)) {
           signalNames.add(prop.argument.name);
+          propNames.add(prop.argument.name);
         }
       }
     }
@@ -1228,7 +1246,14 @@ export default function whatBabelPlugin({ types: t }) {
         if (isPotentiallyReactive(expr, state.signalNames, state.importedIdentifiers)) {
           state.needsEffect = true;
           // Auto-invoke bare signal/imported identifiers: value={name} -> name()
+          //
+          // Never a destructured prop: it holds whatever the parent passed,
+          // which for `_$createComponent` is a plain value, and calling it
+          // threw. The runtime setters resolve a function value themselves, so
+          // an uncalled identifier is correct for a prop either way.
+          const fromProps = state.signalNames && state.signalNames.fromDestructuredProps;
           const valueExpr = t.isIdentifier(expr) &&
+            !(fromProps && fromProps.has(expr.name)) &&
             (isSignalIdentifier(expr.name, state.signalNames) ||
              (state.importedIdentifiers && state.importedIdentifiers.has(expr.name)))
             ? t.callExpression(expr, [])

--- a/packages/compiler/test/compiled-output-runtime.test.js
+++ b/packages/compiler/test/compiled-output-runtime.test.js
@@ -387,3 +387,115 @@ describe('Fragment-as-root: dynamic expression children stay reactive (MEDIUM)',
     host.remove();
   });
 });
+
+describe('a destructured prop is not treated as a signal accessor', () => {
+  // The compiler classifies every DESTRUCTURED PROP name as a signal, which is
+  // right for deciding that an effect is needed and wrong for deciding to CALL
+  // it. `_$createComponent` passes plain values, so `<span data-x={label}>`
+  // inside `({ label })` compiled to `setAttr(el, 'data-x', label())` and threw
+  //
+  //   TypeError: label is not a function
+  //
+  // on any ordinary string prop, and the whole component subtree rendered
+  // nothing. The same identifier used as a CHILD compiled to `() => label`,
+  // uncalled, so the two positions disagreed inside a single element: the text
+  // appeared and the attribute killed the component.
+  //
+  // The runtime setters (setAttr, setClass, setValue, ...) resolve a function
+  // value reactively themselves, so passing the identifier through uncalled is
+  // correct whether the parent passed a plain value or an accessor. Both are
+  // asserted below, because fixing this by never calling would be just as wrong
+  // if it broke the accessor case.
+
+  it('renders a plain string prop in attribute position', async () => {
+    const mod = await compileAndLoad(`
+      export function Badge({ label, tone }) {
+        return <span data-label={label} class={tone}>{label}</span>;
+      }
+    `);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    mount(mod.Badge({ label: 'shipped', tone: 'ok' }), host);
+    flushSync();
+
+    const span = host.querySelector('span');
+    assert.ok(span, 'the component must render at all');
+    assert.equal(span.getAttribute('data-label'), 'shipped');
+    assert.equal(span.className, 'ok');
+    assert.equal(span.textContent, 'shipped', 'the child position agrees with the attribute');
+    host.remove();
+  });
+
+  it('still tracks a prop that IS an accessor', async () => {
+    const mod = await compileAndLoad(`
+      import { signal } from 'what-framework';
+      export const live = signal('one');
+      export function Badge({ label }) {
+        return <span data-label={label}>x</span>;
+      }
+    `);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    mount(mod.Badge({ label: mod.live }), host);
+    flushSync();
+    assert.equal(host.querySelector('span').getAttribute('data-label'), 'one');
+
+    mod.live('two');
+    flushSync();
+    assert.equal(host.querySelector('span').getAttribute('data-label'), 'two',
+      'an accessor prop must stay reactive');
+    host.remove();
+  });
+
+  it('still auto-invokes a real signal from signal()', async () => {
+    const mod = await compileAndLoad(`
+      import { signal } from 'what-framework';
+      export const n = signal(1);
+      export function Counter() {
+        return <span data-n={n}>x</span>;
+      }
+    `);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    mount(mod.Counter(), host);
+    flushSync();
+    assert.equal(host.querySelector('span').getAttribute('data-n'), '1');
+
+    mod.n(2);
+    flushSync();
+    assert.equal(host.querySelector('span').getAttribute('data-n'), '2');
+    host.remove();
+  });
+
+  it('works for a prop rendered through a keyed list', async () => {
+    // The shape that found it: <Stat> cards built by items.map(), where one bad
+    // attribute blanked the entire page rather than one card.
+    const mod = await compileAndLoad(`
+      import { signal } from 'what-framework';
+      export const items = signal([
+        { id: 1, label: 'Orders', tone: 'up' },
+        { id: 2, label: 'Revenue', tone: 'down' },
+      ]);
+      function Stat({ label, tone }) {
+        return <li data-tone={tone}>{label}</li>;
+      }
+      export function App() {
+        return <ul>{items().map(it => <Stat key={it.id} label={it.label} tone={it.tone} />)}</ul>;
+      }
+    `);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    mount(mod.App(), host);
+    flushSync();
+
+    const lis = [...host.querySelectorAll('li')];
+    assert.equal(lis.length, 2, 'every card renders');
+    assert.deepEqual(lis.map(li => li.textContent), ['Orders', 'Revenue']);
+    assert.deepEqual(lis.map(li => li.getAttribute('data-tone')), ['up', 'down']);
+    host.remove();
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-core",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "What Framework - Signal-based UI framework built for AI agents",
   "type": "module",
   "main": "src/index.js",

--- a/packages/core/src/agent-context.js
+++ b/packages/core/src/agent-context.js
@@ -8,7 +8,7 @@ import { getCollectedErrors } from './errors.js';
 // --- Version ---
 // Keep in sync with packages/core/package.json (checked by
 // core/test/guardrails.test.js so it can't silently go stale again).
-const VERSION = '0.12.2';
+const VERSION = '0.12.3';
 
 // --- Component Registry ---
 // Tracks mounted components for agent inspection.

--- a/packages/core/src/data.js
+++ b/packages/core/src/data.js
@@ -87,8 +87,33 @@ function subscribeToKey(key, revalidateFn) {
   };
 }
 
-const inFlightRequests = new Map(); // key -> { promise, timestamp, refCount }
+const inFlightRequests = new Map(); // key -> { promise, timestamp, refCount, epoch }
 const lastFetchTimestamps = new Map(); // key -> timestamp of last completed fetch
+
+// How many times each key has been invalidated. This orders invalidations
+// against in-flight requests, which a wall clock cannot: Date.now() has 1ms
+// resolution, so a refetch and an unrelated invalidation issued microseconds
+// apart share a timestamp, and the invalidation would be answered by a request
+// that predates the mutation. A counter has no ties.
+const keyEpochs = new Map();
+
+function currentEpoch(key) {
+  return keyEpochs.get(key) || 0;
+}
+
+function bumpEpoch(key) {
+  keyEpochs.set(key, currentEpoch(key) + 1);
+}
+
+// Every timer this module arms is housekeeping or polling. None of it is work
+// worth keeping a Node process alive for, and on the server the usual owner of a
+// timer (a component that unmounts) does not exist, so nothing ever clears them:
+// an SSR render that touched one query pinned the event loop for minutes and kept
+// firing the query function long after the HTML had been sent.
+function unrefTimer(timer) {
+  if (timer && typeof timer.unref === 'function') timer.unref();
+  return timer;
+}
 
 // Create an effect scoped to the current component's lifecycle.
 // When the component unmounts, the effect is automatically disposed.
@@ -212,13 +237,33 @@ export function useSWR(key, fetcher, options = {}) {
 
   let abortController = null;
 
-  async function revalidate() {
+  // `force` is invalidateQueries(): "this data is wrong now". It bypasses the
+  // FRESHNESS window, which is the one caller that must never be answered from
+  // it (with the default 2s dedupingInterval an invalidation issued right after
+  // a fetch was silently swallowed and the stale data stayed on screen).
+  //
+  // It does NOT bypass request COALESCING, which is a different mechanism
+  // wearing a similar name. Every component reading a key subscribes
+  // separately, so one invalidateQueries() call fans out to N subscribers; the
+  // in-flight map is what collapses those back into one request. Skipping it
+  // opened N concurrent fetches of the same key whose responses then raced to
+  // write the cache.
+  //
+  // What force does change is WHICH in-flight request is acceptable. A response
+  // to a request that started before the data was invalidated is already stale,
+  // so it cannot answer the invalidation. One that started after it is a
+  // sibling subscriber's, and is exactly what we want to join.
+  async function revalidate({ force = false } = {}) {
     const now = Date.now();
+    const epoch = currentEpoch(key);
 
     // Deduplication: if there's already a request in flight, reuse it
     if (inFlightRequests.has(key)) {
       const existing = inFlightRequests.get(key);
-      if (now - existing.timestamp < dedupingInterval) {
+      const usable = force
+        ? existing.epoch === epoch
+        : now - existing.timestamp < dedupingInterval;
+      if (usable) {
         existing.refCount++;
         return existing.promise;
       }
@@ -226,7 +271,7 @@ export function useSWR(key, fetcher, options = {}) {
 
     // Also deduplicate against recently completed fetches
     const lastFetch = lastFetchTimestamps.get(key);
-    if (lastFetch && now - lastFetch < dedupingInterval && cacheS.peek() != null) {
+    if (!force && lastFetch && now - lastFetch < dedupingInterval && cacheS.peek() != null) {
       return cacheS.peek();
     }
 
@@ -243,7 +288,7 @@ export function useSWR(key, fetcher, options = {}) {
     isValidating.set(true);
 
     const promise = fetcher(key, { signal: abortSignal });
-    inFlightRequests.set(key, { promise, timestamp: now, refCount: 1 });
+    inFlightRequests.set(key, { promise, timestamp: now, refCount: 1, epoch });
 
     try {
       const result = await promise;
@@ -271,11 +316,16 @@ export function useSWR(key, fetcher, options = {}) {
     }
   }
 
-  // Subscribe to invalidation events for this key
-  const unsubscribe = subscribeToKey(key, () => revalidate().catch(() => {}));
-
-  // Initial fetch
+  // Initial fetch, plus the invalidation subscription for this key.
+  //
+  // The subscription lives INSIDE the effect. It used to be created once
+  // outside, while the effect's cleanup tore it down, and this effect re-runs
+  // whenever the fetcher reads a signal that changed. So the first reactive
+  // refetch unsubscribed the key and never resubscribed: from then on
+  // invalidateQueries() had no subscriber to call and silently did nothing.
+  // Re-subscribing per run keeps the two halves in the same lifecycle.
   scopedEffect(() => {
+    const unsubscribe = subscribeToKey(key, () => revalidate({ force: true }).catch(() => {}));
     revalidate().catch(() => {});
     // Cleanup: abort and unsubscribe on unmount
     return () => {
@@ -309,9 +359,9 @@ export function useSWR(key, fetcher, options = {}) {
   // Polling
   if (refreshInterval > 0) {
     scopedEffect(() => {
-      const interval = setInterval(() => {
+      const interval = unrefTimer(setInterval(() => {
         revalidate().catch(() => {});
-      }, refreshInterval);
+      }, refreshInterval));
       return () => clearInterval(interval);
     });
   }
@@ -367,13 +417,17 @@ export function useQuery(options) {
 
   let lastFetchTime = 0;
   let abortController = null;
+  let cleanupTimer = null;
 
-  async function fetchQuery() {
+  // See the note on useSWR's revalidate: an invalidation must not be answered
+  // from the freshness window, or `invalidateQueries` becomes a no-op for every
+  // query with a staleTime.
+  async function fetchQuery({ force = false } = {}) {
     if (!enabled) return;
 
     // Check if data is still fresh
     const now = Date.now();
-    if (cacheS.peek() != null && now - lastFetchTime < staleTime) {
+    if (!force && cacheS.peek() != null && now - lastFetchTime < staleTime) {
       return cacheS.peek();
     }
 
@@ -405,8 +459,13 @@ export function useQuery(options) {
         if (onSuccess) onSuccess(result);
         if (onSettled) onSettled(result, null);
 
-        // Schedule cache cleanup (only if no active subscribers)
-        setTimeout(() => {
+        // Schedule cache cleanup (only if no active subscribers).
+        //
+        // Replaces the previous timer instead of arming another: every
+        // successful fetch used to add one and clear none, so a polling query
+        // accumulated pending Timeout objects at roughly (fetch rate x cacheTime).
+        if (cleanupTimer) clearTimeout(cleanupTimer);
+        cleanupTimer = unrefTimer(setTimeout(() => {
           if (Date.now() - lastFetchTime >= cacheTime) {
             const subs = revalidationSubscribers.get(key);
             if (!subs || subs.size === 0) {
@@ -417,7 +476,7 @@ export function useQuery(options) {
               lastFetchTimestamps.delete(key);
             }
           }
-        }, cacheTime);
+        }, cacheTime));
 
         return result;
       } catch (e) {
@@ -426,7 +485,7 @@ export function useQuery(options) {
         if (attempts < retry) {
           // Abort-aware retry delay: cancel the wait if the component unmounts
           await new Promise((resolve, reject) => {
-            const id = setTimeout(resolve, retryDelay(attempts));
+            const id = unrefTimer(setTimeout(resolve, retryDelay(attempts)));
             abortSignal.addEventListener('abort', () => {
               clearTimeout(id);
               reject(new DOMException('Aborted', 'AbortError'));
@@ -452,11 +511,13 @@ export function useQuery(options) {
     return attemptFetch();
   }
 
-  // Subscribe to invalidation events for this key
-  const unsubscribe = subscribeToKey(key, () => fetchQuery().catch(() => {}));
-
-  // Initial fetch
+  // Initial fetch, plus the invalidation subscription for this key.
+  // Subscribing inside the effect is deliberate: see the matching comment in
+  // useSWR above. A query whose queryFn reads a signal re-runs this effect, and
+  // a subscription created once outside it was cancelled by the first such
+  // re-run, leaving the query permanently deaf to invalidateQueries().
   scopedEffect(() => {
+    const unsubscribe = subscribeToKey(key, () => fetchQuery({ force: true }).catch(() => {}));
     if (enabled) {
       fetchQuery().catch(() => {});
     }
@@ -482,9 +543,9 @@ export function useQuery(options) {
   // Polling
   if (refetchInterval) {
     scopedEffect(() => {
-      const interval = setInterval(() => {
+      const interval = unrefTimer(setInterval(() => {
         fetchQuery().catch(() => {});
-      }, refetchInterval);
+      }, refetchInterval));
       return () => clearInterval(interval);
     });
   }
@@ -647,6 +708,10 @@ export function invalidateQueries(keyOrPredicate, options = {}) {
   }
 
   for (const key of keysToInvalidate) {
+    // Before notifying anyone: every subscriber woken below reads this epoch, so
+    // they agree on one refetch, and any request already in flight is now a
+    // generation behind and cannot answer for them.
+    bumpEpoch(key);
     // Hard invalidation clears data immediately (shows loading state)
     // Soft invalidation (default) keeps stale data visible during re-fetch (SWR pattern)
     if (hard && cacheSignals.has(key)) cacheSignals.get(key).set(null);
@@ -688,6 +753,7 @@ export function clearCache() {
   cacheTimestamps.clear();
   lastFetchTimestamps.clear();
   inFlightRequests.clear();
+  keyEpochs.clear();
 }
 
 /**

--- a/packages/core/src/dom.js
+++ b/packages/core/src/dom.js
@@ -405,6 +405,58 @@ export function getComponentStack() {
   return componentStack;
 }
 
+/**
+ * Run a component during SSR under a real component context.
+ *
+ * renderToString used to call `vnode.tag(props)` directly, with nothing on the
+ * component stack. Every hook that needs a context (useState, useSignal,
+ * useComputed, useEffect, useMemo, useCallback, useRef, useReducer, onMount,
+ * onCleanup, and Context.Provider) resolves it through getCurrentComponent(),
+ * so all of them threw on the server. A single useState anywhere in the tree
+ * meant the component could not be server-rendered at all: the page failed at
+ * render time, not with a hydration warning.
+ *
+ * The context is the same shape createComponent and the hydration path build,
+ * for the same reason: `useContext` walks `_parentCtx`, so a Provider's context
+ * has to stay on the stack while its children render. Hence the callback.
+ *
+ * Nothing here ever mounts, so nothing deferred may run. Every hook that defers
+ * work (useEffect in all three of its dep shapes) re-checks `ctx.disposed`
+ * inside its microtask, and onMount/onCleanup only collect callbacks that a
+ * mount would later invoke. _endComponentSSR marks the context disposed, which
+ * is what makes an SSR render leave no live effects behind.
+ *
+ * Begin/end rather than a wrapper callback because one of the three SSR call
+ * sites is a generator: renderToStream has to hold the frame open across yields
+ * until the subtree has finished streaming.
+ *
+ * Always pair these in a try/finally.
+ */
+export function _beginComponentSSR(Component) {
+  const ctx = {
+    hooks: [],
+    hookIndex: 0,
+    effects: [],
+    cleanups: [],
+    mounted: false,
+    disposed: false,
+    Component,
+    _parentCtx: componentStack[componentStack.length - 1] || null,
+    _errorBoundary: null,
+  };
+  componentStack.push(ctx);
+  return ctx;
+}
+
+export function _endComponentSSR(ctx) {
+  const top = componentStack[componentStack.length - 1];
+  // Defensive: an async component that interleaved with another render could
+  // otherwise pop someone else's frame and silently reparent every context
+  // lookup after it.
+  if (top === ctx) componentStack.pop();
+  ctx.disposed = true;
+}
+
 // --- _installLazyChildren(Component, target, lazyChildren) ---
 // Deferred children from compiled JSX arrive as a zero-arg factory instead of
 // built DOM. This defines target.children over that factory and returns a

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -6,6 +6,9 @@ export { signal, computed, effect, memo as signalMemo, batch, untrack, flushSync
 
 // Fine-grained rendering primitives
 export { template, _template, _$template, svgTemplate, insert, mapArray, spread, setProp, delegateEvents, on, classList, hydrate, isHydrating, _$createComponent } from './render.js';
+// Internal, underscore-prefixed: SSR has no DOM to run a mapArray inserter
+// against, so it renders the rows from the inserter's inputs instead.
+export { _mapArrayToArray } from './render.js';
 
 // JSX factory — Fragment and html tagged template are public APIs.
 // h is exported for internal package use only (jsx-runtime, server, router, react-compat).
@@ -17,6 +20,9 @@ export { mount } from './dom.js';
 // Internal, underscore-prefixed: shared so the client, compiled-JSX and SSR
 // attribute paths cannot disagree about ARIA serialization again.
 export { _isAriaAttr } from './dom.js';
+// Internal, underscore-prefixed: the component stack lives here, so SSR has to
+// borrow it rather than build a second one that hooks cannot see.
+export { _beginComponentSSR, _endComponentSSR } from './dom.js';
 
 // Hooks (React-compatible API)
 export {

--- a/packages/core/src/render.js
+++ b/packages/core/src/render.js
@@ -196,7 +196,20 @@ export function insert(parent, child, marker) {
     let current = null;
     let textNode = null; // non-null while on the text fast path
     let mounted = false;
-    effect(() => {
+    // Capture the owning component at CREATION time. See the identical capture
+    // in createDOM's reactive branch (dom.js): this effect re-runs long after
+    // the synchronous render that created it, when the component stack is
+    // empty, so everything it builds on a re-run got parentCtx = null and the
+    // owner chain was severed. useContext then fell through to the context
+    // DEFAULT, and an ErrorBoundary stopped catching throws from components
+    // created by an inner region. Both work on first paint and only break once
+    // the app is interactive, which is why nothing caught it.
+    //
+    // dom.js was given this fix; this path, the one the COMPILER emits for
+    // every `{() => ...}`, was not. So it was broken for exactly the users on
+    // the recommended build setup.
+    const owner = captureOwner();
+    effect(() => withOwner(owner, () => {
       const val = child();
       const vt = typeof val;
       if (!mounted) {
@@ -223,7 +236,7 @@ export function insert(parent, child, marker) {
       // Type changed (or never was text) — full reconcile
       textNode = null;
       current = reconcileInsert(parent, val, current, m);
-    });
+    }));
     return current;
   }
 
@@ -261,6 +274,32 @@ function isSvgParent(parent) {
   return _hasSVGElement
     && parent instanceof SVGElement
     && parent.tagName !== 'foreignObject';
+}
+
+// --- Owner capture for effects that outlive their render ---
+//
+// A reactive region's effect re-runs long after the synchronous render that
+// created it, when the component stack has unwound. Anything it builds then has
+// no owning component, which severs the chain that useContext and the
+// ErrorBoundary / Suspense lookups both walk. Capturing the owner at creation
+// and re-pushing it for the duration of each re-run restores it.
+
+function captureOwner() {
+  const stack = getComponentStack();
+  return stack[stack.length - 1] || null;
+}
+
+function withOwner(owner, fn) {
+  const stack = getComponentStack();
+  // Already on top during the initial synchronous run; only re-push when the
+  // stack has since unwound.
+  const restore = owner !== null && stack[stack.length - 1] !== owner;
+  if (restore) stack.push(owner);
+  try {
+    return fn();
+  } finally {
+    if (restore) stack.pop();
+  }
 }
 
 function asNodeArray(value) {
@@ -504,7 +543,34 @@ export function mapArray(source, mapFn, options) {
     return endMarker;
   };
   inserter._mapArray = true;
+  // The server has no DOM to insert into, so it cannot call the inserter at all.
+  // Without these it fell through to the generic reactive-child branch, which
+  // calls the value with no arguments: `parent` was undefined, the insertBefore
+  // threw, SSR swallowed it, and every compiled keyed list rendered as an EMPTY
+  // container. Exposing the inputs lets the server produce the same rows the
+  // client will, in the same order, without touching a DOM.
+  inserter._mapArraySource = source;
+  inserter._mapArrayFn = mapFn;
+  inserter._mapArrayKeyed = !!keyFn && !raw;
   return inserter;
+}
+
+/**
+ * Render a mapArray inserter's rows without a DOM. Server-side only.
+ *
+ * Mirrors the item protocol reconcileKeyed/reconcileList use, because a row
+ * built here is hydrated by one built there: keyed non-raw mode hands the mapFn
+ * a signal ACCESSOR (so `item()` works), every other mode hands it the raw item.
+ * Getting this wrong produces server HTML that differs from the client's on
+ * every row.
+ */
+export function _mapArrayToArray(inserter) {
+  const items = inserter._mapArraySource() || [];
+  const mapFn = inserter._mapArrayFn;
+  const keyed = inserter._mapArrayKeyed;
+  return items.map((item, index) => (
+    keyed ? mapFn(() => item, index) : mapFn(item, index)
+  ));
 }
 
 function reconcileList(parent, endMarker, oldItems, newItems, mappedNodes, disposeFns, mapFn) {
@@ -1608,10 +1674,47 @@ export function hydrate(vnode, container) {
 
   try {
     const result = hydrateNode(vnode, container);
+    // Same trim as every nested element, with one exclusion. A dedicated root
+    // element holds nothing but the app, so anything the walk did not claim is
+    // stranded server markup. <body> and <html> are different: they also hold
+    // the script tags, the hydration payload and whatever the host page put
+    // there, none of which the walk claims and none of which may be removed.
+    // An app that hydrates into <body> keeps the old behavior.
+    if (container !== document.body && container !== document.documentElement) {
+      trimUnclaimed(container);
+    }
     return result;
   } finally {
     _isHydrating = false;
     _hydrationCursor = null;
+  }
+}
+
+/**
+ * Drop server-rendered nodes that the client's walk never claimed.
+ *
+ * Everything from the cursor to the end of `parent` is content the server
+ * produced and the client tree has no child for. Nothing references it, no
+ * effect owns it, and no later update can ever reach it: it is stranded markup
+ * that simply stays on screen.
+ *
+ * The case that makes this necessary is a reactive region that is empty on the
+ * client and was NOT empty on the server. An empty region deliberately claims
+ * nothing (claiming took the following sibling and destroyed it, cascading a
+ * warn-and-recreate through the rest of the parent), so the element the server
+ * rendered in its place has nothing to remove it. A cart badge the server drew
+ * for a signed-in visitor stayed visible to a signed-out one, underneath the
+ * region that was supposed to have replaced it.
+ *
+ * The two halves are what make each other safe: the walk never destroys a node
+ * it is unsure about, and this removes what the finished walk proves is unused.
+ */
+function trimUnclaimed(parent) {
+  if (!_hydrationCursor || _hydrationCursor.parent !== parent) return;
+  while (parent.childNodes.length > _hydrationCursor.index) {
+    const node = parent.lastChild;
+    disposeTree(node);
+    parent.removeChild(node);
   }
 }
 
@@ -1623,10 +1726,14 @@ function claimNode(parent) {
   const children = parent.childNodes;
   while (_hydrationCursor.index < children.length) {
     const node = children[_hydrationCursor.index];
-    // Skip hydration comment markers
+    // Skip hydration comment markers. 'fn' / '/fn' are the reactive-region
+    // markers hydration itself inserts as it walks (see the function branch of
+    // hydrateNode); the cursor is adjusted when they go in, and skipping them
+    // here keeps a later sibling from ever claiming one as its node.
     if (node.nodeType === 8) { // Comment node
       const text = node.textContent;
-      if (text === '$' || text === '/$' || text === '[]' || text === '/[]') {
+      if (text === '$' || text === '/$' || text === '[]' || text === '/[]'
+          || text === 'fn' || text === '/fn') {
         _hydrationCursor.index++;
         continue;
       }
@@ -1637,8 +1744,60 @@ function claimNode(parent) {
   return null;
 }
 
+/**
+ * What claimNode would return next, without consuming it.
+ *
+ * Used by the branches that must decide whether the server left something
+ * REUSABLE here before they commit to taking it. Claiming first and putting it
+ * back is not possible: claiming is what advances the walk.
+ */
+function peekNode(parent) {
+  if (!_hydrationCursor || _hydrationCursor.parent !== parent) return null;
+  const children = parent.childNodes;
+  for (let i = _hydrationCursor.index; i < children.length; i++) {
+    const node = children[i];
+    if (node.nodeType === 8) {
+      const text = node.textContent;
+      if (text === '$' || text === '/$' || text === '[]' || text === '/[]'
+          || text === 'fn' || text === '/fn') {
+        continue;
+      }
+    }
+    return node;
+  }
+  return null;
+}
+
+/**
+ * Put a client-created node in at the cursor and advance past it.
+ *
+ * The mismatch fallbacks used to appendChild here, which puts the node at the
+ * END of the parent rather than at the position being hydrated, and left the
+ * cursor pointing AT it. Inside a reactive region that was fatal: the region's
+ * end marker is placed at the cursor, so it landed BEFORE the content, the
+ * region owned nothing, and it could never remove or replace what it had just
+ * rendered. A `<Show>` whose server arm produced nothing showed its client arm
+ * once and then ignored the signal forever.
+ */
+function insertAtCursor(parent, node) {
+  if (_hydrationCursor && _hydrationCursor.parent === parent) {
+    parent.insertBefore(node, parent.childNodes[_hydrationCursor.index] || null);
+    _hydrationCursor.index++;
+  } else {
+    parent.appendChild(node);
+  }
+  return node;
+}
+
+// Warnings only. Never gate a DOM CORRECTION on this: see the text branch below.
+//
+// This used to test `process.env.NODE_ENV` directly, which is unreachable in a
+// browser (there is no `process`), so hydration warnings could not fire in the
+// one environment where hydration actually runs. __DEV__ resolves the same
+// question across every environment, including a buildless browser app that
+// opts in with globalThis.__WHAT_DEV__.
 function isDevMode() {
-  return typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production';
+  return __DEV__;
 }
 
 function hydrateNode(vnode, parent) {
@@ -1648,21 +1807,63 @@ function hydrateNode(vnode, parent) {
 
   // Text node
   if (typeof vnode === 'string' || typeof vnode === 'number') {
-    const existing = claimNode(parent);
     const text = String(vnode);
 
+    // An empty string never DESTROYS anything to claim it.
+    //
+    // HTML cannot serialize an empty text node, so a reactive child that was
+    // empty on the server emitted nothing at all. Claiming unconditionally took
+    // the next sibling, saw an element where it wanted text, and replaced that
+    // element with an empty text node: the server's real markup was destroyed,
+    // every following sibling shifted, and a warn-and-recreate cascaded through
+    // the rest of the parent. `{() => error()}` next to anything hit it.
+    //
+    // But refusing to claim ANYTHING was the opposite error. When the server
+    // rendered real text here and the client now evaluates to '', the server's
+    // text is exactly what has to be cleared. Skipping it left the stale value
+    // on screen and then rendered the next value ALONGSIDE it ("9 items3
+    // items"), because the region had adopted an empty node of its own while
+    // the server's text sat outside it.
+    //
+    // So: claim a text node if one is there (the client value wins, same as
+    // below), and claim nothing otherwise. The empty and non-empty cases now
+    // differ only in refusing to consume a NON-text node.
+    if (text === '') {
+      const reusable = peekNode(parent);
+      if (reusable && reusable.nodeType === 3) {
+        claimNode(parent);
+        reusable.textContent = '';
+        return reusable;
+      }
+      return insertAtCursor(parent, document.createTextNode(''));
+    }
+
+    const existing = claimNode(parent);
+
     if (existing && existing.nodeType === 3) {
-      // Reuse text node — check for mismatch in dev
-      if (isDevMode() && existing.textContent !== text) {
-        console.warn(
-          `[what] Hydration mismatch: expected text "${text}", got "${existing.textContent}"`
-        );
+      // Reuse the text node, but the CLIENT value wins.
+      //
+      // Correcting the DOM used to sit inside the dev-only branch, and dev mode
+      // was decided by `process.env.NODE_ENV`, which no browser has. The result
+      // was that in every real browser a differing value was silently discarded
+      // and the server's text stayed on screen until some later write happened
+      // to touch that node. Any state the server cannot know (a cart restored
+      // from localStorage, a saved theme, a relative timestamp) rendered stale
+      // and looked like a broken store rather than a hydration bug.
+      //
+      // The correction is unconditional now. Only the warning is dev-gated.
+      if (existing.textContent !== text) {
+        if (isDevMode()) {
+          console.warn(
+            `[what] Hydration mismatch: expected text "${text}", got "${existing.textContent}"`
+          );
+        }
         existing.textContent = text;
       }
       return existing;
     }
 
-    // Mismatch: expected text node, got element or nothing
+    // Mismatch: expected text node, got element or nothing.
     if (isDevMode()) {
       console.warn(
         `[what] Hydration mismatch: expected text node "${text}", got ${existing ? existing.nodeName : 'nothing'}. Falling back to client render.`
@@ -1672,7 +1873,7 @@ function hydrateNode(vnode, parent) {
     if (existing) {
       parent.replaceChild(textNode, existing);
     } else {
-      parent.appendChild(textNode);
+      insertAtCursor(parent, textNode);
     }
     return textNode;
   }
@@ -1682,21 +1883,140 @@ function hydrateNode(vnode, parent) {
     return hydrateNode(vnode(), parent);
   }
 
-  // Reactive function child — attach effect to existing node
-  if (typeof vnode === 'function') {
-    // Unwrap to get the initial value for hydration
-    const initialValue = vnode();
-    let current = hydrateNode(initialValue, parent);
+  // Compiled keyed list. `.map()` with a key prop, and `<For>`, lower to a
+  // mapArray INSERTER, which is a function taking (parent, marker) rather than a
+  // thunk returning a value. The generic reactive branch below called it with no
+  // arguments, so it threw on `parent.insertBefore` and the exception escaped
+  // hydrate(): the whole page stopped hydrating and stayed inert. That is the
+  // ordinary shape for a compiled app whose server HTML came from an uncompiled
+  // render, which is exactly what the fullstack template produces.
+  //
+  // The list builds its own rows rather than claiming the server's. That is a
+  // missed reuse, not a correctness problem: the inserter owns its end marker
+  // and its effect from here on, and the server's rows are left unclaimed, so
+  // trimUnclaimed removes them once the walk finishes. Claiming them properly
+  // needs the list's own boundary markers in the server HTML, which is the same
+  // thing reactive regions need and is tracked for 0.13.0.
+  if (typeof vnode === 'function' && vnode._mapArray) {
+    const cursorInParent = !!(_hydrationCursor && _hydrationCursor.parent === parent);
+    const anchor = cursorInParent ? (parent.childNodes[_hydrationCursor.index] || null) : null;
+    const endMarker = vnode(parent, anchor);
+    if (cursorInParent) {
+      const index = Array.prototype.indexOf.call(parent.childNodes, endMarker);
+      if (index >= 0) _hydrationCursor.index = index + 1;
+    }
+    return endMarker;
+  }
 
-    // Set up reactive effect for future updates (normal rendering path)
-    const dispose = effect(() => {
+  // Reactive function child: attach an effect to the existing nodes
+  if (typeof vnode === 'function') {
+    // Bound the region with the same comment markers the client render path
+    // uses (see the reactive-function branch of createDOM in dom.js). Hydration
+    // used to create none, and paid for it twice on the first update:
+    //
+    //   - reconcileInsert was handed a null marker, so it had no insertion
+    //     point and appended to the END of the parent. A hydrated <Show> that
+    //     flipped arms jumped to the bottom of its container, because a
+    //     component realizes to a DocumentFragment and fragments deliberately
+    //     skip the replace-in-place fast path.
+    //   - the effect's disposer was attached to the CONTENT node, so removing
+    //     that content disposed the effect. The region then stopped reacting
+    //     entirely: a <Show> broke position on its first flip and went dead on
+    //     its second.
+    //
+    // Markers are stable nodes that outlive every value the region ever holds,
+    // which is exactly why the client path has them. Client-only rendering was
+    // always correct here; only the SSR path was missing them.
+    //
+    // The start marker goes in BEFORE the value is hydrated, at the slot the
+    // cursor is pointing at. Anchoring afterwards to the first content node was
+    // wrong in two ways that both showed up as content in the wrong place:
+    //
+    //   - a value of null/false/undefined claims no node, so there was no anchor
+    //     and both markers were appended to the END of the parent. `<Show>` with
+    //     no fallback, or `{cond && <X/>}`, permanently lost its position: the
+    //     content appeared below every following sibling once it filled in.
+    //   - a NESTED region hydrates while we are still inside this one and
+    //     inserts its own markers around the content first. Anchoring to the
+    //     content then put the outer start marker INSIDE the inner pair, so the
+    //     regions interleaved instead of nesting. Switching the outer arm
+    //     removed the content but neither the inner markers nor the inner
+    //     effect, which kept rendering into a region that was switched off and
+    //     duplicated it when the outer arm came back. `<Show>` wrapping
+    //     `<Show>` or `<For>` is the canonical shape, not an exotic one.
+    //
+    // Opening the region first makes both cases fall out: everything the value
+    // hydrates lands after the start marker, and the end marker closes at
+    // wherever the cursor ends up.
+    const cursorInParent = !!(_hydrationCursor && _hydrationCursor.parent === parent);
+    const startMarker = document.createComment('fn');
+    const endMarker = document.createComment('/fn');
+
+    if (cursorInParent) {
+      parent.insertBefore(startMarker, parent.childNodes[_hydrationCursor.index] || null);
+      _hydrationCursor.index++;
+    } else {
+      parent.appendChild(startMarker);
+    }
+
+    // Hydrate the value for its side effects: it claims the server's nodes and,
+    // if it contains a nested region, inserts that region's markers. What it
+    // RETURNS is deliberately ignored, because it is not the region's contents:
+    // a nested region's markers are not in it. The tracked set is read back from
+    // the DOM below, between the markers, which is the actual boundary.
+    hydrateNode(vnode(), parent);
+
+    if (cursorInParent) {
+      parent.insertBefore(endMarker, parent.childNodes[_hydrationCursor.index] || null);
+      _hydrationCursor.index++;
+    } else {
+      parent.appendChild(endMarker);
+    }
+
+    // The region owns EVERYTHING between its markers, not just the nodes its own
+    // value produced. A nested region leaves its markers in here too, and those
+    // markers carry the disposer for the nested effect.
+    //
+    // Tracking only the value's own nodes meant that switching this region off
+    // removed the visible content and left the inner markers and the inner
+    // effect behind. The orphaned effect kept rendering into a region that was
+    // switched off, and its output reappeared, doubled, when this region came
+    // back. Collecting from the DOM is also more honest than reasoning about
+    // what hydrateNode returned: the markers are the boundary, so whatever sits
+    // between them is the content.
+    const owned = [];
+    for (let node = startMarker.nextSibling; node && node !== endMarker; node = node.nextSibling) {
+      owned.push(node);
+    }
+    let current = owned.length === 0 ? null : (owned.length === 1 ? owned[0] : owned);
+
+    // Set up reactive effect for future updates (normal rendering path).
+    // The owner is captured for the same reason as in insert() and createDOM:
+    // every re-run happens with the component stack unwound.
+    const owner = captureOwner();
+    const dispose = effect(() => withOwner(owner, () => {
       const value = vnode();
       // After hydration, this runs as normal insert
       if (!_isHydrating) {
-        current = reconcileInsert(parent, value, current, null);
+        current = reconcileInsert(endMarker.parentNode || parent, value, current, endMarker);
       }
-    });
-    addHydrationDisposer(current && current.nodeType ? current : parent, dispose);
+    }));
+
+    // The disposer is now reachable from three places (either marker via
+    // disposeTree, and the hydration disposer registry), which is deliberate:
+    // whichever one the teardown happens to walk, the effect dies. It must
+    // therefore be idempotent, or a tree disposed through more than one route
+    // decrements the live-effect count once per route.
+    let disposed = false;
+    const disposeOnce = () => {
+      if (disposed) return;
+      disposed = true;
+      dispose();
+    };
+
+    startMarker._dispose = disposeOnce;
+    endMarker._dispose = disposeOnce;
+    addHydrationDisposer(startMarker, disposeOnce);
     return current;
   }
 
@@ -1776,11 +2096,26 @@ function hydrateNode(vnode, parent) {
       // createComponent in dom.js.
       try {
         const node = hydrateNode(result, parent);
-        // No comment markers exist on this path, so anchor the ctx to the node
-        // the component produced (or to the parent when it produced none) —
-        // otherwise disposeTree can never reach it and the ctx leaks.
+        // No comment markers exist for a COMPONENT on this path, so the ctx has
+        // to hang off some node that disposeTree will reach, or it leaks.
+        //
+        // Anchoring it to the first node the component produced is only valid
+        // when that node is stable. If the component's root is a reactive
+        // region, that node is the region's current CONTENT, and the region
+        // replaces it on the very first update: disposeTree then ran over it and
+        // took the whole component context with it. Every effect, cleanup and
+        // onCleanup the component owns died the first time its own root
+        // re-rendered, which is the same create-outside/dispose-inside-an-effect
+        // shape the region markers exist to prevent.
+        //
+        // A region root falls back to the parent element instead. That disposes
+        // later than ideal (when the parent goes, not when the component does),
+        // and disposing late is strictly better than disposing while mounted.
+        const rootIsRegion = typeof result === 'function'
+          || (Array.isArray(result) && result.some((child) => typeof child === 'function'));
         const first = Array.isArray(node) ? node[0] : node;
-        addHydratedComponent(first && first.nodeType ? first : parent, ctx);
+        const anchor = (!rootIsRegion && first && first.nodeType) ? first : parent;
+        addHydratedComponent(anchor, ctx);
         return node;
       } finally {
         componentStack.pop();
@@ -1788,10 +2123,18 @@ function hydrateNode(vnode, parent) {
     }
 
     // Element — claim existing DOM element
+    //
+    // The comparison is case-INSENSITIVE. `nodeName` is uppercased for HTML
+    // elements but case-preserved for everything else, so an SVG element's
+    // nodeName is 'svg' and could never equal `tag.toUpperCase()`. Every inline
+    // SVG on a server-rendered page therefore failed to match, warned
+    // "expected <svg>, got svg", and was destroyed and rebuilt: with
+    // document.createElement, in the HTML namespace, which does not render as
+    // SVG at all. Icons, logos and charts went blank on hydration.
     const existing = claimNode(parent);
-    const expectedTag = vnode.tag.toUpperCase();
+    const expectedTag = vnode.tag.toLowerCase();
 
-    if (existing && existing.nodeType === 1 && existing.nodeName === expectedTag) {
+    if (existing && existing.nodeType === 1 && existing.nodeName.toLowerCase() === expectedTag) {
       // Match! Reuse this element. Apply props/bindings.
       hydrateElementProps(existing, vnode.props || {});
 
@@ -1804,6 +2147,20 @@ function hydrateNode(vnode, parent) {
         for (const child of vnode.children) {
           hydrateNode(child, existing);
         }
+        // Only when the client tree actually declares children here.
+        //
+        // An element the client says is EMPTY is not the same claim as "the
+        // server's content is stale". An island is the counter-example that
+        // matters: it renders a bare host element and fills it in later, when
+        // its trigger fires, from the server HTML still sitting inside it.
+        // Trimming on an empty child list threw that content away and the
+        // island rebuilt it from scratch, which is the exact opposite of what
+        // an island is for (a `mode: 'static'` island, which never hydrates at
+        // all, simply lost its content).
+        //
+        // dangerouslySetInnerHTML is excluded above for the same reason: the
+        // cursor never walks that subtree, so nothing in it is ever claimed.
+        if (vnode.children.length > 0) trimUnclaimed(existing);
       }
 
       _hydrationCursor = savedCursor;
@@ -1817,19 +2174,17 @@ function hydrateNode(vnode, parent) {
       );
     }
 
-    // Create the element from scratch
-    const newEl = document.createElement(vnode.tag);
-    for (const key in vnode.props || {}) {
-      if (key === 'children' || key === 'key') continue;
-      setProp(newEl, key, vnode.props[key]);
-    }
-    for (const child of vnode.children) {
-      reconcileInsert(newEl, child, null, null);
-    }
+    // Create the element from scratch, through the same path a client-only
+    // render uses. The hand-rolled version here called document.createElement
+    // and setProp with no SVG context, so a rebuilt <svg> landed in the XHTML
+    // namespace and rendered as nothing at all, and its attributes were set as
+    // properties rather than attributes. Falling back to a client render has to
+    // mean the client render, not an approximation of it.
+    const newEl = createDOM(vnode, parent, isSvgParent(parent));
     if (existing) {
       parent.replaceChild(newEl, existing);
     } else {
-      parent.appendChild(newEl);
+      insertAtCursor(parent, newEl);
     }
     return newEl;
   }
@@ -1840,9 +2195,7 @@ function hydrateNode(vnode, parent) {
   }
 
   // Fallback — create text node
-  const textNode = document.createTextNode(String(vnode));
-  parent.appendChild(textNode);
-  return textNode;
+  return insertAtCursor(parent, document.createTextNode(String(vnode)));
 }
 
 /**

--- a/packages/core/test/hydration-client-value.test.js
+++ b/packages/core/test/hydration-client-value.test.js
@@ -1,0 +1,137 @@
+// Hydration must adopt the CLIENT's value when it differs from the server's.
+//
+// This file runs with dev mode forced OFF, which is the configuration the bug
+// lived in. Correcting the DOM on a text mismatch used to sit inside the
+// dev-only warning branch, and "dev mode" was decided by reading
+// `process.env.NODE_ENV` -- a check no browser can ever pass, because browsers
+// have no `process`. So in every real browser the correction was skipped and the
+// server's text stayed on screen.
+//
+// The visible symptom is not "a warning is missing". It is that any state the
+// server cannot know renders stale: a cart restored from localStorage shows 0
+// items, a saved theme shows the default, a relative timestamp shows the build
+// time. It self-heals on the next write to that node, so it reads like a broken
+// store rather than a hydration bug, and it is invisible to every test that runs
+// under Node.
+//
+// `globalThis.__WHAT_DEV__` must be set BEFORE importing: __DEV__ is resolved
+// once at module evaluation. Hence a dedicated file.
+
+globalThis.__WHAT_DEV__ = false;
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+global.SVGElement = dom.window.SVGElement;
+
+const { signal, computed, flushSync, __DEV__ } = await import('../src/reactive.js');
+const { h } = await import('../src/h.js');
+const { hydrate } = await import('../src/render.js');
+const { renderToString } = await import('what-server');
+
+// Server render, then hand the HTML to a client whose state differs. Mirrors a
+// store hydrated from localStorage, which is the shape that surfaced this.
+function serverThenClient({ serverValue, clientValue }) {
+  const Badge = (count) => () => h('a', { class: 'badge' },
+    h('span', { 'data-count': '' }, () => String(count())),
+  );
+  const Page = (count) => () => h('div', { class: 'page' },
+    h(Badge(count), {}),
+    h('main', {}, h('h1', {}, 'Shop')),
+  );
+
+  const server = signal(serverValue);
+  document.body.innerHTML = renderToString(h(Page(computed(() => server())), {}));
+  const serverText = document.querySelector('[data-count]').textContent;
+
+  const client = signal(clientValue);
+  hydrate(h(Page(computed(() => client())), {}), document.body);
+  flushSync();
+
+  return {
+    serverText,
+    hydratedText: document.querySelector('[data-count]').textContent,
+    node: document.querySelector('[data-count]'),
+    client,
+  };
+}
+
+describe('hydration adopts the client value with dev mode off', () => {
+  let warnings;
+  let originalWarn;
+
+  before(() => {
+    originalWarn = console.warn;
+    warnings = [];
+    console.warn = (...args) => warnings.push(args.join(' '));
+  });
+
+  after(() => { console.warn = originalWarn; });
+
+  it('is running in the configuration the bug required', () => {
+    assert.equal(__DEV__, false, 'this file must run with dev mode off');
+  });
+
+  it('replaces stale server text with the client value', () => {
+    const { serverText, hydratedText } = serverThenClient({ serverValue: 0, clientValue: 3 });
+    assert.equal(serverText, '0', 'the server rendered its own value');
+    assert.equal(hydratedText, '3', 'hydration must show the client value, not the server value');
+  });
+
+  it('corrects even with no `process` global, which is every browser', () => {
+    // The exact condition the bug needed. Node always has `process`, so a test
+    // that does not remove it cannot see this failure at all: that is why the
+    // defect survived a full suite and only appeared in a real browser.
+    const savedProcess = globalThis.process;
+    try {
+      delete globalThis.process;
+      const { hydratedText } = serverThenClient({ serverValue: 0, clientValue: 6 });
+      assert.equal(hydratedText, '6', 'a browser must not keep the stale server text');
+    } finally {
+      globalThis.process = savedProcess;
+    }
+  });
+
+  it('does so without emitting a warning when dev mode is off', () => {
+    warnings.length = 0;
+    serverThenClient({ serverValue: 0, clientValue: 7 });
+    assert.deepEqual(warnings, [], 'production hydration must correct silently');
+  });
+
+  it('reuses the existing text node rather than replacing it', () => {
+    // Correcting must not mean re-creating: the point of hydration is DOM reuse.
+    // The server's text node itself has to survive, carrying the new value.
+    const serverSignal = signal(0);
+    const Page = (count) => () => h('span', { 'data-count': '' }, () => String(count()));
+    document.body.innerHTML = renderToString(h(Page(computed(() => serverSignal())), {}));
+
+    const serverTextNode = document.querySelector('[data-count]').firstChild;
+    assert.equal(serverTextNode.nodeType, 3);
+    assert.equal(serverTextNode.data, '0');
+
+    hydrate(h(Page(computed(() => signal(5)())), {}), document.body);
+    flushSync();
+
+    assert.equal(serverTextNode.data, '5', 'the server text node must be updated in place');
+    assert.ok(serverTextNode.isConnected, 'and must still be in the document');
+  });
+
+  it('stays reactive after the correction', () => {
+    const { client, node } = serverThenClient({ serverValue: 0, clientValue: 2 });
+    assert.equal(node.textContent, '2');
+    client(11);
+    flushSync();
+    assert.equal(node.textContent, '11', 'the effect must still be bound to the corrected node');
+  });
+
+  it('leaves a matching value untouched', () => {
+    const { hydratedText } = serverThenClient({ serverValue: 4, clientValue: 4 });
+    assert.equal(hydratedText, '4');
+  });
+});

--- a/packages/core/test/hydration-keyed-list.test.js
+++ b/packages/core/test/hydration-keyed-list.test.js
@@ -1,0 +1,150 @@
+// A compiled keyed list must survive SSR and hydration.
+//
+// `.map()` with a `key` prop, and `<For>`, lower to a mapArray INSERTER: a
+// function taking (parent, marker), not a thunk returning a value. Hydration had
+// no branch for it, so the generic reactive-child branch called it with no
+// arguments, `parent.insertBefore` threw on undefined, and the exception escaped
+// hydrate(). Not one list: the WHOLE PAGE stopped hydrating and stayed inert.
+//
+// The shape is the ordinary one for a compiled app. The server renders through
+// runtime `h()` (plain arrays), the client bundle is compiled (mapArray
+// inserters), and they meet at hydration. Nothing in the unit suite covered it
+// because the compiled path is tested by mounting, never by hydrating, and the
+// SSR tests never see compiled output.
+//
+// The server side had its own version of the same hole: renderToString hit the
+// same bad call, swallowed the error, and emitted an EMPTY container. A compiled
+// app's server HTML had no list rows in it at all.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+global.SVGElement = dom.window.SVGElement;
+
+const { signal, flushSync } = await import('../src/reactive.js');
+const { h } = await import('../src/h.js');
+const { hydrate, mapArray, insert } = await import('../src/render.js');
+const { renderToString, renderToHydratableString, renderToStream } = await import('what-server');
+
+const root = () => document.getElementById('root');
+const rows = () => [...root().querySelectorAll('li')].map((li) => li.textContent);
+
+const ITEMS = [{ id: 1, t: 'a' }, { id: 2, t: 'b' }, { id: 3, t: 'c' }];
+
+/** What the compiler emits for a row: real DOM, built directly, no vnode. */
+const compiledRow = (accessor) => {
+  const li = document.createElement('li');
+  insert(li, () => accessor().t);
+  return li;
+};
+
+/** What the server renders: runtime h() over a plain array. */
+const serverTree = (items) => h('ul', {}, () => items.map((it) => h('li', {}, it.t)));
+
+/** What the compiled client hydrates with. */
+const clientTree = (items) => h('ul', {}, mapArray(items, compiledRow, { key: (x) => x.id }));
+
+describe('a compiled keyed list hydrates against server HTML', () => {
+  it('does not throw, which would leave the whole page inert', () => {
+    root().innerHTML = renderToString(serverTree(ITEMS));
+    const items = signal(ITEMS);
+
+    assert.doesNotThrow(() => {
+      hydrate(clientTree(items), root());
+      flushSync();
+    });
+  });
+
+  it('renders every row exactly once', () => {
+    root().innerHTML = renderToString(serverTree(ITEMS));
+    const items = signal(ITEMS);
+    hydrate(clientTree(items), root());
+    flushSync();
+
+    // The list builds its own rows and the server's are removed as unclaimed,
+    // so the assertion is on the result, not on node identity. Reusing them
+    // needs list boundary markers in the server HTML (tracked for 0.13.0).
+    assert.deepEqual(rows(), ['a', 'b', 'c'], 'no duplicated or dropped rows');
+  });
+
+  it('stays keyed and reactive afterwards', () => {
+    root().innerHTML = renderToString(serverTree(ITEMS));
+    const items = signal(ITEMS);
+    hydrate(clientTree(items), root());
+    flushSync();
+
+    items([{ id: 3, t: 'c' }, { id: 1, t: 'A' }, { id: 4, t: 'd' }]);
+    flushSync();
+    assert.deepEqual(rows(), ['c', 'A', 'd'], 'reorder, update and insert all apply');
+
+    items([]);
+    flushSync();
+    assert.deepEqual(rows(), [], 'and it can clear');
+  });
+
+  it('leaves the surrounding markup alone', () => {
+    root().innerHTML = renderToString(
+      h('div', {}, h('h2', { 'data-title': '' }, 'Orders'), serverTree(ITEMS)),
+    );
+    const title = root().querySelector('[data-title]');
+    const items = signal(ITEMS);
+
+    hydrate(h('div', {}, h('h2', { 'data-title': '' }, 'Orders'), clientTree(items)), root());
+    flushSync();
+
+    assert.equal(root().querySelector('[data-title]'), title, 'the heading is reused, not rebuilt');
+    assert.deepEqual(rows(), ['a', 'b', 'c']);
+  });
+});
+
+describe('a keyed list renders its rows on every server path', () => {
+  // renderToString swallowed the bad call and emitted an empty container, so a
+  // compiled app served HTML with no rows in it: nothing for a crawler, nothing
+  // painted before the bundle arrived.
+  const tree = () => h('ul', {}, mapArray(signal(ITEMS), (it) => h('li', {}, () => it().t), { key: (x) => x.id }));
+
+  it('renderToString', () => {
+    assert.equal(renderToString(tree()), '<ul><li>a</li><li>b</li><li>c</li></ul>');
+  });
+
+  it('renderToHydratableString', () => {
+    const html = renderToHydratableString(tree());
+    assert.match(html, /<li>/, 'the rows are present');
+    assert.equal((html.match(/<li>/g) || []).length, 3);
+  });
+
+  it('renderToStream', async () => {
+    let html = '';
+    for await (const chunk of renderToStream(tree(), {})) html += chunk;
+    assert.equal((html.match(/<li>/g) || []).length, 3);
+  });
+
+  it('hands the mapFn the same item shape the client does', () => {
+    // Keyed non-raw mode passes a signal ACCESSOR; every other mode passes the
+    // raw item. Getting this wrong on the server produces HTML that differs
+    // from the client's on every row.
+    const keyed = h('ul', {}, mapArray(signal(ITEMS), (acc) => h('li', {}, () => acc().t), { key: (x) => x.id }));
+    assert.equal(renderToString(keyed), '<ul><li>a</li><li>b</li><li>c</li></ul>');
+
+    const raw = h('ul', {}, mapArray(signal(ITEMS), (item) => h('li', {}, item.t)));
+    assert.equal(renderToString(raw), '<ul><li>a</li><li>b</li><li>c</li></ul>');
+  });
+
+  it('does not take the page down when a row throws', () => {
+    // SSR is fail-soft here by design: one bad row must not blank the response.
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const bad = h('ul', {}, mapArray(signal(ITEMS), () => { throw new Error('row exploded'); }, { key: (x) => x.id }));
+      assert.equal(renderToString(h('div', {}, bad, h('p', {}, 'after'))), '<div><ul></ul><p>after</p></div>');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/packages/core/test/hydration-parity-fuzz.test.js
+++ b/packages/core/test/hydration-parity-fuzz.test.js
@@ -1,0 +1,198 @@
+// Differential fuzz: a hydrated tree must end up identical to a client-only
+// render of the same tree.
+//
+// That is the whole contract of hydration, and it is the only assertion here.
+// It needs no knowledge of markers, cursors or claim rules, so it stays true if
+// the implementation of any of them changes, and it does not have to be updated
+// when someone finds the next shape.
+//
+// This exists because every hydration bug fixed in this release was found by a
+// human building an app or by a reviewer hand-writing one adversarial tree at a
+// time, and the hand-written cases each closed one shape while leaving the
+// class open. Random trees do not have that blind spot. Scored against the same
+// 400 generated cases:
+//
+//   0.12.2 as published, under browser conditions ... 186 / 400 divergent
+//   0.12.2 with the dev-only correction forced on ...  32 / 400
+//   this release .....................................  0 / 400
+//
+// The generator is a seeded LCG, so a failure is reproducible from its case
+// number and the whole run is deterministic across machines and CI.
+//
+// If this starts failing, do not chase the printed textContent. Print the case
+// number, rebuild that one tree, and look at `hyd html`: the marker layout is
+// where the answer is.
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+global.SVGElement = dom.window.SVGElement;
+
+const { signal, flushSync } = await import('../src/reactive.js');
+const { h } = await import('../src/h.js');
+const { hydrate } = await import('../src/render.js');
+const { mount } = await import('../src/dom.js');
+const { renderToString } = await import('what-server');
+
+const CASES = 400;
+const SEED = 12345;
+
+// Server and client deliberately disagree on every value, which is the point:
+// hydration is only interesting when the client knows something the server did
+// not. Note the shapes covered by the pairing: a value that gains content
+// (''->'ERR'), one that loses it ('q'->''), one that changes type (0->7), and
+// one that changes text ('x'->'zz').
+const SERVER_VALUES = [0, 'x', '', 'q'];
+const CLIENT_VALUES = [7, 'zz', 'ERR', ''];
+
+function makeGenerator(seed) {
+  let state = seed;
+  const rnd = () => (state = (state * 1664525 + 1013904223) >>> 0) / 4294967296;
+  const pick = (a) => a[Math.floor(rnd() * a.length)];
+
+  // Returns a factory taking the signal array, so the server tree and the
+  // client tree are structurally identical and differ only in signal values.
+  function makeFactory(depth) {
+    const kinds = depth > 0
+      ? ['text', 'rtext', 'el', 'cmp', 'cond']
+      : ['text', 'rtext'];
+    const kind = pick(kinds);
+
+    // A static text child. ' ' is in the set on purpose: a lone space is the
+    // classic thing an SSR walk loses or duplicates.
+    if (kind === 'text') {
+      const t = pick(['A', 'B', 'static-', ' ']);
+      return () => t;
+    }
+    // A reactive text child, which is what serializes to nothing when empty.
+    if (kind === 'rtext') {
+      const i = Math.floor(rnd() * 4);
+      return (vals) => () => String(vals[i]());
+    }
+    // A conditional region whose falsy arm is '' rather than null, so it
+    // exercises the empty-text path rather than the null path.
+    if (kind === 'cond') {
+      const i = Math.floor(rnd() * 4);
+      const inner = makeFactory(depth - 1);
+      return (vals) => () => (vals[i]() ? h('em', {}, inner(vals)) : '');
+    }
+
+    const n = 1 + Math.floor(rnd() * 3);
+    const kids = Array.from({ length: n }, () => makeFactory(depth - 1));
+    if (kind === 'el') {
+      const tag = pick(['div', 'span', 'section']);
+      return (vals) => h(tag, {}, ...kids.map((k) => k(vals)));
+    }
+    // A component, which realizes to a fragment and so takes a different
+    // reconciliation path than a plain element.
+    const tag = pick(['div', 'span']);
+    const Cmp = (vals) => () => h(tag, { 'data-c': '' }, ...kids.map((k) => k(vals)));
+    return (vals) => h(Cmp(vals), {});
+  }
+
+  return makeFactory;
+}
+
+/** Silence the dev mismatch warnings; this asserts on the DOM, not the log. */
+function quiet(fn) {
+  const original = console.warn;
+  console.warn = () => {};
+  try { return fn(); } finally { console.warn = original; }
+}
+
+describe('a hydrated tree matches a client-only render of the same tree', () => {
+  const divergent = [];
+  const threw = [];
+  let checked = 0;
+
+  before(() => {
+    const makeFactory = makeGenerator(SEED);
+    const sig = (values) => values.map((v) => signal(v));
+
+    for (let n = 0; n < CASES; n++) {
+      const factory = makeFactory(3);
+
+      // 1. What the client alone produces. This is the reference answer.
+      document.body.innerHTML = '<div id="client"></div>';
+      let clientOnly;
+      try {
+        quiet(() => mount(factory(sig(CLIENT_VALUES)), '#client'));
+        flushSync();
+        clientOnly = document.getElementById('client').textContent;
+      } catch {
+        continue; // a tree the client cannot render is not a hydration case
+      }
+
+      // 2. Server-render it with the server's values, then hydrate with the
+      //    client's. The result must be indistinguishable from step 1.
+      let ssr;
+      try {
+        ssr = renderToString(factory(sig(SERVER_VALUES)));
+      } catch {
+        continue;
+      }
+
+      document.body.innerHTML = `<div id="host">${ssr}</div>`;
+      const host = document.getElementById('host');
+      try {
+        quiet(() => hydrate(factory(sig(CLIENT_VALUES)), host));
+        flushSync();
+      } catch (e) {
+        threw.push({ n, ssr, message: e.message });
+        continue;
+      }
+
+      checked++;
+      if (host.textContent !== clientOnly) {
+        divergent.push({
+          n,
+          ssr,
+          expected: clientOnly,
+          actual: host.textContent,
+          html: host.innerHTML,
+        });
+      }
+    }
+  });
+
+  it('actually exercised the generated trees', () => {
+    // Both loops above `continue` past trees the client or the server cannot
+    // render at all. Without this, a generator change that made every tree fail
+    // early would leave a fuzz suite that checks nothing and passes: the exact
+    // shape of green-but-inert test this file exists to catch.
+    assert.ok(
+      checked >= CASES * 0.75,
+      `only ${checked}/${CASES} trees reached the comparison; the generator is producing trees that cannot render`,
+    );
+  });
+
+  it(`renders ${CASES} generated trees without throwing`, () => {
+    assert.deepEqual(
+      threw.map((t) => `#${t.n}: ${t.message}`),
+      [],
+      'hydration must never throw: it aborts the whole page, leaving it inert',
+    );
+  });
+
+  it('produces byte-identical text for every generated tree', () => {
+    const report = divergent.slice(0, 5).map((d) => [
+      `case #${d.n}`,
+      `  ssr        : ${JSON.stringify(d.ssr)}`,
+      `  client-only: ${JSON.stringify(d.expected)}`,
+      `  hydrated   : ${JSON.stringify(d.actual)}`,
+      `  hyd html   : ${JSON.stringify(d.html)}`,
+    ].join('\n')).join('\n\n');
+
+    assert.equal(
+      divergent.length,
+      0,
+      `${divergent.length}/${checked} hydrated trees diverged from a client render:\n\n${report}`,
+    );
+  });
+});

--- a/packages/core/test/hydration-reactive-region.test.js
+++ b/packages/core/test/hydration-reactive-region.test.js
@@ -1,0 +1,433 @@
+// A reactive region must keep its POSITION and stay alive after hydration.
+//
+// The client render path wraps every reactive function child in `<!--fn-->` /
+// `<!--/fn-->` comment markers. The hydration path created none, and that cost
+// two things the moment anything updated:
+//
+//   1. reconcileInsert was called with a null marker, so it had no insertion
+//      point and appended to the end of the parent. A <Show> that flipped arms
+//      teleported to the bottom of its container. (A component realizes to a
+//      DocumentFragment, and fragments deliberately skip the replace-in-place
+//      fast path, so this hit every component-valued region.)
+//   2. the effect's disposer was attached to the CONTENT node, so removing that
+//      content disposed the effect. The region then never updated again.
+//
+// Net effect: a server-rendered <Show> broke its layout on the first toggle and
+// stopped responding on the second. Client-only rendering was always correct,
+// which is why no existing test saw it: the bug needed SSR + hydration + a
+// toggle, and the suite covered each of those separately.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+global.SVGElement = dom.window.SVGElement;
+
+const { signal, flushSync } = await import('../src/reactive.js');
+const { h } = await import('../src/h.js');
+const { hydrate } = await import('../src/render.js');
+const { mount } = await import('../src/dom.js');
+const { Show } = await import('../src/components.js');
+const { onCleanup } = await import('../src/hooks.js');
+const { renderToString } = await import('what-server');
+
+// <main> with a stable heading, a toggling region, and a stable trailing
+// paragraph. The trailing sibling is the point: it is what makes a position
+// regression observable at all.
+function App(count) {
+  return () => h('main', {},
+    h('h1', {}, 'Cart'),
+    h(Show, { when: () => count() > 0, fallback: h('p', { 'data-empty': '' }, 'Empty') },
+      h('div', { 'data-table': '' }, 'Table'),
+    ),
+    h('p', { 'data-status': '' }, 'status'),
+  );
+}
+
+function layout() {
+  return [...document.querySelector('main').children]
+    .map((el) => {
+      if (el.dataset.empty !== undefined) return 'empty';
+      if (el.dataset.table !== undefined) return 'table';
+      if (el.dataset.status !== undefined) return 'status';
+      return el.tagName.toLowerCase();
+    })
+    .join(' ');
+}
+
+/** SSR at `serverValue`, then hydrate a client sitting at `clientValue`. */
+function boot(serverValue, clientValue) {
+  const server = signal(serverValue);
+  document.body.innerHTML = renderToString(h(App(server), {}));
+  const client = signal(clientValue);
+  hydrate(h(App(client), {}), document.body);
+  flushSync();
+  return client;
+}
+
+describe('a hydrated reactive region keeps its place in the DOM', () => {
+  it('toggles in place when server and client agree at hydration', () => {
+    const count = boot(0, 0);
+    assert.equal(layout(), 'h1 empty status');
+
+    count(1); flushSync();
+    assert.equal(layout(), 'h1 table status', 'the region must stay between h1 and status');
+
+    count(0); flushSync();
+    assert.equal(layout(), 'h1 empty status');
+  });
+
+  it('keeps toggling indefinitely, not just once', () => {
+    const count = boot(0, 0);
+    for (let i = 0; i < 4; i++) {
+      count(1); flushSync();
+      assert.equal(layout(), 'h1 table status', `cycle ${i}: failed to show content`);
+      count(0); flushSync();
+      assert.equal(layout(), 'h1 empty status', `cycle ${i}: failed to return to fallback`);
+    }
+  });
+
+  it('toggles in place when the client starts on the other arm', () => {
+    // The realistic case: the server cannot see localStorage, so it renders the
+    // empty cart and the client immediately knows better.
+    const count = boot(0, 1);
+    assert.equal(layout(), 'h1 table status', 'hydration must adopt the client arm, in position');
+
+    count(0); flushSync();
+    assert.equal(layout(), 'h1 empty status');
+
+    count(1); flushSync();
+    assert.equal(layout(), 'h1 table status');
+  });
+
+  it('bounds the region with markers so following siblings are untouched', () => {
+    const count = boot(0, 0);
+    const status = document.querySelector('[data-status]');
+    count(1); flushSync();
+    count(0); flushSync();
+    assert.equal(document.querySelector('[data-status]'), status,
+      'the sibling after the region must never be recreated or moved');
+  });
+});
+
+describe('nested reactive regions nest, rather than interleave', () => {
+  // Hydration claims the inner content first, so the inner region's markers went
+  // in first; anchoring the outer markers to the CONTENT node then put the outer
+  // start marker INSIDE the inner pair. The regions interleaved, and switching
+  // the outer arm removed the visible content but neither the inner markers nor
+  // the inner effect. The orphaned effect kept rendering into a region that was
+  // switched off, and its output came back doubled when the outer arm returned.
+  //
+  // <Show> wrapping <Show> or <For> is the canonical shape, not an exotic one.
+  //
+  // The assertion is PARITY with a client-only render of the same tree, which is
+  // the standard hydration has to meet and the only one that stays honest if the
+  // control-flow semantics themselves ever change.
+  const Nested = (outer, inner) => () => h('div', { id: 'root' },
+    h(Show, { when: outer },
+      h(Show, { when: inner, fallback: h('em', {}, 'NO') }, h('p', {}, 'YES'))),
+    h('hr', {}),
+  );
+
+  function toggleSequence(outer, inner) {
+    const text = () => document.querySelector('#root').textContent.trim();
+    const seen = [text()];
+    for (const [sig, value] of [[outer, false], [inner, false], [outer, true], [inner, true]]) {
+      sig(value);
+      flushSync();
+      seen.push(text());
+    }
+    return seen;
+  }
+
+  it('behaves exactly like a client-only render of the same tree', () => {
+    const serverOuter = signal(true);
+    const serverInner = signal(true);
+    document.body.innerHTML = renderToString(h(Nested(serverOuter, serverInner), {}));
+
+    const hydratedOuter = signal(true);
+    const hydratedInner = signal(true);
+    hydrate(h(Nested(hydratedOuter, hydratedInner), {}), document.body);
+    flushSync();
+    const hydrated = toggleSequence(hydratedOuter, hydratedInner);
+
+    document.body.innerHTML = '<div id="host"></div>';
+    const clientOuter = signal(true);
+    const clientInner = signal(true);
+    mount(h(Nested(clientOuter, clientInner), {}), '#host');
+    flushSync();
+    const clientOnly = toggleSequence(clientOuter, clientInner);
+
+    assert.deepEqual(hydrated, clientOnly,
+      'a hydrated tree must behave identically to the same tree rendered on the client');
+  });
+
+  it('does not leave the inner region rendering while the outer arm is off', () => {
+    // The specific symptom: with the outer arm off, flipping the INNER signal
+    // used to paint the inner fallback into a region nobody is showing.
+    const serverOuter = signal(true);
+    const serverInner = signal(true);
+    document.body.innerHTML = renderToString(h(Nested(serverOuter, serverInner), {}));
+
+    const outer = signal(true);
+    const inner = signal(true);
+    hydrate(h(Nested(outer, inner), {}), document.body);
+    flushSync();
+
+    outer(false);
+    flushSync();
+    assert.equal(document.querySelector('#root').textContent.trim(), '');
+
+    inner(false);
+    flushSync();
+    assert.equal(document.querySelector('#root').textContent.trim(), '',
+      'the inner region must not render while the outer arm is off');
+  });
+});
+
+describe('a region that renders nothing still knows where it lives', () => {
+  // `{() => flag() && <Box/>}` with the flag false on the server produces NO
+  // node, so there is nothing to place markers around. Appending them put the
+  // region after every remaining sibling, and the content appeared at the bottom
+  // of its parent the moment the flag flipped: permanently, and with no warning.
+  // This is the same class as the <Show> bug above but the branch that <Show>
+  // never reaches, because a <Show> with a fallback always produces a node.
+  function Falsy(flag) {
+    return () => h('main', {},
+      h('h1', {}, 'Title'),
+      () => (flag() ? h('div', { 'data-box': '' }, 'Box') : null),
+      h('p', { 'data-after': '' }, 'after'),
+    );
+  }
+
+  function order() {
+    return [...document.querySelector('main').children]
+      .map((el) => (el.dataset.box !== undefined ? 'box' : el.tagName.toLowerCase()))
+      .join(' ');
+  }
+
+  it('inserts falsy-region content in position, not at the end of the parent', () => {
+    const server = signal(false);
+    document.body.innerHTML = renderToString(h(Falsy(server), {}));
+    assert.equal(order(), 'h1 p', 'the server renders nothing for the region');
+
+    const client = signal(false);
+    hydrate(h(Falsy(client), {}), document.body);
+    flushSync();
+
+    client(true); flushSync();
+    assert.equal(order(), 'h1 box p', 'the box belongs between the heading and the paragraph');
+
+    client(false); flushSync();
+    assert.equal(order(), 'h1 p');
+
+    client(true); flushSync();
+    assert.equal(order(), 'h1 box p', 'and stays there on every later toggle');
+  });
+
+  it('keeps the following sibling identical across the toggle', () => {
+    const server = signal(false);
+    document.body.innerHTML = renderToString(h(Falsy(server), {}));
+    const after = document.querySelector('[data-after]');
+
+    const client = signal(false);
+    hydrate(h(Falsy(client), {}), document.body);
+    flushSync();
+    client(true); flushSync();
+
+    assert.equal(document.querySelector('[data-after]'), after,
+      'the sibling after the region must never be recreated');
+  });
+});
+
+describe('empty reactive text is not a hydration mismatch', () => {
+  it('does not warn when a reactive child renders an empty string', () => {
+    // HTML cannot serialize an empty text node, so the server emitting nothing
+    // is the only possible correct output. Warning here fired on the most
+    // ordinary conditional there is and taught developers to tune the warnings
+    // out.
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      const message = signal('');
+      const Page = (msg) => () => h('div', {},
+        h('span', { 'data-msg': '' }, () => msg()),
+        h('b', { 'data-after': '' }, 'AFTER'),
+      );
+
+      document.body.innerHTML = renderToString(h(Page(message), {}));
+      const clientMessage = signal('');
+      hydrate(h(Page(clientMessage), {}), document.body);
+      flushSync();
+
+      assert.deepEqual(warnings.filter((w) => /Hydration mismatch/.test(w)), []);
+
+      // And it must still become reactive.
+      clientMessage('now something');
+      flushSync();
+      assert.equal(document.querySelector('[data-msg]').textContent, 'now something');
+      assert.equal(document.querySelector('[data-after]').textContent, 'AFTER');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('does not consume a sibling when the empty text has one after it', () => {
+    // The destructive shape. An empty string used to claim the next node, find
+    // an ELEMENT where it wanted text, and replaceChild it away: the server's
+    // real markup was destroyed, every following sibling shifted, and a
+    // warn-and-recreate cascaded through the rest of the parent. Any DOM state
+    // on those nodes (a typed-into input, an open details, a scroll position)
+    // went with it.
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      const App = (msg) => () => h('main', {},
+        h('b', { 'data-before': '' }, 'BEFORE'),
+        () => msg(),
+        h('p', { 'data-after': '' }, 'AFTER'),
+      );
+
+      const server = signal('');
+      document.body.innerHTML = renderToString(h(App(server), {}));
+      const before = document.querySelector('[data-before]');
+      const after = document.querySelector('[data-after]');
+
+      const client = signal('');
+      hydrate(h(App(client), {}), document.body);
+      flushSync();
+
+      assert.equal(document.querySelector('[data-before]'), before, 'the preceding sibling survives');
+      assert.equal(document.querySelector('[data-after]'), after, 'the following sibling survives');
+      assert.deepEqual(warnings.filter((w) => /Hydration mismatch/.test(w)), []);
+
+      client('now something');
+      flushSync();
+      assert.equal(document.querySelector('[data-after]'), after,
+        'and still survives once the region fills in');
+      assert.match(document.querySelector('main').textContent, /BEFOREnow somethingAFTER/);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('clears text the server rendered when the client value is empty', () => {
+    // The other half of the same decision, and the one the first version of the
+    // fix broke. Refusing to claim ANYTHING for an empty value left the server's
+    // text on screen with the region's own empty node sitting beside it. The
+    // stale value never went away, and the next value rendered ALONGSIDE it
+    // rather than replacing it: "9 items3 items".
+    //
+    // This is the ordinary case, not an edge: a count restored from
+    // localStorage, a signed-out user where the server assumed signed-in, any
+    // value the server guesses and the client corrects to nothing.
+    const App = (msg) => () => h('main', {},
+      h('b', { 'data-before': '' }, 'BEFORE'),
+      () => msg(),
+      h('p', { 'data-after': '' }, 'AFTER'),
+    );
+
+    const server = signal('9 items');
+    document.body.innerHTML = renderToString(h(App(server), {}));
+    assert.match(document.querySelector('main').textContent, /9 items/, 'the server rendered a value');
+    const after = document.querySelector('[data-after]');
+
+    const client = signal('');
+    hydrate(h(App(client), {}), document.body);
+    flushSync();
+
+    assert.equal(document.querySelector('main').textContent, 'BEFOREAFTER',
+      "the server's text must be cleared, not left on screen");
+    assert.equal(document.querySelector('[data-after]'), after, 'without disturbing the sibling');
+
+    client('3 items');
+    flushSync();
+    assert.equal(document.querySelector('main').textContent, 'BEFORE3 itemsAFTER',
+      'and the next value replaces it rather than joining it');
+  });
+});
+
+describe('a region owns content it had to create itself', () => {
+  // When the server rendered nothing for a region and the client renders
+  // something, the content is created rather than claimed. It used to be
+  // APPENDED to the end of the parent while the cursor stayed put, so the end
+  // marker was then inserted BEFORE it. The region owned nothing between its
+  // markers and could never take the content back: switching the condition off
+  // left it on screen permanently, with no warning and no way to recover.
+  //
+  // The falsy-region tests above cannot reach this: they have a trailing sibling
+  // for the content to displace, so the create path lands inside the markers by
+  // accident. The bug needs the region to be the LAST thing in its parent.
+  function Trailing(flag) {
+    return () => h('main', {},
+      h('h1', {}, 'Title'),
+      () => (flag() ? h('div', { 'data-box': '' }, 'Box') : null),
+    );
+  }
+
+  it('can remove content it created during hydration', () => {
+    const server = signal(false);
+    document.body.innerHTML = renderToString(h(Trailing(server), {}));
+    assert.equal(document.querySelector('[data-box]'), null, 'the server renders nothing');
+
+    const client = signal(true);
+    hydrate(h(Trailing(client), {}), document.body);
+    flushSync();
+    assert.ok(document.querySelector('[data-box]'), 'the client fills the region in');
+
+    client(false);
+    flushSync();
+    assert.equal(document.querySelector('[data-box]'), null,
+      'and must be able to take it back out again');
+
+    client(true);
+    flushSync();
+    assert.ok(document.querySelector('[data-box]'), 'and put it back');
+    assert.equal(document.querySelectorAll('[data-box]').length, 1, 'exactly once');
+  });
+});
+
+describe('a component whose root is a reactive region survives its first update', () => {
+  // Hydration has no comment markers for a COMPONENT, so its context is anchored
+  // to a DOM node in order to be reachable for disposal. Anchoring to the node
+  // the component produced is only safe when that node is stable, and the root
+  // of a <Show>-style component is precisely the node its own region replaces.
+  //
+  // The first toggle therefore disposed the component that owns the toggle:
+  // every effect, cleanup and onCleanup it registered died while it was still
+  // mounted. A hydrated component that polls, subscribes, or holds a query went
+  // silent the first time its own root re-rendered.
+  it('does not dispose its own context when the region updates', () => {
+    let cleanups = 0;
+    const Panel = ({ flag }) => {
+      onCleanup(() => { cleanups++; });
+      return () => (flag() ? h('div', { 'data-on': '' }, 'ON') : h('div', { 'data-off': '' }, 'OFF'));
+    };
+
+    const serverFlag = signal(true);
+    document.body.innerHTML = renderToString(h('section', {}, h(Panel, { flag: serverFlag })));
+
+    const flag = signal(true);
+    hydrate(h('section', {}, h(Panel, { flag })), document.body);
+    flushSync();
+    assert.equal(cleanups, 0, 'nothing is disposed at hydration');
+
+    flag(false);
+    flushSync();
+    assert.ok(document.querySelector('[data-off]'), 'the region updates');
+    assert.equal(cleanups, 0,
+      'the component must not dispose itself when its own root region updates');
+
+    flag(true);
+    flushSync();
+    assert.ok(document.querySelector('[data-on]'), 'and keeps updating');
+    assert.equal(cleanups, 0);
+  });
+});

--- a/packages/core/test/hydration-server-leftovers.test.js
+++ b/packages/core/test/hydration-server-leftovers.test.js
@@ -1,0 +1,190 @@
+// Hydration must not leave server markup on screen that the client never
+// claimed, and must not destroy markup the client claims later.
+//
+// These are the two halves of one decision, and getting either one alone wrong
+// is how the release before this one shipped:
+//
+//   - An empty reactive region deliberately claims NOTHING, because claiming
+//     took the following sibling and replaced it (destroying a typed-into
+//     input, an open <details>, a scroll position, and cascading a
+//     warn-and-recreate through every node after it). That is right, and it
+//     leaves whatever the server rendered for that region stranded: no effect
+//     owns it, no update can reach it, it just stays visible. A cart badge the
+//     server drew for a signed-in visitor stayed on screen for a signed-out
+//     one, underneath the region meant to replace it.
+//
+//   - So the finished walk removes what it did not claim. Which is wrong for a
+//     subtree the walk does not own: an island renders a bare host element and
+//     fills it in later, from the server HTML still sitting inside it, and a
+//     `mode: 'static'` island never hydrates at all.
+//
+// The rule that satisfies both: never destroy during the walk, remove after it,
+// and only inside an element whose client tree actually declares children.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+global.SVGElement = dom.window.SVGElement;
+
+const { signal, flushSync } = await import('../src/reactive.js');
+const { h } = await import('../src/h.js');
+const { hydrate } = await import('../src/render.js');
+const { renderToString } = await import('what-server');
+
+const root = () => document.getElementById('root');
+
+/** SSR with `serverValue`, hydrate with `clientValue`, both into #root. */
+function boot(Factory, serverValue, clientValue) {
+  root().innerHTML = renderToString(h(Factory(signal(serverValue)), {}));
+  const client = signal(clientValue);
+  hydrate(h(Factory(client), {}), root());
+  flushSync();
+  return client;
+}
+
+describe('server content the client did not claim is removed', () => {
+  // The region is empty on the client and was NOT empty on the server. This is
+  // the ordinary shape for anything the server has to guess: a signed-in
+  // header, a cart count from localStorage, a locale-dependent banner.
+  const Banner = (msg) => () => h('div', {},
+    h('h1', {}, 'Shop'),
+    () => (msg() ? h('p', { 'data-banner': '' }, msg()) : ''),
+  );
+
+  it('does not leave a stranded element behind an empty region', () => {
+    const msg = boot(Banner, 'Welcome back, Ines', '');
+
+    assert.equal(document.querySelector('[data-banner]'), null,
+      "the server's banner must not survive a client that renders none");
+    assert.equal(root().textContent, 'Shop');
+
+    // And the region still works afterwards.
+    msg('Now something');
+    flushSync();
+    assert.equal(document.querySelectorAll('[data-banner]').length, 1);
+    assert.equal(document.querySelector('[data-banner]').textContent, 'Now something');
+  });
+
+  it('removes stranded content at the root element too', () => {
+    // A root-level boot gate is the canonical shape, and the root is where a
+    // stranded subtree is most visible. The gate has to be a reactive CHILD,
+    // not the component body: components run once, so a conditional written as
+    // the body itself evaluates a single time and is never reactive at all.
+    const Gate = (ready) => () => [
+      () => (ready() ? h('main', { 'data-app': '' }, 'App') : ''),
+    ];
+
+    root().innerHTML = renderToString(h(Gate(signal(true)), {}));
+    assert.ok(document.querySelector('[data-app]'), 'the server rendered the app');
+
+    const ready = signal(false);
+    hydrate(h(Gate(ready), {}), root());
+    flushSync();
+
+    assert.equal(document.querySelector('[data-app]'), null,
+      'a client that is not ready must not show the server\'s app shell');
+
+    ready(true);
+    flushSync();
+    assert.equal(document.querySelectorAll('[data-app]').length, 1,
+      'and exactly one appears when it becomes ready');
+  });
+
+  it('leaves <body> alone, because the app does not own all of it', () => {
+    // Scripts, the hydration payload and anything the host page put there are
+    // never claimed by the walk and must never be removed by it.
+    document.body.innerHTML = '<div id="host"></div><script id="payload"></script>';
+    const host = document.getElementById('host');
+    host.innerHTML = renderToString(h('span', {}, 'x'));
+
+    hydrate(h('span', {}, 'x'), document.body);
+    flushSync();
+
+    assert.ok(document.getElementById('payload'), 'the script tag must survive');
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+});
+
+describe('content the walk does not own is never removed', () => {
+  it('keeps server HTML inside an element the client leaves empty', () => {
+    // The island shape, reduced: the client declares a host element with no
+    // children and fills it in later. Trimming on an empty child list threw the
+    // server's content away and the island rebuilt it from scratch, which is
+    // the opposite of what an island is for.
+    root().innerHTML = '<div data-island=""><button>count 7</button></div>';
+    const serverButton = root().querySelector('button');
+
+    hydrate(h('div', { 'data-island': '' }), root());
+    flushSync();
+
+    assert.equal(root().querySelector('button'), serverButton,
+      'a host element with no client children keeps what the server put in it');
+  });
+
+  it('keeps a dangerouslySetInnerHTML payload', () => {
+    // The cursor never walks that subtree, so nothing in it is ever claimed.
+    const html = '<p id="raw">from the server</p>';
+    root().innerHTML = `<div>${html}</div>`;
+
+    hydrate(h('div', { dangerouslySetInnerHTML: { __html: html } }), root());
+    flushSync();
+
+    assert.ok(document.getElementById('raw'), 'the raw payload survives hydration');
+  });
+});
+
+describe('inline SVG survives hydration', () => {
+  // nodeName is uppercased for HTML elements but case-preserved for everything
+  // else, so an <svg>'s nodeName is 'svg' and could never equal
+  // tag.toUpperCase(). Every inline SVG on a server-rendered page therefore
+  // failed to match, warned "expected <svg>, got svg", and was rebuilt with
+  // document.createElement in the HTML namespace, which does not render as SVG
+  // at all. Icons, logos and charts went blank on hydration.
+  const Icon = () => h('div', {},
+    h('svg', { viewBox: '0 0 16 16', width: 16, 'data-icon': '' },
+      h('path', { d: 'M0 0h16v16H0z' })),
+  );
+
+  it('reuses the server-rendered svg rather than rebuilding it', () => {
+    globalThis.__WHAT_DEV__ = true;
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      root().innerHTML = renderToString(h(Icon, {}));
+      const serverSvg = root().querySelector('[data-icon]');
+      const serverPath = root().querySelector('path');
+
+      hydrate(h(Icon, {}), root());
+      flushSync();
+
+      assert.equal(root().querySelector('[data-icon]'), serverSvg, 'the svg element is reused');
+      assert.equal(root().querySelector('path'), serverPath, 'and so is its subtree');
+      assert.deepEqual(warnings.filter((w) => /Hydration mismatch/.test(w)), []);
+    } finally {
+      console.warn = originalWarn;
+      delete globalThis.__WHAT_DEV__;
+    }
+  });
+
+  it('keeps the svg namespace when it does have to rebuild', () => {
+    // An element created with document.createElement lands in the XHTML
+    // namespace and renders as nothing, so the fallback path has to go through
+    // the same namespace-aware creation the client render uses.
+    root().innerHTML = '<div><span>wrong</span></div>';
+
+    hydrate(h(Icon, {}), root());
+    flushSync();
+
+    const svg = root().querySelector('[data-icon]');
+    assert.ok(svg, 'the svg is rendered');
+    assert.equal(svg.namespaceURI, 'http://www.w3.org/2000/svg');
+    assert.equal(root().querySelector('path').namespaceURI, 'http://www.w3.org/2000/svg');
+  });
+});

--- a/packages/core/test/query-invalidation-lifecycle.test.js
+++ b/packages/core/test/query-invalidation-lifecycle.test.js
@@ -1,0 +1,219 @@
+// A query must still answer invalidateQueries() after it has refetched once.
+//
+// useQuery/useSWR subscribed to their key ONCE, outside the effect that does the
+// fetching, while that effect's cleanup unsubscribed. The effect re-runs
+// whenever the query function reads a signal that changed (a search term, a
+// filter, a page number: the entire reason a query key has a reactive part). So
+// the first reactive refetch ran the cleanup, dropped the subscription, and
+// never restored it. From that moment invalidateQueries() found no subscriber
+// for the key and did nothing at all, silently.
+//
+// The shape that hides this: the FIRST invalidation, before any refetch, works
+// fine. So a test that mounts a query and immediately invalidates it passes, and
+// only a query that has actually been used goes deaf. This was found by driving
+// a real search box in a browser, not by a unit test.
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+
+const { signal, flushSync } = await import('../src/reactive.js');
+const { useQuery, useSWR, invalidateQueries, clearCache } = await import('../src/data.js');
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('useQuery stays subscribed to invalidation across refetches', () => {
+  beforeEach(() => clearCache());
+
+  it('refetches on invalidateQueries after a reactive refetch', async () => {
+    const term = signal('');
+    let fetches = 0;
+
+    useQuery({
+      queryKey: ['products', 'search'],
+      queryFn: async () => {
+        fetches++;
+        return `results for "${term()}"`;   // reading the signal re-runs the effect
+      },
+      staleTime: 0,
+    });
+
+    await tick();
+    assert.equal(fetches, 1, 'initial fetch');
+
+    // A reactive refetch. This is the step that used to cancel the subscription.
+    term('mug');
+    flushSync();
+    await tick();
+    assert.equal(fetches, 2, 'the query refetches when its fetcher reads a changed signal');
+
+    invalidateQueries(['products']);
+    await tick();
+    assert.equal(fetches, 3, 'invalidateQueries must still reach a query that has refetched');
+  });
+
+  it('keeps answering invalidation repeatedly', async () => {
+    const term = signal('a');
+    let fetches = 0;
+
+    useQuery({
+      queryKey: ['orders'],
+      queryFn: async () => { fetches++; return term(); },
+      staleTime: 0,
+    });
+
+    await tick();
+    for (let i = 0; i < 3; i++) {
+      term(`term-${i}`);
+      flushSync();
+      await tick();
+      const beforeInvalidate = fetches;
+      invalidateQueries(['orders']);
+      await tick();
+      assert.equal(fetches, beforeInvalidate + 1, `round ${i}: invalidation must refetch`);
+    }
+  });
+});
+
+describe('invalidation is not answered from the freshness window', () => {
+  beforeEach(() => clearCache());
+
+  it('refetches a query with a staleTime, which its own dedupe would have skipped', async () => {
+    // invalidateQueries means "this data is wrong now". Answering it from the
+    // staleTime window is the one case where deduping is exactly wrong, and it
+    // made invalidation a silent no-op for every query configured with one.
+    let fetches = 0;
+    useQuery({
+      queryKey: ['reports'],
+      queryFn: async () => { fetches++; return 'report'; },
+      staleTime: 60_000,
+    });
+
+    await tick();
+    assert.equal(fetches, 1);
+
+    invalidateQueries(['reports']);
+    await tick();
+    assert.equal(fetches, 2, 'a staleTime must not swallow an explicit invalidation');
+  });
+
+  it('refetches a useSWR inside its default deduping interval', async () => {
+    // useSWR dedupes for 2s by default, so an invalidation issued right after a
+    // fetch (the normal case: mutate, then invalidate) did nothing at all.
+    let fetches = 0;
+    useSWR('dashboard', async () => { fetches++; return 'data'; }, { revalidateOnFocus: false });
+
+    await tick();
+    assert.equal(fetches, 1);
+
+    invalidateQueries('dashboard');
+    await tick();
+    assert.equal(fetches, 2, 'the default dedupe window must not swallow an invalidation');
+  });
+
+  it('collapses one invalidation across many subscribers into one request', async () => {
+    // Forcing past the freshness window must not also force past request
+    // COALESCING: they share a name and a map but are different mechanisms.
+    // Every component reading a key subscribes separately, so one
+    // invalidateQueries() call arrives at N subscribers. Bypassing the in-flight
+    // map opened N concurrent fetches of the same key whose responses then raced
+    // to write the cache, and the loser could land last.
+    let fetches = 0;
+    let release;
+    const gate = new Promise((resolve) => { release = resolve; });
+    const fetcher = async () => { fetches++; await gate; return 'data'; };
+
+    for (let i = 0; i < 4; i++) {
+      useSWR('widgets', fetcher, { revalidateOnFocus: false });
+    }
+    release();
+    await tick();
+    assert.equal(fetches, 1, 'four consumers of one key share one initial request');
+
+    invalidateQueries('widgets');
+    await tick();
+    assert.equal(fetches, 2,
+      'one invalidation across four subscribers must issue ONE refetch, not four');
+  });
+
+  it('is not answered by a request that was already in flight', async () => {
+    // The ordering guarantee. A request that started BEFORE the mutation may
+    // have read pre-mutation data, so it cannot answer an invalidation issued
+    // after it, no matter how recently it started.
+    //
+    // Sequencing this on Date.now() was not enough: it has 1ms resolution, so a
+    // refetch and an unrelated invalidation microseconds apart share a
+    // timestamp and the invalidation joined the stale request. It showed up as
+    // a 1-in-6 flake before it showed up as a bug.
+    let fetches = 0;
+    let release;
+    const gate = new Promise((resolve) => { release = resolve; });
+    let firstResponseSent = false;
+
+    useSWR('inventory', async () => {
+      fetches++;
+      if (fetches === 1) { await gate; firstResponseSent = true; return 'before-mutation'; }
+      return 'after-mutation';
+    }, { revalidateOnFocus: false });
+
+    await tick();
+    assert.equal(fetches, 1, 'the first request is in flight');
+    assert.equal(firstResponseSent, false, 'and has not answered yet');
+
+    // Mutation happens here, then invalidation, while request 1 is still open.
+    invalidateQueries('inventory');
+    await tick();
+    assert.equal(fetches, 2, 'the invalidation must issue its own request');
+
+    release();
+    await tick();
+  });
+
+  it('ordinary reactive refetches still dedupe', async () => {
+    // The force flag must be scoped to invalidation. If it leaked into the
+    // normal path, every keystroke in a search box would bypass deduping.
+    let fetches = 0;
+    const term = signal('a');
+    useSWR('search', async () => { fetches++; return term(); }, { revalidateOnFocus: false });
+
+    await tick();
+    assert.equal(fetches, 1);
+
+    // Same key, immediately again, within the dedupe window: still deduped.
+    useSWR('search', async () => { fetches++; return term(); }, { revalidateOnFocus: false });
+    await tick();
+    assert.equal(fetches, 1, 'a second consumer inside the dedupe window must not refetch');
+  });
+});
+
+describe('useSWR stays subscribed to invalidation across refetches', () => {
+  beforeEach(() => clearCache());
+
+  it('refetches on invalidateQueries after a reactive refetch', async () => {
+    const page = signal(1);
+    let fetches = 0;
+
+    useSWR('feed', async () => {
+      fetches++;
+      return `page ${page()}`;
+    }, { dedupingInterval: 0, revalidateOnFocus: false });
+
+    await tick();
+    assert.equal(fetches, 1);
+
+    page(2);
+    flushSync();
+    await tick();
+    assert.equal(fetches, 2, 'useSWR refetches when its fetcher reads a changed signal');
+
+    invalidateQueries('feed');
+    await tick();
+    assert.equal(fetches, 3, 'invalidateQueries must still reach a useSWR that has refetched');
+  });
+});

--- a/packages/core/test/region-owner-chain.test.js
+++ b/packages/core/test/region-owner-chain.test.js
@@ -1,0 +1,132 @@
+// A reactive region must keep its owning component for every re-run, not just
+// the first.
+//
+// The effect behind `{() => ...}` re-runs long after the synchronous render
+// that created it, when the component stack has unwound. Anything it builds on
+// a re-run therefore got `parentCtx = null`, severing the chain that two
+// separate lookups walk:
+//
+//   - useContext walks parent contexts, so it fell through to the context
+//     DEFAULT for anything rendered after a state change.
+//   - the ErrorBoundary / Suspense lookup walks the same chain, so a throw from
+//     a component created by an inner region escaped the boundary wrapping it.
+//
+// Both are invisible on first paint and only appear once the app is
+// interactive, which is the hardest timing there is to notice: the page looks
+// right, and then a click makes context silently wrong.
+//
+// dom.js was given this fix. render.js's insert(), which is the path the
+// COMPILER emits for every reactive expression, was not, so it was broken for
+// exactly the users on the recommended build setup. This file pins both paths.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+global.SVGElement = dom.window.SVGElement;
+
+const { signal, flushSync } = await import('../src/reactive.js');
+const { h } = await import('../src/h.js');
+const { insert } = await import('../src/render.js');
+const { mount } = await import('../src/dom.js');
+const { ErrorBoundary } = await import('../src/components.js');
+const { createContext, useContext } = await import('../src/hooks.js');
+
+const root = () => document.getElementById('root');
+
+function reset() {
+  document.body.innerHTML = '<div id="root"></div>';
+}
+
+const Theme = createContext('DEFAULT');
+const Leaf = () => h('span', { 'data-value': '' }, useContext(Theme));
+
+/**
+ * Two ways to put a reactive region inside an element, which take two different
+ * code paths that have to agree:
+ *   - 'runtime'  : h('div', {}, () => ...)   -> createDOM  (dom.js)
+ *   - 'compiled' : insert(el, () => ...)     -> insert      (render.js)
+ * The compiler emits the second for every `{() => ...}` in JSX.
+ */
+const HOSTS = {
+  runtime: (child) => () => h('div', {}, child),
+  compiled: (child) => () => {
+    const el = document.createElement('div');
+    insert(el, child);
+    return el;
+  },
+};
+
+describe('context still resolves for components created after a state change', () => {
+  for (const [name, host] of Object.entries(HOSTS)) {
+    it(`on the ${name} path`, () => {
+      reset();
+      const show = signal(false);
+      const Page = host(() => (show() ? h(Leaf, {}) : h('em', {}, 'off')));
+
+      mount(h(Theme.Provider, { value: 'PROVIDED' }, h(Page, {})), '#root');
+      flushSync();
+      assert.equal(root().textContent, 'off');
+
+      show(true);
+      flushSync();
+      assert.equal(
+        root().querySelector('[data-value]').textContent,
+        'PROVIDED',
+        'a component built by a region re-run must still see its provider, not the default',
+      );
+    });
+  }
+
+  it('keeps resolving across repeated toggles', () => {
+    reset();
+    const show = signal(true);
+    const Page = HOSTS.compiled(() => (show() ? h(Leaf, {}) : h('em', {}, 'off')));
+    mount(h(Theme.Provider, { value: 'PROVIDED' }, h(Page, {})), '#root');
+    flushSync();
+
+    for (let i = 0; i < 3; i++) {
+      show(false); flushSync();
+      show(true); flushSync();
+      assert.equal(root().querySelector('[data-value]').textContent, 'PROVIDED', `cycle ${i}`);
+    }
+  });
+});
+
+describe('an ErrorBoundary still catches throws from an inner region', () => {
+  for (const [name, host] of Object.entries(HOSTS)) {
+    it(`on the ${name} path`, () => {
+      reset();
+      const boom = signal(false);
+      const Bad = () => { throw new Error('component exploded'); };
+      const Good = () => h('p', { 'data-good': '' }, 'fine');
+      const Page = host(() => (boom() ? h(Bad, {}) : h(Good, {})));
+
+      const originalError = console.error;
+      console.error = () => {};
+      try {
+        mount(
+          h(ErrorBoundary, { fallback: ({ error }) => h('p', { 'data-caught': '' }, error.message) },
+            h(Page, {})),
+          '#root',
+        );
+        flushSync();
+        assert.ok(root().querySelector('[data-good]'), 'renders normally first');
+
+        boom(true);
+        flushSync();
+      } finally {
+        console.error = originalError;
+      }
+
+      const caught = root().querySelector('[data-caught]');
+      assert.ok(caught, 'the boundary must catch a throw from a region re-run, not let it escape');
+      assert.equal(caught.textContent, 'component exploded');
+    });
+  }
+});

--- a/packages/create-what/package.json
+++ b/packages/create-what/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-what",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Scaffold a new What Framework project",
   "type": "module",
   "bin": {

--- a/packages/devtools-mcp/package.json
+++ b/packages/devtools-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-devtools-mcp",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "MCP server bridging AI agents to live What Framework app state via WebSocket",
   "type": "module",
   "bin": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-devtools",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Dev tools for What Framework — signal inspector, component tree, effect graph",
   "type": "module",
   "main": "src/index.js",
@@ -20,7 +20,7 @@
     "inspector"
   ],
   "peerDependencies": {
-    "what-core": "^0.12.2"
+    "what-core": "^0.12.3"
   },
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-what",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "ESLint rules for What Framework — catch signal bugs, enforce patterns",
   "type": "module",
   "main": "src/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-mcp",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "[DEPRECATED — use what-devtools-mcp instead] MCP Server for What Framework documentation and assistance",
   "type": "module",
   "main": "src/index.js",

--- a/packages/react-compat/package.json
+++ b/packages/react-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-react",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "React compatibility layer for What Framework — real React semantics (value hooks, re-renders, context) on a dedicated compat runtime",
   "type": "module",
   "sideEffects": false,
@@ -53,7 +53,7 @@
     "compatibility"
   ],
   "peerDependencies": {
-    "what-core": "^0.12.2"
+    "what-core": "^0.12.3"
   },
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-router",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "What Framework - File-based & programmatic router with View Transitions",
   "type": "module",
   "main": "src/index.js",
@@ -35,7 +35,7 @@
   "license": "MIT",
   "dependencies": {},
   "peerDependencies": {
-    "what-core": "^0.12.2"
+    "what-core": "^0.12.3"
   },
   "repository": {
     "type": "git",

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -184,7 +184,16 @@ export async function navigate(to, opts = {}) {
   // Use View Transitions API if available and enabled
   if (transition && typeof document !== 'undefined' && document.startViewTransition) {
     try {
-      await document.startViewTransition(doNavigation).finished;
+      const viewTransition = document.startViewTransition(doNavigation);
+      // `.ready` rejects when the transition is skipped, which two navigations
+      // in quick succession do routinely. Awaiting only `.finished` left that
+      // rejection unhandled, so it surfaced as an uncaught page error
+      // ("Transition was skipped") and landed in whatever error reporter the
+      // app had installed, for a navigation that actually succeeded.
+      if (viewTransition.ready && typeof viewTransition.ready.catch === 'function') {
+        viewTransition.ready.catch(() => {});
+      }
+      await viewTransition.finished;
     } catch (e) {
       // Transition failed, navigation still happened
     }
@@ -328,6 +337,23 @@ function loopScreen(message) {
 // instead would never catch a cycle between two route components, because each
 // hop matches successfully before its component throws the next redirect.
 function handleRedirect(target, options) {
+  // A navigation to this exact target is already in flight, so this is a
+  // re-match of the same hop, not a second one.
+  //
+  // It happens on every re-match that occurs before the URL commits. With the
+  // View Transitions API, navigate() defers the `_url` write into the
+  // transition callback while `_isNavigating` flips immediately, and
+  // renderMatch reads `_isNavigating`, so the match re-runs against the
+  // still-old URL, the same middleware returns the same target, and the hop was
+  // counted twice. One guarded deep link produced 25 false "Redirect cycle
+  // detected" errors and a flash of the redirect-loop screen, and the detector
+  // then cleared `_isNavigating` / `_pendingUrl` while the real navigation was
+  // still in flight, corrupting router state mid-navigation.
+  //
+  // Chromium-only, because without View Transitions doNavigation() runs
+  // synchronously and the URL and the flag change together.
+  if (_pendingUrl.peek() === target) return null;
+
   _redirectHistory.push(target);
 
   if (_redirectHistory.length > MAX_REDIRECTS) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-server",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "What Framework - SSR, islands architecture, static generation",
   "type": "module",
   "main": "src/index.js",
@@ -51,8 +51,8 @@
   "author": "ZVN DEV (https://zvndev.com)",
   "license": "MIT",
   "peerDependencies": {
-    "what-core": "^0.12.2",
-    "what-router": "^0.12.2"
+    "what-core": "^0.12.3",
+    "what-router": "^0.12.3"
   },
   "peerDependenciesMeta": {
     "what-router": {

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -5,6 +5,9 @@
 import {
   h,
   _isAriaAttr,
+  _beginComponentSSR,
+  _endComponentSSR,
+  _mapArrayToArray,
   getServerContext,
   runWithServerContext,
   beginHeadCollection,
@@ -71,6 +74,20 @@ function _renderHydratable(vnode) {
     return `<!--$-->${_renderHydratable(vnode())}<!--/$-->`;
   }
 
+  // Compiled keyed list: an inserter taking (parent, marker), not a thunk.
+  // Calling it with no arguments threw and SSR swallowed it, so every compiled
+  // keyed list server-rendered as an empty container. See _mapArrayToArray.
+  if (typeof vnode === 'function' && vnode._mapArray) {
+    try {
+      return `<!--$-->${_renderHydratable(_mapArrayToArray(vnode))}<!--/$-->`;
+    } catch (e) {
+      if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+        console.warn('[what-server] Error rendering keyed list in SSR:', e.message);
+      }
+      return '<!--$--><!--/$-->';
+    }
+  }
+
   // Reactive function child — wrap in dynamic content markers
   if (typeof vnode === 'function') {
     try {
@@ -91,8 +108,13 @@ function _renderHydratable(vnode) {
   // Component — add hydration key to root element
   if (typeof vnode.tag === 'function') {
     const hkId = nextHydrationId();
-    const result = vnode.tag({ ...vnode.props, children: vnode.children });
-    const html = _renderHydratable(result);
+    const ctx = _beginComponentSSR(vnode.tag);
+    let html;
+    try {
+      html = _renderHydratable(vnode.tag({ ...vnode.props, children: vnode.children }));
+    } finally {
+      _endComponentSSR(ctx);
+    }
     // Inject data-hk into the first element tag if present
     return injectHydrationKey(html, hkId);
   }
@@ -146,6 +168,18 @@ export function renderToString(vnode) {
     return renderToString(vnode());
   }
 
+  // Compiled keyed list: see _renderHydratable above.
+  if (typeof vnode === 'function' && vnode._mapArray) {
+    try {
+      return renderToString(_mapArrayToArray(vnode));
+    } catch (e) {
+      if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+        console.warn('[what-server] Error rendering keyed list in SSR:', e.message);
+      }
+      return '';
+    }
+  }
+
   // Reactive function child — call to get value
   if (typeof vnode === 'function') {
     try {
@@ -178,9 +212,18 @@ export function renderToString(vnode) {
   }
 
   // Component
+  //
+  // Run it under a component context. Calling it bare left the component stack
+  // empty, so every context-dependent hook threw and the render failed outright
+  // rather than degrading. The context has to stay on the stack while the
+  // result is rendered, because useContext resolves by walking parent contexts.
   if (typeof vnode.tag === 'function') {
-    const result = vnode.tag({ ...vnode.props, children: vnode.children });
-    return renderToString(result);
+    const ctx = _beginComponentSSR(vnode.tag);
+    try {
+      return renderToString(vnode.tag({ ...vnode.props, children: vnode.children }));
+    } finally {
+      _endComponentSSR(ctx);
+    }
   }
 
   // Element
@@ -315,6 +358,20 @@ export async function* renderToStream(vnode, ctx) {
     return;
   }
 
+  // Compiled keyed list: see _renderHydratable above.
+  if (typeof vnode === 'function' && vnode._mapArray) {
+    let rows = null;
+    try {
+      rows = runWithServerContext(ctx, () => _mapArrayToArray(vnode));
+    } catch (e) {
+      if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+        console.warn('[what-server] Error rendering keyed list in stream SSR:', e.message);
+      }
+    }
+    if (rows) yield* renderToStream(rows, ctx);
+    return;
+  }
+
   // Reactive function child — call to get value
   if (typeof vnode === 'function') {
     try {
@@ -361,6 +418,10 @@ export async function* renderToStream(vnode, ctx) {
   }
 
   if (typeof vnode.tag === 'function') {
+    // The frame stays open across the yields below: useContext resolves by
+    // walking parent contexts, so a Provider's context has to outlive the
+    // streaming of its own subtree.
+    const componentCtx = _beginComponentSSR(vnode.tag);
     try {
       const result = runWithServerContext(
         ctx,
@@ -376,6 +437,8 @@ export async function* renderToStream(vnode, ctx) {
       yield _isDevMode
         ? `<!-- SSR Error: ${escapeHtml(e.message || 'Component error')} -->`
         : `<!-- SSR Error -->`;
+    } finally {
+      _endComponentSSR(componentCtx);
     }
     return;
   }

--- a/packages/server/src/islands.js
+++ b/packages/server/src/islands.js
@@ -473,54 +473,180 @@ export function enhance(selector, handler) {
   }
 }
 
-// Form enhancement: submit via fetch instead of page reload
+/**
+ * Recover the double-submit CSRF token for a form.
+ *
+ * The meta tag alone is not enough. A cached page (mode 'static' or 'hybrid') is
+ * shared between visitors, so the adapter deliberately does NOT embed a
+ * per-visitor token in it; the token lives only in the cookie. A form inside
+ * such a page therefore has no meta tag to read, and blocking on that alone
+ * refused perfectly valid submissions. `<Form>` also emits the token as a hidden
+ * field, which is the same value, so all three sources are checked.
+ */
+function readFormCsrfToken(form) {
+  const meta = document.querySelector('meta[name="csrf-token"]')
+    || document.querySelector('meta[name="what-csrf-token"]');
+  if (meta) return meta.getAttribute('content');
+
+  const field = form.querySelector('input[name="what-csrf-token"], input[name="_csrf"]');
+  if (field && field.value) return field.value;
+
+  const cookie = document.cookie.match(/(?:^|;\s*)what-csrf=([^;]+)/);
+  return cookie ? decodeURIComponent(cookie[1]) : null;
+}
+
+/**
+ * Serialize a form the way the browser would, so an enhanced submit and a plain
+ * one are indistinguishable to the server.
+ *
+ * Two details that look pedantic and are not:
+ *   - newlines in every text entry normalize to CRLF. The urlencoded and
+ *     multipart serializers both do this per spec; URLSearchParams does not, so
+ *     a <textarea> round-tripped different bytes with JS on than with JS off.
+ *   - a File under a non-multipart encoding contributes only its NAME, which is
+ *     what a native submit sends. Sending "[object File]" would be worse than
+ *     useless, and silently sending nothing hides a real mistake.
+ */
+function formEntries(form, submitter, multipart) {
+  const data = new FormData(form);
+
+  // FormData(form) never includes the submit button, so a multi-button form
+  // could not tell the server which button was pressed. Native submits include
+  // the submitter's name/value.
+  if (submitter && submitter.name) {
+    data.append(submitter.name, submitter.value ?? '');
+  }
+
+  if (multipart) return data;
+
+  const params = new URLSearchParams();
+  let droppedFile = null;
+  for (const [key, value] of data) {
+    if (typeof value === 'string') {
+      params.append(key, value.replace(/\r\n|\r|\n/g, '\r\n'));
+    } else {
+      droppedFile = droppedFile || key;
+      params.append(key, value.name ?? '');
+    }
+  }
+
+  if (droppedFile && typeof console !== 'undefined') {
+    console.warn(
+      `[what] Form field "${droppedFile}" holds a file, but the form is not ` +
+      'enctype="multipart/form-data", so only the file NAME is sent. This is what ' +
+      'a plain HTML submit does too. Add enctype="multipart/form-data" to upload ' +
+      'the bytes.'
+    );
+  }
+  return params;
+}
+
+/**
+ * Form enhancement: submit via fetch instead of a full page load.
+ *
+ * The encoding is not a detail. `/__what_action` parses
+ * application/x-www-form-urlencoded or JSON, never multipart, so an enhanced
+ * submit of a default form has to use the same encoding as the plain HTML submit
+ * it replaces. Posting a FormData object unconditionally produced a multipart
+ * body the endpoint could not parse: the action id went missing and every
+ * enhanced `<Form>` failed with 400 while the no-JS path kept working.
+ *
+ * The encoding now follows the form's own `enctype`, exactly as the browser
+ * would, so a form that declares multipart still uploads its files.
+ *
+ * On success the action endpoint answers 303 to the form's `_redirect` target,
+ * which fetch follows. The page is then navigated there so the enhanced path
+ * lands where the unenhanced one would. Cancel the `form:response` event to keep
+ * the page put and handle the response yourself.
+ */
 export function enhanceForms(selector = 'form[data-enhance]') {
   enhance(selector, (form) => {
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-
-      const formData = new FormData(form);
-      const method = form.method.toUpperCase() || 'POST';
-      const action = form.action || location.href;
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
 
       try {
-        // Read CSRF token from meta tag
-        const csrfMeta = document.querySelector('meta[name="csrf-token"]') ||
-                         document.querySelector('meta[name="what-csrf-token"]');
-        const csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : null;
+        // getAttribute, never the properties. HTMLFormElement is
+        // [LegacyOverrideBuiltIns]: a field named "method" or "action" SHADOWS
+        // form.method / form.action with the input element itself. Reading
+        // `form.method.toUpperCase()` then threw a TypeError after
+        // preventDefault() had already run, so the submit produced no fetch, no
+        // form:error, and no native fallback. It just did nothing.
+        const submitter = event.submitter || null;
+        const attr = (name) => (submitter && submitter.getAttribute(`form${name}`))
+          || form.getAttribute(name);
 
-        // If no CSRF token and form hasn't opted out, block submission
-        const noCsrf = form.getAttribute('data-no-csrf') === 'true';
-        if (!csrfToken && !noCsrf) {
-          console.warn(
-            '[what] Form submission blocked: no CSRF token found. ' +
-            'Add a <meta name="what-csrf-token"> tag (csrfMetaTag() emits it) ' +
-            'or set data-no-csrf="true" on the form to opt out.'
-          );
-          form.dispatchEvent(new CustomEvent('form:error', {
-            bubbles: true,
-            detail: { error: new Error('Missing CSRF token') },
-          }));
-          return;
+        const method = (attr('method') || 'get').toUpperCase();
+        const action = new URL(attr('action') || location.href, location.href);
+        const enctype = (attr('enctype') || '').toLowerCase();
+        const multipart = enctype === 'multipart/form-data';
+
+        const entries = formEntries(form, submitter, multipart);
+
+        // CSRF is about protecting OUR endpoint. A form aimed at another origin
+        // must neither be blocked by our token policy nor be handed our token:
+        // attaching it would export the visitor's double-submit secret to a
+        // third party.
+        const sameOrigin = action.origin === location.origin;
+        const headers = { 'X-Requested-With': 'XMLHttpRequest' };
+
+        if (sameOrigin) {
+          const csrfToken = readFormCsrfToken(form);
+          const noCsrf = form.getAttribute('data-no-csrf') === 'true';
+          if (!csrfToken && !noCsrf) {
+            console.warn(
+              '[what] Form submission blocked: no CSRF token found. ' +
+              'Add a <meta name="what-csrf-token"> tag (csrfMetaTag() emits it) ' +
+              'or set data-no-csrf="true" on the form to opt out.'
+            );
+            form.dispatchEvent(new CustomEvent('form:error', {
+              bubbles: true,
+              detail: { error: new Error('Missing CSRF token') },
+            }));
+            return;
+          }
+          if (csrfToken) headers['X-CSRF-Token'] = csrfToken;
         }
 
-        const headers = {
-          'X-Requested-With': 'XMLHttpRequest',
-        };
-        if (csrfToken) {
-          headers['X-CSRF-Token'] = csrfToken;
+        let body;
+        if (method === 'GET') {
+          // A native GET submit REPLACES the query string with the form data.
+          // The previous code built the params and then threw them away, so an
+          // enhanced GET form fetched a bare URL with none of its fields.
+          action.search = String(entries);
+        } else if (multipart) {
+          // Hand FormData straight to fetch so the browser writes the boundary.
+          body = entries;
+        } else {
+          body = entries;
+          headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
         }
 
-        const response = await fetch(action, {
+        const response = await fetch(action.href, {
           method,
-          body: method === 'GET' ? undefined : formData,
+          body,
           headers,
+          credentials: 'same-origin',
         });
 
-        form.dispatchEvent(new CustomEvent('form:response', {
+        const responseEvent = new CustomEvent('form:response', {
           bubbles: true,
-          detail: { response, ok: response.ok },
-        }));
+          cancelable: true,
+          detail: { response, ok: response.ok, redirected: response.redirected },
+        });
+        const proceed = form.dispatchEvent(responseEvent);
+
+        // Same-origin only. A native submit would follow an off-site redirect,
+        // but a framework default that can navigate the page to another origin
+        // on a server's say-so is not a default worth having. Listen for
+        // form:response if you need that.
+        if (proceed && response.ok && response.redirected) {
+          let target = null;
+          try {
+            const url = new URL(response.url, location.href);
+            if (url.origin === location.origin) target = url.href;
+          } catch { /* unparseable: do not navigate */ }
+          if (target) location.assign(target);
+        }
       } catch (error) {
         form.dispatchEvent(new CustomEvent('form:error', {
           bubbles: true,

--- a/packages/server/test/enhance-forms.test.js
+++ b/packages/server/test/enhance-forms.test.js
@@ -1,0 +1,333 @@
+// enhanceForms() is the JS half of the <Form> contract: it replaces a plain HTML
+// submit with a fetch. "Indistinguishable from the plain submit" is the whole
+// test, and it is where this has gone wrong twice.
+//
+// First it posted a FormData object unconditionally. /__what_action parses
+// application/x-www-form-urlencoded or JSON and nothing else, so the body failed
+// to parse, the `_action` field vanished, and every enhanced form answered 400
+// while the no-JS path kept working: exactly the shape of failure that survives a
+// release.
+//
+// Then the fix for that overcorrected and sent urlencoded unconditionally, which
+// silently dropped file uploads from forms that correctly declared
+// enctype="multipart/form-data". Encoding now follows the form's own enctype, as
+// the browser does.
+//
+// These tests pin the WIRE FORMAT against the real parser, not the
+// implementation.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost/' });
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.Node = dom.window.Node;
+global.CustomEvent = dom.window.CustomEvent;
+global.FormData = dom.window.FormData;
+global.URLSearchParams = dom.window.URLSearchParams;
+global.URL = dom.window.URL;
+global.File = dom.window.File;
+
+// islands.js calls bare `location.assign` after a followed redirect. There is no
+// global location in Node, and jsdom's is non-configurable, so the module global
+// is the only stubbable surface.
+let assigned = null;
+global.location = {
+  assign: (url) => { assigned = url; },
+  href: 'http://localhost/',
+  origin: 'http://localhost',
+};
+
+const { enhanceForms } = await import('../src/islands.js');
+const { createActionHandler, parseActionBody } = await import('../src/action-handler.js');
+const { action } = await import('../src/actions.js');
+
+// action() only populates the server registry when there is no `window`, and this
+// file installs one for the DOM. Register as the server would.
+{
+  const savedWindow = global.window;
+  delete global.window;
+  action(async (form) => ({ got: form.title }), { id: 'enhanceTest' });
+  global.window = savedWindow;
+}
+
+/** Install a form and capture the single fetch enhanceForms performs. */
+function mountForm(html, { respond, cookie = 'what-csrf=cookie-token' } = {}) {
+  document.body.innerHTML = html;
+  document.cookie = cookie || 'what-csrf=; Max-Age=0';
+  assigned = null;
+
+  const calls = [];
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+
+  global.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return respond
+      ? respond({ url, init })
+      : { ok: true, status: 200, url: String(url), redirected: false };
+  };
+
+  enhanceForms();
+  const form = document.querySelector('form');
+
+  return {
+    form,
+    calls,
+    warnings,
+    restore: () => { console.warn = originalWarn; },
+    async submit(submitter) {
+      if (submitter) form.requestSubmit(submitter);
+      else form.dispatchEvent(new dom.window.Event('submit', { cancelable: true, bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      console.warn = originalWarn;
+    },
+  };
+}
+
+const FORM = `
+  <form method="post" action="/__what_action" data-action="enhanceTest" data-enhance>
+    <input type="hidden" name="_action" value="enhanceTest">
+    <input type="hidden" name="what-csrf-token" value="field-token">
+    <input type="hidden" name="_redirect" value="/done">
+    <input name="title" value="hello">
+    <button type="submit">Go</button>
+  </form>`;
+
+describe('enhanceForms posts what the action endpoint can parse', () => {
+  it('sends url-encoded for a default form, not multipart', async () => {
+    const h = mountForm(FORM);
+    await h.submit();
+
+    assert.equal(h.calls.length, 1);
+    const { init } = h.calls[0];
+    assert.match(init.headers['Content-Type'], /application\/x-www-form-urlencoded/);
+    assert.ok(init.body instanceof dom.window.URLSearchParams, 'body must be url-encoded');
+  });
+
+  it('produces a body the real handler dispatches', async () => {
+    const h = mountForm(FORM);
+    await h.submit();
+
+    // Feed the exact bytes to the real parser + handler. If the encoding drifts
+    // again this fails here rather than in a browser.
+    const body = parseActionBody(String(h.calls[0].init.body), 'application/x-www-form-urlencoded');
+    assert.equal(body._action, 'enhanceTest');
+
+    const handle = createActionHandler({ getCsrfToken: () => 'cookie-token' });
+    const out = await handle({
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', 'x-csrf-token': 'cookie-token' },
+      body,
+      query: {},
+    });
+    assert.equal(out.status, 303, out.body);
+    assert.equal(out.headers.location, '/done');
+  });
+
+  it('preserves reserved and user fields', async () => {
+    const h = mountForm(FORM);
+    await h.submit();
+
+    const body = parseActionBody(String(h.calls[0].init.body), 'application/x-www-form-urlencoded');
+    assert.equal(body.title, 'hello');
+    assert.equal(body['what-csrf-token'], 'field-token');
+    assert.equal(body._redirect, '/done');
+  });
+
+  it('normalizes newlines to CRLF the way the urlencoded serializer does', async () => {
+    // A textarea round-tripped different bytes with JS on than with JS off:
+    // native sends CRLF, URLSearchParams passes LF straight through.
+    const h = mountForm(`
+      <form method="post" action="/__what_action" data-enhance data-no-csrf="true">
+        <textarea name="body">line one\nline two</textarea>
+      </form>`);
+    await h.submit();
+    assert.match(String(h.calls[0].init.body), /line\+one%0D%0Aline\+two/);
+  });
+});
+
+describe('enhanceForms honors the form encoding', () => {
+  it('keeps multipart when the form declares it, so files still upload', async () => {
+    // The regression this pins: sending urlencoded unconditionally dropped the
+    // file bytes from a form that had correctly asked for multipart.
+    //
+    // jsdom cannot put a real file in a file input (it has no DataTransfer, and
+    // FormData reads the internal file list, not a monkey-patched `files`), so
+    // the byte-level assertion is not available here. What IS assertable is the
+    // contract that carries the bytes in a browser: the body must be a FormData
+    // handed straight to fetch, and we must NOT set Content-Type, because only
+    // the browser can write the multipart boundary. Setting it by hand produces
+    // a body no server can parse.
+    const h = mountForm(`
+      <form method="post" action="/upload" enctype="multipart/form-data" data-enhance data-no-csrf="true">
+        <input type="file" name="avatar">
+        <input name="title" value="hi">
+      </form>`);
+    await h.submit();
+
+    const { init } = h.calls[0];
+    assert.ok(init.body instanceof dom.window.FormData, 'a multipart form must send FormData');
+    assert.equal(init.headers['Content-Type'], undefined,
+      'the browser must set the multipart boundary itself');
+    assert.equal(init.body.get('title'), 'hi', 'ordinary fields still ride along');
+    assert.ok(init.body.has('avatar'), 'the file field is present in the body');
+  });
+
+  it('a file in a non-multipart form sends its name and says so', async () => {
+    // Native behavior: with the default encoding a file input contributes only
+    // its filename. Matching that is right, but doing it silently would hide a
+    // real mistake, so it warns.
+    const h = mountForm(`
+      <form method="post" action="/upload" data-enhance data-no-csrf="true">
+        <input type="file" name="avatar">
+        <input name="title" value="hi">
+      </form>`);
+    await h.submit();
+
+    const { init } = h.calls[0];
+    assert.ok(init.body instanceof dom.window.URLSearchParams);
+    assert.match(init.headers['Content-Type'], /application\/x-www-form-urlencoded/);
+  });
+
+  it('a GET form puts its fields in the query string', async () => {
+    // The fields were serialized and then thrown away: an enhanced GET form
+    // fetched a bare URL with none of its data.
+    const h = mountForm(`
+      <form method="get" action="/search" data-enhance data-no-csrf="true">
+        <input name="q" value="mug">
+        <input name="page" value="2">
+      </form>`);
+    await h.submit();
+
+    const { url, init } = h.calls[0];
+    assert.match(String(url), /\/search\?q=mug&page=2$/);
+    assert.equal(init.body, undefined, 'a GET request must have no body');
+    assert.equal(init.headers['Content-Type'], undefined);
+  });
+});
+
+describe('enhanceForms matches a native submit', () => {
+  it('sends the submitter button name and value', async () => {
+    // Without this a multi-button form cannot tell the server which button was
+    // pressed, because FormData(form) never includes submit buttons.
+    const h = mountForm(`
+      <form method="post" action="/__what_action" data-enhance data-no-csrf="true">
+        <input type="hidden" name="_action" value="enhanceTest">
+        <button type="submit" name="intent" value="publish">Publish</button>
+        <button type="submit" name="intent" value="delete">Delete</button>
+      </form>`);
+
+    await h.submit(document.querySelectorAll('button')[1]);
+
+    const body = parseActionBody(String(h.calls[0].init.body), 'application/x-www-form-urlencoded');
+    assert.equal(body.intent, 'delete');
+  });
+
+  it('a field named "method" or "action" does not kill the submit', async () => {
+    // HTMLFormElement is [LegacyOverrideBuiltIns]: these fields SHADOW
+    // form.method / form.action with the input element. Reading them threw a
+    // TypeError after preventDefault, so the form did nothing at all: no fetch,
+    // no error event, no native fallback.
+    const h = mountForm(`
+      <form method="post" action="/__what_action" data-enhance data-no-csrf="true">
+        <input type="hidden" name="_action" value="enhanceTest">
+        <input name="method" value="wire-transfer">
+        <input name="action" value="refund">
+      </form>`);
+    await h.submit();
+
+    assert.equal(h.calls.length, 1, 'the submit must still happen');
+    assert.equal(h.calls[0].init.method, 'POST');
+    assert.match(String(h.calls[0].url), /\/__what_action$/);
+    const body = parseActionBody(String(h.calls[0].init.body), 'application/x-www-form-urlencoded');
+    assert.equal(body.method, 'wire-transfer');
+  });
+});
+
+describe('enhanceForms CSRF handling', () => {
+  it('falls back to the form field when the page has no meta tag', async () => {
+    const h = mountForm(FORM);
+    await h.submit();
+    assert.equal(h.calls[0].init.headers['X-CSRF-Token'], 'field-token');
+  });
+
+  it('falls back to the cookie when there is neither meta nor field', async () => {
+    // The cached-page case: shared HTML carries no per-visitor token, so
+    // refusing to submit on a missing meta tag blocked valid posts.
+    const h = mountForm(`
+      <form method="post" action="/__what_action" data-enhance>
+        <input type="hidden" name="_action" value="enhanceTest">
+        <input name="title" value="hello">
+      </form>`);
+    await h.submit();
+    assert.equal(h.calls.length, 1, 'a cookie token must be enough to submit');
+    assert.equal(h.calls[0].init.headers['X-CSRF-Token'], 'cookie-token');
+  });
+
+  it('blocks and reports when no token exists anywhere', async () => {
+    const h = mountForm(`
+      <form method="post" action="/__what_action" data-enhance>
+        <input type="hidden" name="_action" value="enhanceTest">
+      </form>`, { cookie: null });
+
+    const errors = [];
+    h.form.addEventListener('form:error', (e) => errors.push(e.detail.error.message));
+    await h.submit();
+
+    assert.equal(h.calls.length, 0);
+    assert.deepEqual(errors, ['Missing CSRF token']);
+  });
+
+  it('never sends our CSRF token to another origin', async () => {
+    // The token is a double-submit secret. Attaching it to a third-party form
+    // action hands it to that third party.
+    const h = mountForm(`
+      <form method="post" action="https://evil.example/collect" data-enhance>
+        <input name="title" value="hello">
+      </form>`);
+    await h.submit();
+
+    assert.equal(h.calls.length, 1, 'a cross-origin form is not ours to block');
+    assert.equal(h.calls[0].init.headers['X-CSRF-Token'], undefined,
+      'the CSRF token must never leave this origin');
+  });
+});
+
+describe('enhanceForms redirect handling', () => {
+  const redirectTo = (url) => () => ({ ok: true, status: 200, url, redirected: true });
+
+  it('navigates to a followed same-origin redirect', async () => {
+    const h = mountForm(FORM, { respond: redirectTo('http://localhost/done') });
+    const seen = [];
+    h.form.addEventListener('form:response', (e) => seen.push(e.detail.redirected));
+
+    await h.submit();
+
+    assert.deepEqual(seen, [true]);
+    assert.equal(assigned, 'http://localhost/done');
+  });
+
+  it('refuses to navigate to another origin', async () => {
+    const h = mountForm(FORM, { respond: redirectTo('https://evil.example/landing') });
+    await h.submit();
+    assert.equal(assigned, null, 'a server response must not be able to move the page off-site');
+  });
+
+  it('a cancelled form:response suppresses navigation', async () => {
+    const h = mountForm(FORM, { respond: redirectTo('http://localhost/done') });
+    h.form.addEventListener('form:response', (e) => e.preventDefault());
+    await h.submit();
+    assert.equal(assigned, null);
+  });
+
+  it('stays put when the response was not a redirect', async () => {
+    const h = mountForm(FORM);
+    await h.submit();
+    assert.equal(assigned, null);
+  });
+});

--- a/packages/server/test/ssr-component-context.test.js
+++ b/packages/server/test/ssr-component-context.test.js
@@ -1,0 +1,185 @@
+// A component using hooks must be renderable on the server.
+//
+// renderToString called `vnode.tag(props)` directly, with nothing on the
+// component stack. Every hook that needs a context resolves it through
+// getCurrentComponent(), so all ten of them plus Context.Provider threw:
+//
+//   [what] useState() can only be called inside a component function.
+//
+// A single useState, useRef, onMount or <Ctx.Provider> anywhere in the tree
+// meant the page could not be server-rendered at all. Not a hydration warning,
+// not a degraded render: renderToString threw and SSR failed outright. The same
+// hole existed in all three server render paths (renderToString,
+// renderToHydratableString, renderToStream), each with its own bare call.
+//
+// Nothing in the unit suite caught it because SSR tests render plain element
+// trees and hook tests mount on the client. The two features are only broken
+// TOGETHER, which is the shape every bug in this class has had.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { h } from 'what-core';
+import {
+  useState,
+  useSignal,
+  useComputed,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+  useReducer,
+  onMount,
+  onCleanup,
+  createContext,
+  useContext,
+} from 'what-core';
+import { renderToString, renderToHydratableString, renderToStream } from '../src/index.js';
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('every context-dependent hook survives server rendering', () => {
+  // One case per hook that calls getCtx(). If a new one is added and it is not
+  // safe on the server, this table is where that shows up.
+  const cases = {
+    useState: () => { const [n] = useState(7); return h('p', {}, `n=${n()}`); },
+    useSignal: () => { const s = useSignal(7); return h('p', {}, `n=${s()}`); },
+    useComputed: () => { const c = useComputed(() => 7); return h('p', {}, `n=${c()}`); },
+    useEffect: () => { useEffect(() => {}, []); return h('p', {}, 'n=7'); },
+    // useMemo returns a computed accessor, not the value.
+    useMemo: () => { const m = useMemo(() => 7, []); return h('p', {}, `n=${m()}`); },
+    useCallback: () => { useCallback(() => {}, []); return h('p', {}, 'n=7'); },
+    useRef: () => { const r = useRef(null); return h('p', {}, `n=${r.current === null ? 7 : 0}`); },
+    useReducer: () => { const [n] = useReducer((s) => s, 7); return h('p', {}, `n=${n()}`); },
+    onMount: () => { onMount(() => {}); return h('p', {}, 'n=7'); },
+    onCleanup: () => { onCleanup(() => {}); return h('p', {}, 'n=7'); },
+  };
+
+  for (const [name, Component] of Object.entries(cases)) {
+    it(`renders a component using ${name}()`, () => {
+      assert.equal(renderToString(h(Component, {})), '<p>n=7</p>');
+    });
+  }
+});
+
+describe('the hooks are usable on every server render path', () => {
+  const Counter = () => {
+    const [n] = useState(41);
+    return h('p', {}, `n=${n() + 1}`);
+  };
+
+  it('renderToString', () => {
+    assert.equal(renderToString(h(Counter, {})), '<p>n=42</p>');
+  });
+
+  it('renderToHydratableString', () => {
+    // This path also injects data-hk keys, so assert on content rather than an
+    // exact string.
+    assert.match(renderToHydratableString(h(Counter, {})), /n=42/);
+  });
+
+  it('renderToStream', async () => {
+    let html = '';
+    for await (const chunk of renderToStream(h(Counter, {}), {})) html += chunk;
+    assert.match(html, /n=42/);
+  });
+});
+
+describe('context resolves through the tree on the server', () => {
+  // useContext walks _parentCtx, so the provider's context has to stay on the
+  // stack while its children render. Popping it as soon as the provider
+  // returned would leave every consumer reading the default value: a silent
+  // wrong render rather than a crash, which is worse.
+  const Theme = createContext('default');
+
+  const Consumer = () => h('span', {}, useContext(Theme));
+
+  it('a consumer sees its provider value, not the default', () => {
+    const html = renderToString(
+      h(Theme.Provider, { value: 'dark' }, h('div', {}, h(Consumer, {}))),
+    );
+    assert.equal(html, '<div><span>dark</span></div>');
+  });
+
+  it('the nearest provider wins', () => {
+    const html = renderToString(
+      h(Theme.Provider, { value: 'dark' },
+        h('div', {},
+          h(Consumer, {}),
+          h(Theme.Provider, { value: 'light' }, h(Consumer, {})))),
+    );
+    assert.equal(html, '<div><span>dark</span><span>light</span></div>');
+  });
+
+  it('falls back to the default outside any provider', () => {
+    assert.equal(renderToString(h(Consumer, {})), '<span>default</span>');
+  });
+
+  it('sibling subtrees do not leak context into each other', () => {
+    // If a frame were left on the stack after its subtree finished, the next
+    // sibling would inherit it.
+    const html = renderToString(
+      h('div', {},
+        h(Theme.Provider, { value: 'dark' }, h(Consumer, {})),
+        h(Consumer, {})),
+    );
+    assert.equal(html, '<div><span>dark</span><span>default</span></div>');
+  });
+
+  it('streams context correctly too', async () => {
+    let html = '';
+    const tree = h(Theme.Provider, { value: 'dark' }, h('div', {}, h(Consumer, {})));
+    for await (const chunk of renderToStream(tree, {})) html += chunk;
+    assert.match(html, /<span>dark<\/span>/);
+  });
+});
+
+describe('a server render leaves nothing running', () => {
+  it('does not run useEffect bodies', async () => {
+    // useEffect defers its body to a microtask that checks ctx.disposed. The
+    // server never mounts, so the context is marked disposed on the way out and
+    // the body must never fire. If it did, an SSR render would start intervals,
+    // open subscriptions and fetch on the server, once per render, with no
+    // unmount to ever clean them up.
+    let ran = 0;
+    const Component = () => {
+      useEffect(() => { ran++; }, []);
+      useEffect(() => { ran++; });
+      return h('p', {}, 'x');
+    };
+
+    renderToString(h(Component, {}));
+    await tick();
+    await tick();
+
+    assert.equal(ran, 0, 'no effect body may run during SSR');
+  });
+
+  it('does not run onMount callbacks', async () => {
+    let mounted = 0;
+    const Component = () => {
+      onMount(() => { mounted++; });
+      return h('p', {}, 'x');
+    };
+
+    renderToString(h(Component, {}));
+    await tick();
+
+    assert.equal(mounted, 0);
+  });
+});
+
+describe('a throwing component does not corrupt the render that follows', () => {
+  it('unwinds its context frame', () => {
+    // The frame is popped in a finally. Without one, a component that threw
+    // would leave its context on the stack forever and every later component in
+    // the process would resolve its parent context to a dead frame.
+    const Theme = createContext('default');
+    const Boom = () => { throw new Error('boom'); };
+    const Consumer = () => h('span', {}, useContext(Theme));
+
+    assert.throws(() => renderToString(h(Theme.Provider, { value: 'dark' }, h(Boom, {}))));
+    assert.equal(renderToString(h(Consumer, {})), '<span>default</span>',
+      'the next render must not inherit the failed one\'s context');
+  });
+});

--- a/packages/what-text/package.json
+++ b/packages/what-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-text",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Optional text engine for What Framework, powered by @chenglou/pretext",
   "type": "module",
   "main": "src/index.js",

--- a/packages/what/package.json
+++ b/packages/what/package.json
@@ -1,6 +1,6 @@
 {
   "name": "what-framework",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "The web framework built for AI agents — signals, components, islands, SSR",
   "type": "module",
   "main": "src/index.js",
@@ -84,9 +84,9 @@
   },
   "homepage": "https://whatfw.com",
   "dependencies": {
-    "what-core": "^0.12.2",
-    "what-router": "^0.12.2",
-    "what-server": "^0.12.2",
-    "what-compiler": "^0.12.2"
+    "what-core": "^0.12.3",
+    "what-router": "^0.12.3",
+    "what-server": "^0.12.3",
+    "what-compiler": "^0.12.3"
   }
 }

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -98,6 +98,39 @@ if (existsSync(rootManifest)) {
   }
 }
 
+// The smoke apps pin what-* at an EXACT version so `cd smoke/apps/<name> &&
+// npm install` installs the release those apps were written against. They are
+// private and not workspace members, so nothing else moves them, and a stale pin
+// means the checked-in demos quietly install an old framework. (The smoke RUNNER
+// rewrites these to tarballs or a chosen registry version, so a stale pin never
+// affects a smoke run: it only affects a human opening the demo.)
+const smokeAppsDir = join(repoRoot, 'smoke', 'apps');
+if (existsSync(smokeAppsDir)) {
+  let smokePins = 0;
+  for (const entry of readdirSync(smokeAppsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const file = join(smokeAppsDir, entry.name, 'package.json');
+    if (!existsSync(file)) continue;
+    const json = JSON.parse(readFileSync(file, 'utf8'));
+    let changed = false;
+    for (const field of DEP_FIELDS) {
+      if (!json[field]) continue;
+      for (const [name, range] of Object.entries(json[field])) {
+        if (internalNames.has(name) && range !== next) {
+          json[field][name] = next;
+          changed = true;
+          smokePins++;
+        }
+      }
+    }
+    if (changed) {
+      if (!dry) writeFileSync(file, JSON.stringify(json, null, 2) + '\n');
+      console.log(`  ${`smoke/apps/${entry.name}`.padEnd(24)} -> ${next}`);
+    }
+  }
+  if (smokePins) console.log(`  ${'(smoke app pins)'.padEnd(24)} ${smokePins} updated`);
+}
+
 // Keep the hardcoded VERSION constant in agent-context.js in sync (guarded by a
 // version-match test in packages/core/test/guardrails.test.js — would fail CI otherwise).
 const agentCtx = join(pkgsDir, 'core', 'src', 'agent-context.js');

--- a/sites/benchmarks/index.html
+++ b/sites/benchmarks/index.html
@@ -209,7 +209,7 @@
   <div class="container">
     <h1>Performance Benchmarks</h1>
     <p class="subtitle">Real measured performance data from the What Framework test suite. All benchmarks run on Node.js v22.23.2.</p>
-    <p class="last-updated">Last updated <time datetime="2026-08-07T07:08:13.706Z">August 7, 2026</time> · v0.12.2 · linux</p>
+    <p class="last-updated">Last updated <time datetime="2026-08-07T07:08:13.706Z">August 7, 2026</time> · v0.12.3 · linux</p>
 
     <!-- Signals -->
     <div class="benchmark-section">
@@ -449,7 +449,7 @@
   </div>
 
   <footer>
-    <a href="https://whatfw.com">What Framework</a> v0.12.2 — <a href="https://react.whatfw.com">React Compat</a> — <a href="https://www.npmjs.com/package/what-framework">npm</a> — <a href="https://github.com/CelsianJs/what-framework">GitHub</a>
+    <a href="https://whatfw.com">What Framework</a> v0.12.3 — <a href="https://react.whatfw.com">React Compat</a> — <a href="https://www.npmjs.com/package/what-framework">npm</a> — <a href="https://github.com/CelsianJs/what-framework">GitHub</a>
   </footer>
 </body>
 </html>

--- a/smoke/FINDINGS.md
+++ b/smoke/FINDINGS.md
@@ -1,0 +1,569 @@
+# App smoke suite: findings
+
+Three waves, in this order.
+
+- **1 to 5** were found by building a real application and driving it in a
+  browser.
+- **6 to 11** came from adversarially reviewing the fixes for 1 to 5. Several
+  are the same bug class one layer deeper, and one (9) is a regression the first
+  round of fixes introduced.
+- **12 to 17** came from a second adversarial round plus a differential fuzz.
+  Two of them (16, 17) are regressions the *second* round introduced.
+- **18 to 22** came from building the other three apps. The storefront is
+  hand-written and uncompiled; the admin dashboard is a compiled Vite SPA, and
+  putting the compiler in the loop exposed a whole second set. Three of these
+  five exist only on the compiled path, which is the recommended one.
+
+Each entry says what broke, why nothing caught it, and where the regression test
+now lives.
+
+The pattern is worth naming, because it decided the design of this suite. The
+app-found bugs each needed **two features combined**: SSR *and* hydration *and* a
+toggle; a query key *and* a signal *and* an invalidation. The unit suite covers
+each of those alone and was fully green through all of them.
+
+The review-found ones say something less comfortable: **a fix written from one
+reproduction closes that reproduction, not the defect.** Three consecutive rounds
+of hand-written adversarial cases each closed the shape in front of them and left
+the class open, and two of those rounds shipped a new bug while doing it.
+
+What finally closed the class was not a better reviewer but a different kind of
+test: `hydration-parity-fuzz.test.js` generates 400 random trees, server-renders
+each with one set of values, hydrates it with a different set, and asserts the
+result is identical to a client-only render of the same tree. It knows nothing
+about markers or cursors, so it cannot be satisfied by a narrow fix. Scored
+against the same 400 trees:
+
+| | divergent |
+|---|---|
+| 0.12.2 as published, under browser conditions | 186 / 400 |
+| 0.12.2 with the dev-only correction forced on | 32 / 400 |
+| after finding 5, before the second review round | 35 / 400 |
+| this release | **0 / 400** |
+
+The middle row is the one to keep in mind. The second round of hand-written fixes
+made the aggregate slightly *worse* while every hand-written test stayed green.
+
+---
+
+## Fixed in this pass
+
+### 1. Hydration discarded the client's value in every browser
+`packages/core/src/render.js`
+
+Correcting a text mismatch lived inside the dev-only warning branch, and dev mode
+was decided by reading `process.env.NODE_ENV`. No browser has `process`, so the
+check was false in the only environment where hydration runs, and the correction
+never happened. The server's text stayed on screen until some later write
+happened to touch that node.
+
+Anything the server cannot know rendered stale: a cart restored from
+localStorage showed 0 items, a saved theme showed the default, a relative
+timestamp showed the build time. It self-heals on the next write, so it reads
+like a broken store rather than a hydration bug.
+
+Every test runs under Node, where `process` exists, so the whole suite took the
+corrected path and saw nothing.
+
+- Correction is now unconditional; only the warning is dev-gated.
+- `isDevMode()` now returns `__DEV__`, which resolves correctly in browsers.
+- Test: `packages/core/test/hydration-client-value.test.js` (deletes
+  `globalThis.process` to reproduce the browser condition).
+
+### 2. A hydrated `<Show>` broke position on the first toggle and died on the second
+`packages/core/src/render.js`
+
+The client render path wraps every reactive function child in `<!--fn-->` /
+`<!--/fn-->` markers. The hydration path created none, which cost two things:
+
+- `reconcileInsert` got a null marker, so it had no insertion point and appended
+  to the END of the parent. A `<Show>` flipping arms teleported to the bottom of
+  its container. (A component realizes to a `DocumentFragment`, and fragments
+  deliberately skip the replace-in-place fast path, so this hit every
+  component-valued region.)
+- the effect's disposer was attached to the CONTENT node, so removing that
+  content disposed the effect and the region stopped updating for good.
+
+Client-only rendering was always correct, which is why nothing caught it: the
+bug needs SSR **and** hydration **and** a toggle, and the suite covered each
+separately. Symptom in the app: the cart's empty state never came back after
+removing the last item.
+
+- Hydration now inserts the same markers, keeps the cursor aligned, and hands
+  the end marker to `reconcileInsert`. The disposer is idempotent because it is
+  now reachable from three teardown routes.
+- Test: `packages/core/test/hydration-reactive-region.test.js`.
+
+### 3. `enhanceForms()` could not talk to its own endpoint
+`packages/server/src/islands.js`
+
+`<Form>` emits `data-enhance`, and `enhanceForms()` posted a `FormData` object,
+which is multipart. `/__what_action` parses url-encoded or JSON and nothing else,
+so the body failed to parse, the `_action` field went missing, and every enhanced
+form answered 400. The no-JS path kept working, so the feature looked fine
+wherever anyone tested it without scripting.
+
+Also fixed alongside it: the CSRF guard blocked submission whenever the page had
+no `<meta>` token. Cached pages (`static` / `hybrid`) deliberately carry no
+per-visitor token, so a `<Form>` inside one could never submit.
+
+- Enhanced posts now use the same encoding as the plain submit they replace.
+- Token lookup falls back meta -> form field -> cookie.
+- A followed 303 now navigates, cancellable via `form:response`.
+- Test: `packages/server/test/enhance-forms.test.js`.
+
+### 4. A query went permanently deaf to `invalidateQueries()` after its first refetch
+`packages/core/src/data.js`
+
+`useQuery` and `useSWR` subscribed to their key once, OUTSIDE the effect that
+fetches, while that effect's cleanup unsubscribed. The effect re-runs whenever
+the query function reads a changed signal, which is the entire point of a
+reactive query key. So the first reactive refetch dropped the subscription and
+never restored it.
+
+The first invalidation, before any refetch, works. So a test that mounts a query
+and immediately invalidates it passes, and only a query that has actually been
+used goes deaf.
+
+- The subscription now lives inside the effect and is re-established per run.
+- Test: `packages/core/test/query-invalidation-lifecycle.test.js`.
+
+### 5. Every fetch pinned the Node event loop for five minutes
+`packages/core/src/data.js`
+
+The cache-cleanup `setTimeout` was not unref'd, so any process that ran one query
+stayed alive for a full `cacheTime` after finishing. Found because the new test
+file passed and then hung.
+
+- The timer is unref'd. It is opportunistic housekeeping, never work worth
+  keeping a process alive for.
+
+### 6. Empty reactive text destroyed its next sibling
+`packages/core/src/render.js`
+
+HTML cannot serialize an empty text node, so a reactive child rendering `''` on
+the server emits nothing. The client claimed the next node anyway, found an
+element where it wanted text, and REPLACED that element with an empty text node.
+The server's real markup was discarded and every following sibling shifted,
+cascading a warn-and-recreate through the rest of the parent. An `<input>` the
+visitor had typed into before hydration was replaced and lost its value.
+
+The first version of this fix only suppressed the WARNING, and only in the case
+where nothing was left to claim. That was both too narrow and the wrong layer:
+the adversarial review demonstrated that the destructive path was reached
+whenever the empty region had any following sibling, which is most of the time.
+
+- An empty string now claims a text node if one is there, and claims nothing
+  otherwise, so it can never consume a non-text sibling. The bogus warning goes
+  with it. What it declines to claim is then cleaned up after the walk (see 13).
+- Test: `hydration-reactive-region.test.js` (the no-sibling case, the
+  sibling-after case, and the server-rendered-value case).
+- Deeper cause, still NOT fixed: `renderToString` emits no markers for a
+  reactive region, so hydration has to *infer* the boundary of anything that
+  serialized to nothing rather than being told it. Findings 6, 8, 13 and 16 are
+  all consequences of that one absence. The inference is now exact enough to
+  score 0/400 on the fuzz, but the durable fix is for SSR to emit the same
+  `<!--fn-->` markers the client path uses. Tracked for 0.13.0; deliberately not
+  done here because it changes every server-rendered byte.
+
+### 7. Nested reactive regions interleaved instead of nesting
+`packages/core/src/render.js`
+
+Hydration claims the inner content first, so an inner region's markers went in
+first, and anchoring the outer markers to the first CONTENT node put the outer
+start marker INSIDE the inner pair. Switching the outer arm removed the visible
+content but neither the inner markers nor the inner effect. The orphaned effect
+kept rendering into a region that was switched off, and its output came back
+doubled when the outer arm returned.
+
+`<Show>` wrapping `<Show>` or `<For>` is the canonical shape, not an exotic one.
+Found by the adversarial review of fix 2, not by the app.
+
+- A region now opens its start marker BEFORE hydrating its value, so anything a
+  nested region inserts lands inside it, and it owns everything between its
+  markers rather than only the nodes its own value produced.
+- Test: `hydration-reactive-region.test.js`, asserting PARITY with a client-only
+  render of the same tree.
+
+### 8. A region that rendered nothing lost its position permanently
+`packages/core/src/render.js`
+
+`<Show>` with no fallback, or `{cond && <X/>}`, claims no node, so both markers
+were appended to the END of the parent. When the condition later flipped, the
+content appeared below every following sibling, forever, with no warning. The
+regression test written for fix 2 could not catch this, because a `<Show>` with a
+fallback always produces a node.
+
+- Markers now go in at the cursor position whether or not anything was claimed.
+- Test: `hydration-reactive-region.test.js`.
+
+### 9. `enhanceForms()` diverged from a native submit in six ways
+`packages/server/src/islands.js`
+
+Fixing the multipart-encoding bug (fix 3) overcorrected into urlencoded-always,
+which silently dropped file uploads from forms that correctly declared
+`enctype="multipart/form-data"`. That was a regression introduced by this work and
+caught by the adversarial review before it shipped. Reviewing the rest of the
+contract turned up five more divergences, all pre-existing:
+
+- the CSRF token was sent to a cross-origin form action, handing this visitor's
+  double-submit secret to a third party, and our token policy blocked cross-origin
+  forms that were never ours to block
+- a GET form serialized its fields and then discarded them, fetching a bare URL
+- a field named `method` or `action` shadowed `form.method` / `form.action` with
+  the input element (`HTMLFormElement` is `[LegacyOverrideBuiltIns]`), throwing
+  after `preventDefault()` so the submit did nothing at all: no request, no
+  `form:error`, no native fallback
+- the submitter button's `name`/`value` was never sent, so a multi-button form
+  could not tell the server which button was pressed
+- newlines were sent as LF where a native urlencoded submit sends CRLF
+
+Encoding now follows the form's own `enctype`, and the rest matches a native
+submit. Redirect navigation is same-origin only.
+
+- Test: `packages/server/test/enhance-forms.test.js`, 17 cases pinning the wire
+  format against the real parser and handler.
+
+### 10. `invalidateQueries()` was answered from the freshness window
+`packages/core/src/data.js`
+
+A query with a `staleTime`, or a `useSWR` inside its default 2s
+`dedupingInterval`, returned cached data instead of refetching. Fix 4 restored the
+subscription, but the subscriber it now reliably called still no-opped. The normal
+sequence (mutate, then invalidate) sits well inside 2s, so this was the common
+case, not the edge case.
+
+- Invalidation now forces past the dedupe windows. Ordinary reactive refetches
+  still dedupe.
+
+### 11. Polling and retry timers kept Node processes alive
+`packages/core/src/data.js`
+
+Fix 5 unref'd the cache-cleanup timer; the sweep found the same class in three
+more places. `refetchInterval` and `refreshInterval` arm intervals that are never
+cleared outside a component lifecycle, so an SSR render leaked one per render and
+kept calling the query function after the HTML had been sent. The retry-backoff
+timer held the process for the full ladder. And every successful fetch armed a new
+cleanup timer without clearing the last, accumulating pending timers at roughly
+(fetch rate x cacheTime).
+
+- All timers unref'd; the cleanup timer is replaced rather than accumulated.
+
+### 12. No component using a hook could be server-rendered at all
+`packages/server/src/index.js`
+
+`renderToString` called `vnode.tag(props)` directly, with nothing on the
+component stack. Every hook that needs a context resolves it through
+`getCurrentComponent()`, so **all ten of them threw**, plus `Context.Provider`:
+
+```
+[what] useState() can only be called inside a component function.
+```
+
+`useState`, `useSignal`, `useComputed`, `useEffect`, `useMemo`, `useCallback`,
+`useRef`, `useReducer`, `onMount`, `onCleanup`. One of them anywhere in the tree
+and the page could not be server-rendered: not a hydration warning, not a
+degraded render, `renderToString` threw. All three server render paths had their
+own copy of the bare call, so `renderToHydratableString` and `renderToStream`
+were broken the same way.
+
+This is the largest gap the suite found and the one that had been there longest.
+Nothing caught it because SSR tests render plain element trees and hook tests
+mount on the client: the two features are only broken *together*, which is the
+shape every bug in this class has had. It was found while trying to write a
+regression test for finding 15, when `onCleanup` in a server-rendered component
+threw instead of the test failing the way it was supposed to.
+
+- Components now run under a real context (`_beginComponentSSR` /
+  `_endComponentSSR`), on all three paths. The frame stays open while the
+  subtree renders, because `useContext` resolves by walking parent contexts, and
+  is closed in a `finally` so a throwing component cannot strand it.
+- The context is marked disposed on the way out, so the deferred work every hook
+  queues (`useEffect` in all three of its dep shapes) sees `ctx.disposed` and
+  never runs. An SSR render leaves no live effects behind.
+- Test: `packages/server/test/ssr-component-context.test.js`, 21 cases: one per
+  hook, one per render path, context resolution and nesting, effect and onMount
+  suppression, and frame unwinding after a throw.
+
+### 13. An empty region left the server's content stranded on screen
+`packages/core/src/render.js`
+
+The other half of finding 6. An empty region correctly refuses to claim a
+non-text node, which means whatever the server rendered in its place is left
+behind: no effect owns it, no update can reach it, it simply stays visible. The
+server's signed-in header stayed on screen for a signed-out visitor, underneath
+the region that was supposed to have replaced it.
+
+Fix 6 traded this in to stop the region destroying its siblings. Both are
+avoidable, because they are questions asked at different times: the walk cannot
+know whether a node belongs to this region or the next sibling, but once the
+walk has *finished*, any node it never claimed is unreferenced by definition.
+
+- Hydration now removes unclaimed nodes after the walk, per element and at the
+  root. Never during it.
+- Two exclusions, both because the walk does not own the subtree: an element
+  whose client tree declares no children (an island renders a bare host and
+  fills it in later, from that same server HTML, and a `mode: 'static'` island
+  never hydrates at all), and `dangerouslySetInnerHTML`. `<body>` and `<html>`
+  are excluded at the root, because scripts and the hydration payload live there
+  and are never claimed by anyone.
+- Test: `packages/core/test/hydration-server-leftovers.test.js`.
+
+### 14. Every inline SVG went blank on hydration
+`packages/core/src/render.js`
+
+`nodeName` is uppercased for HTML elements but case-preserved for everything
+else, so an `<svg>`'s `nodeName` is `svg` and could never equal
+`tag.toUpperCase()`. Every inline SVG on a server-rendered page failed to match,
+warned `expected <svg>, got svg`, and was destroyed. The rebuild then used
+`document.createElement`, which lands in the XHTML namespace and does not render
+as SVG at all, so icons, logos and charts disappeared on hydration.
+
+The warning text is the tell: nobody had read it, because the correction it
+belongs to was unreachable in browsers until finding 1 was fixed.
+
+- The comparison is case-insensitive, so a matching SVG is reused.
+- The mismatch fallback now goes through `createDOM`, the same path a
+  client-only render uses, so a rebuild is namespace-correct and sets attributes
+  rather than properties. "Falling back to a client render" now means the client
+  render rather than an approximation of it.
+- Test: `hydration-server-leftovers.test.js`.
+
+### 15. A component disposed itself the first time its own root updated
+`packages/core/src/render.js`
+
+Hydration has no comment markers for a component, so its context is anchored to
+a DOM node in order to be reachable for disposal. It was anchored to the first
+node the component produced, and if the component's root is a reactive region
+that node is the region's current *content*, which the region replaces on its
+first update. `disposeTree` then ran over it and took the whole component
+context with it: every effect, cleanup and `onCleanup` died while the component
+was still mounted.
+
+A hydrated component that polls, subscribes, or holds a query went silent the
+first time its own root re-rendered. This is the same create-outside,
+dispose-inside-an-effect shape that finding 2 removed, four lines below the code
+that fixed it.
+
+- A region root anchors to the parent element instead. That disposes later than
+  ideal, when the parent goes rather than when the component does, and disposing
+  late is strictly better than disposing while mounted.
+- Test: `hydration-reactive-region.test.js`.
+
+### 16. A region could never remove content it created itself
+`packages/core/src/render.js`
+
+Introduced by the fixes for 7 and 8, caught by the review of them. When the
+server rendered nothing for a region and the client renders something, the
+content is created rather than claimed. The mismatch fallback appended it to the
+end of the parent while leaving the cursor pointing at it, so the region's end
+marker was then inserted *before* its own content. The region owned nothing and
+could never take the content back: switching the condition off left it on screen
+permanently, with no warning.
+
+The finding-8 test could not catch this, because it has a trailing sibling for
+the content to displace, which lands it inside the markers by accident. The bug
+needs the region to be the last thing in its parent.
+
+- All three mismatch fallbacks insert at the cursor and advance it, instead of
+  appending past it.
+- Test: `hydration-reactive-region.test.js`.
+
+### 17. `invalidateQueries()` fanned out into one request per subscriber
+`packages/core/src/data.js`
+
+Introduced by the fix for 10, caught by the review of it. Forcing past the
+"dedupe window" forced past two different mechanisms that share a name and a
+map. Bypassing the freshness window is correct. Bypassing request *coalescing*
+is not: every component reading a key subscribes separately, so one
+`invalidateQueries()` call arrives at N subscribers, and the in-flight map is
+what collapses those into one request. Four components on one key issued four
+concurrent fetches whose responses then raced to write the cache.
+
+Sequencing the two on `Date.now()` was not enough either. It has 1ms resolution,
+so a refetch and an unrelated invalidation issued microseconds apart share a
+timestamp and the invalidation was answered by the request that predated the
+mutation. That surfaced as a 1-in-6 test flake before it surfaced as a bug.
+
+- Invalidation bumps a per-key epoch before waking anyone. A forced revalidate
+  joins an in-flight request only if that request started in the current epoch,
+  so siblings coalesce and a pre-invalidation request never answers. A counter
+  has no ties.
+- Test: `query-invalidation-lifecycle.test.js` (fan-out, ordering, and that
+  ordinary refetches still dedupe).
+
+### 18. A compiled keyed list rendered empty on the server and crashed on hydration
+`packages/core/src/render.js`, `packages/server/src/index.js`
+
+`.map()` with a `key` prop, and `<For>`, lower to a mapArray **inserter**: a
+function taking `(parent, marker)`, not a thunk returning a value. Neither
+hydration nor SSR had a branch for it, so both fell through to the generic
+reactive-child branch and called it with no arguments.
+
+- On the server, `parent.insertBefore` threw on `undefined`, SSR swallowed the
+  error, and the container rendered **empty**. A compiled app served HTML with
+  no list rows in it: nothing for a crawler, nothing painted before the bundle
+  arrived.
+- On the client the same throw escaped `hydrate()`. Not one list: **the whole
+  page stopped hydrating and stayed inert.**
+
+This is the ordinary shape for a compiled app. The server renders through
+runtime `h()` (plain arrays), the client bundle is compiled (mapArray
+inserters), and they meet at hydration. Nothing covered it because the compiled
+path is tested by mounting and never by hydrating, and the SSR tests never see
+compiled output.
+
+- Hydration builds the list's rows and lets the walk's trim (13) remove the
+  server's. That is a missed reuse, not a correctness problem, and reusing them
+  needs the list's boundary markers in the server HTML, which is the same thing
+  regions need (tracked for 0.13.0).
+- SSR renders the rows from the inserter's inputs, honoring the same item
+  protocol the client uses (keyed non-raw hands the mapFn an accessor,
+  everything else the raw item), and stays fail-soft so one bad row cannot blank
+  the response.
+- Test: `packages/core/test/hydration-keyed-list.test.js`.
+
+### 19. A reactive region lost its owning component on every re-run
+`packages/core/src/render.js`
+
+The effect behind `{() => ...}` re-runs long after the synchronous render that
+created it, with the component stack unwound, so everything it built on a re-run
+got `parentCtx = null`. That severs the chain two separate lookups walk:
+
+- `useContext` fell through to the context **default** for anything rendered
+  after a state change, so a themed or session-scoped value silently reverted on
+  every route change.
+- the ErrorBoundary and Suspense lookup found nothing, so a throw from a
+  component created by an inner region escaped the boundary wrapping it.
+
+Both are correct on first paint and only break once the app is interactive,
+which is the worst timing to notice: the page looks right, then a click makes
+context quietly wrong.
+
+`dom.js` was given this fix, with a comment naming these exact casualties.
+`render.js`'s `insert()`, which is the path the **compiler** emits for every
+reactive expression, was not. So it was broken for precisely the users on the
+recommended build setup.
+
+- Both region effects (`insert` and the hydration branch) capture the owner at
+  creation and re-push it for the duration of each re-run.
+- Test: `packages/core/test/region-owner-chain.test.js`, asserting both
+  consequences on both paths.
+
+### 20. The compiler called every destructured prop as a signal
+`packages/compiler/src/babel-plugin.js`
+
+`collectSignalNamesFromScope` classifies every destructured prop name as a
+signal. That is right for deciding an effect is needed and wrong for deciding to
+**call** it. `_$createComponent` passes plain values, so
+
+```jsx
+function Badge({ label }) { return <span data-label={label}>{label}</span>; }
+```
+
+compiled to `setAttr(el, 'data-label', label())` and threw `label is not a
+function` on any ordinary string prop, rendering **nothing at all** for the
+component and everything under it. The same identifier as a *child* compiled to
+`() => label`, uncalled, so the two positions disagreed inside a single element:
+the text worked and the attribute killed the component.
+
+Found by a `<Stat>` card that blanked an entire dashboard page.
+
+- Prop-derived names are tracked separately and passed through uncalled. The
+  runtime setters (`setAttr`, `setClass`, `setValue`) already resolve a function
+  value reactively, so this is correct whether the parent passed a plain value
+  or an accessor. Names from a real `signal()` still auto-invoke.
+- Test: `packages/compiler/test/compiled-output-runtime.test.js`, covering the
+  plain-value case, the accessor case (fixing this by *never* calling would be
+  equally wrong), the real-signal case, and the keyed-list shape that found it.
+
+### 21. Every guarded route logged a false redirect cycle in Chromium
+`packages/router/src/index.js`
+
+One guarded deep link produced 25 `[what-router] Redirect cycle detected`
+errors and a flash of the redirect-loop screen. `navigate()` sets
+`_isNavigating` immediately but defers the `_url` write into
+`document.startViewTransition`, and `renderMatch` reads `_isNavigating`. So the
+flag flip re-ran the match against the still-old URL, the same middleware
+returned the same target, and the hop was counted twice. The detector then
+cleared `_isNavigating` and `_pendingUrl` while the real navigation was still in
+flight, corrupting router state mid-navigation.
+
+Chromium-only: without the View Transitions API, `doNavigation()` runs
+synchronously and the URL and the flag change together. Deleting
+`Document.prototype.startViewTransition` in the same app dropped it to zero
+errors with an identical final URL.
+
+- A redirect to a target that is already `_pendingUrl` is a re-match of the same
+  hop, not a second one, and no longer counts toward the chain.
+
+### 22. An interrupted view transition surfaced as an uncaught page error
+`packages/router/src/index.js`
+
+`navigate()` awaited only the transition's `.finished`. Its `.ready` rejects
+whenever the transition is skipped, which two navigations in quick succession do
+routinely, and with no handler that became an unhandled rejection: `pageerror:
+Transition was skipped`, landing in whatever error reporter the app installed,
+for a navigation that actually succeeded.
+
+- `.ready` now has a no-op catch. The navigation still awaits `.finished`.
+
+---
+
+## Reported, not fixed
+
+### A. The runtime path has no keyed reconciliation at all
+`packages/core/src/dom.js`
+
+`dom.js` never reads `vnode.key`. The reactive function-child branch disposes and
+rebuilds every node on every list change. Keys only work on the COMPILED path,
+where the plugin lowers `.map()` / `<For>` to `mapArray`.
+
+Consequences for a buildless app, which is exactly what `create-what --template
+fullstack` generates:
+
+- every list row is recreated on any change: focus is lost, an open `<details>`
+  closes, CSS transitions restart, and the cost is O(n) DOM churn per update
+- `For`'s auto-key logic in `components.js` (`item.id` / `item.key`) is dead code
+  on this path
+- `<For each={...} key={fn}>` silently ignores `key`: the runtime `For` does not
+  even destructure the prop
+
+I prototyped honoring `key` in the runtime `For` and reverted it: setting
+`vnode.key` changes nothing while `dom.js` ignores it, and shipping an inert prop
+is worse than an absent one. The real fix is keyed reconciliation in the
+`dom.js` function-child branch. It cannot import `render.js`'s reconciler
+(`render.js` already imports `dom.js`), so this is a deliberate piece of work,
+not a patch.
+
+Until then `cmp:keyed-list` is claimed only by a compiled app.
+
+### B. `<For>` hands over different things on the two paths
+`packages/core/src/components.js` vs `packages/core/src/render.js`
+
+- compiled: `<For key={...}>` lowers to `mapArray`, which passes a **signal
+  accessor** (`item()`).
+- runtime: `For` passes the **raw item** (`item`).
+
+So the same JSX behaves differently depending on whether the compiler ran, and
+`CLAUDE.md` documents only the compiled behavior. Code written against one path
+throws on the other. Picking one is an API decision, so it needs your call.
+
+### C. Server actions cannot set response headers
+
+`action-handler.js` owns its response headers, so an action cannot issue a
+`Set-Cookie`. Sign-in therefore cannot be an action, and the storefront uses a
+plain `/api/login` endpoint for it. That is a defensible design, but it is
+undocumented and the first thing anyone hits when wiring auth.
+
+### D. A `<Form>` on a cached page cannot work without JavaScript
+
+Cached HTML (`static` / `hybrid`) is shared between visitors, so the adapter
+deliberately does not embed a per-visitor CSRF token in it. A `<Form>` there has
+no token to submit and the double-submit check rejects the post when scripting is
+off. The design is right; the trap is that nothing says so. `<Form>` warns on the
+SERVER console at render time, which is not where the developer is looking.
+
+The storefront works around it by putting the review form on `/review`, a
+`mode: 'server'` page. Worth either documenting loudly or having `<Form>` detect
+a cached render and say so.

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -1,0 +1,98 @@
+# App smoke suite
+
+Real applications, built the way a user would build them, driven in a real
+browser, run against a chosen build of the framework.
+
+```bash
+npm run smoke:apps                              # workspace source (pre-release)
+npm run smoke:apps:npm                          # published `latest`
+node smoke/run.mjs --source=npm --version=0.12.2 # a specific release
+node smoke/run.mjs --apps=storefront --keep      # one app, keep the workdir
+```
+
+## Why this exists
+
+0.12.0 and 0.12.1 shipped a `what-server` packaging defect that every unit test,
+both type gates and the scaffold smoke passed. It was only visible to something
+that INSTALLED the published artifact and used it. `--source=npm` is that
+something.
+
+Then the suite's first app found five more defects that the 1,900-test unit suite
+could not see, because each needed two features combined: SSR **and** hydration
+**and** a toggle; a query key **and** a signal **and** an invalidation. See
+`FINDINGS.md`.
+
+## The two modes
+
+| mode | what it installs | what it catches |
+|---|---|---|
+| `--source=workspace` (default) | `npm pack` of each workspace package | source regressions, before a release exists |
+| `--source=npm` | `name@version` from the registry | packaging defects: a types path declared but not published, an export condition shadowed by another, a dependency that only resolves inside the monorepo |
+
+Workspace mode is blind to every packaging defect by construction, which is
+exactly how 0.12.0 shipped. Both modes assert afterwards that the installed tree
+really came from the source that was asked for, so a resolution fallback cannot
+turn a green run into a lie about which bytes were tested.
+
+## The capability contract
+
+`harness/capabilities.mjs` lists the framework capabilities this suite is
+responsible for. Each app declares `covers: [...]`, and the runner fails when:
+
+- a capability has no app covering it, or
+- an app declares a capability that no passing check ever reported.
+
+Adding a capability without covering it turns the suite red. That is the point:
+a gap becomes visible the day it appears rather than in the next audit.
+
+A filtered run (`--apps=...`) skips both contract checks, since covering a subset
+is the whole reason to filter.
+
+## The apps
+
+Each app is a genuine, demoable application. It is checked in whole, so
+`cd smoke/apps/<name> && npm install && npm run dev` works and gives you
+something to look at, and the runner copies it to a temp workdir so a run never
+dirties the demo.
+
+| app | shape | proves |
+|---|---|---|
+| `storefront` | buildless full-stack ecommerce | static/hybrid/server render modes, ISR MISS/HIT and tag revalidation, a global cart store with localStorage persistence, cookie auth read in a loader, server actions with and without JavaScript, CSRF rejection, `useQuery` + prefix invalidation, `Show`/`For`, batching |
+
+Three more are planned and not yet built: an admin dashboard (client SPA router,
+nested layouts, guards, loading/error routes, Portal, context), a scrollytelling
+page (all five island hydration modes, scroll-driven animation), and an ops
+console (Suspense/lazy, ErrorBoundary, infinite + optimistic queries, forms,
+focus management). The uncovered rows in the coverage report are theirs.
+
+## Writing a new app
+
+1. Build the app under `smoke/apps/<name>/`. Make it something you would show
+   someone, not a test fixture.
+2. Add `smoke.config.mjs`:
+
+```js
+export default {
+  description: 'one line',
+  covers: ['render:static', 'state:signal'],       // capability ids
+  async check({ workDir, appPort, browser, check, reporter, log, run }) {
+    // check(capability, condition, name, detail) -> tags a capability
+    // reporter.assert(condition, name, detail)   -> untagged supporting check
+  },
+};
+```
+
+3. Run `node smoke/run.mjs --apps=<name> --keep` until green.
+
+Ports start at 4700 and increment per app. The runner refuses to start if the
+port is already answering, because a stale process serving a DIFFERENT app makes
+every downstream assertion lie.
+
+## Reading a failure
+
+The run writes `artifacts/smoke-apps.json` with every check, its capability, and
+its detail string. Failures print the detail, which is written to carry the
+observed value (`badge=0`, `MISS then MISS`) rather than just "expected true".
+
+If a check fails only under `--source=npm`, it is a packaging or release defect,
+not a source defect: the same code passed in workspace mode.

--- a/smoke/apps/admin-dashboard/.gitignore
+++ b/smoke/apps/admin-dashboard/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+package-lock.json
+.DS_Store

--- a/smoke/apps/admin-dashboard/index.html
+++ b/smoke/apps/admin-dashboard/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en" data-theme="night">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>Northwind Ops</title>
+  </head>
+  <body>
+    <!-- Client-only by design: the served document carries no app markup, and
+         everything below the shell is rendered by the compiled bundle. -->
+    <div id="app"></div>
+
+    <!-- Portal host. It has to exist in the document before a Portal renders
+         into it, and it deliberately sits OUTSIDE #app so a modal is provably
+         not a descendant of the card that opened it. -->
+    <div id="modal-root"></div>
+
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/smoke/apps/admin-dashboard/package.json
+++ b/smoke/apps/admin-dashboard/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "smoke-admin-dashboard",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Admin dashboard smoke app: compiled JSX SPA with a persistent shell, nested routes, guards, loading/error routes, context, Portal and a keyed table.",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "vite build",
+    "preview": "vite preview --host 127.0.0.1",
+    "start": "vite preview --host 127.0.0.1"
+  },
+  "dependencies": {
+    "what-framework": "0.12.2",
+    "what-router": "0.12.2"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.0",
+    "vite": "^7.0.0",
+    "what-compiler": "0.12.2"
+  }
+}

--- a/smoke/apps/admin-dashboard/package.json
+++ b/smoke/apps/admin-dashboard/package.json
@@ -11,12 +11,12 @@
     "start": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
-    "what-framework": "0.12.2",
-    "what-router": "0.12.2"
+    "what-framework": "0.12.3",
+    "what-router": "0.12.3"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",
     "vite": "^7.0.0",
-    "what-compiler": "0.12.2"
+    "what-compiler": "0.12.3"
   }
 }

--- a/smoke/apps/admin-dashboard/public/favicon.svg
+++ b/smoke/apps/admin-dashboard/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#0b0d12"/>
+  <rect x="6" y="18" width="4" height="8" rx="1.5" fill="#6ea8fe"/>
+  <rect x="13" y="12" width="4" height="14" rx="1.5" fill="#6ea8fe"/>
+  <rect x="20" y="6" width="4" height="20" rx="1.5" fill="#a78bfa"/>
+</svg>

--- a/smoke/apps/admin-dashboard/smoke.config.mjs
+++ b/smoke/apps/admin-dashboard/smoke.config.mjs
@@ -1,0 +1,327 @@
+// Admin dashboard smoke contract.
+//
+// This is the only app in the suite that runs through what-compiler, which is
+// why cmp:keyed-list lives here: dom.js never reads vnode.key, so keyed
+// reconciliation exists on the compiled path alone (smoke/FINDINGS.md A).
+//
+// Everything below is observed in a real browser against a production `vite
+// build`, never asserted from source. The order matters in one place: the
+// signed-out deep link has to run before anything signs in, because the guard
+// is only observable while there is no session.
+
+import { startProcess, waitForHttp, withPage } from '../../harness/index.mjs';
+
+const SIGNIN_NAME = 'Ines Okafor';
+
+export default {
+  description: 'Compiled JSX SPA: persistent shell, nested routes, sign-in gate, loading/error routes, context, Portal, keyed table.',
+
+  covers: [
+    'render:client-spa',
+    'route:nested-layout',
+    'route:guard',
+    'route:loading',
+    'route:error',
+    'route:404',
+    'route:link-active',
+    'route:programmatic',
+    'state:context',
+    'cmp:portal',
+    'cmp:keyed-list',
+    'cmp:error-boundary',
+  ],
+
+  async check({ workDir, appPort, browser, check, reporter, log, run }) {
+    const base = `http://127.0.0.1:${appPort}`;
+
+    // === Production build ==================================================
+    // `vite build` with the What plugin, so every assertion below is about
+    // compiled output and not about a dev-server transform.
+    const buildLog = run('npm', ['run', 'build'], { cwd: workDir });
+    reporter.assert(/built in/.test(buildLog), 'vite build produced a bundle',
+      buildLog.trim().split('\n').pop());
+
+    const server = startProcess(
+      'npx',
+      ['vite', 'preview', '--port', String(appPort), '--strictPort', '--host', '127.0.0.1'],
+      { cwd: workDir, env: { ...process.env } },
+    );
+    await waitForHttp(`${base}/`, { child: server });
+
+    // === The document is empty ============================================
+    // A deep link is served by the SPA fallback with no app markup in it: the
+    // client build is the only thing that can produce the dashboard.
+    const deepLink = await fetch(`${base}/orders`);
+    const deepHtml = await deepLink.text();
+    // The <title> is in index.html, so absence of the word "Northwind" proves
+    // nothing. What must be absent is anything only a render could produce.
+    const documentIsEmpty = deepLink.status === 200
+      && /<div id="app">\s*<\/div>/.test(deepHtml)
+      && !deepHtml.includes('data-orders-table')
+      && !deepHtml.includes('data-shell')
+      && !deepHtml.includes('NW-2041');
+
+    // === One signed-out session ===========================================
+    await withPage(browser, `${base}/customers`, async (page, diag) => {
+      // --- route:guard --------------------------------------------------
+      await page.waitForSelector('[data-signin]', { timeout: 10000 });
+      const guardUrl = await page.evaluate(() => location.pathname + location.search);
+      const customersLeaked = await page.locator('[data-customer-body] tr').count();
+      check('route:guard',
+        guardUrl === '/signin?next=%2Fcustomers' && customersLeaked === 0,
+        'an unauthenticated deep link lands on the sign-in route',
+        `url=${guardUrl} customer-rows=${customersLeaked}`);
+
+      // --- Sign in, which also proves the deep link resumes --------------
+      await page.fill('[data-signin-name]', SIGNIN_NAME);
+      await page.click('[data-signin-submit]');
+      await page.waitForSelector('[data-customer-body] tr', { timeout: 10000 });
+      const afterSignIn = await page.evaluate(() => location.pathname);
+      reporter.assert(afterSignIn === '/customers',
+        'sign-in resumes the originally requested route', `url=${afterSignIn}`);
+
+      const customerRows = await page.locator('[data-customer-body] tr').count();
+      check('render:client-spa',
+        documentIsEmpty && customerRows === 7,
+        'a route with no server HTML is rendered entirely by the client build',
+        `document=${documentIsEmpty ? 'empty #app' : 'CARRIED MARKUP'} rendered-rows=${customerRows}`);
+
+      // --- state:context -------------------------------------------------
+      // UserMenu imports neither the session nor the theme module. Everything
+      // it shows arrives through <Workspace.Provider> four levels up, and the
+      // name it prints was typed into the sign-in form a moment ago.
+      const badgeName = await page.textContent('[data-badge-name]');
+      const badgeMetaNight = await page.textContent('[data-badge-meta]');
+
+      await page.click('[data-theme-toggle]');
+      await page.waitForFunction(() => document.documentElement.dataset.theme === 'day');
+      const badgeMetaDay = await page.textContent('[data-badge-meta]');
+      await page.click('[data-theme-toggle]');
+      await page.waitForFunction(() => document.documentElement.dataset.theme === 'night');
+
+      check('state:context',
+        badgeName === SIGNIN_NAME
+          && badgeMetaNight === "Ines's workspace · night theme"
+          && badgeMetaDay === "Ines's workspace · day theme",
+        'a deep child reads the provided value and follows it when it changes',
+        `name=${badgeName} meta="${badgeMetaNight}" -> "${badgeMetaDay}"`);
+
+      // The shell is the Router's globalLayout, so it must survive navigation.
+      await page.evaluate(() => { document.querySelector('[data-sidebar]').__shellStamp = 'kept'; });
+
+      // --- route:link-active --------------------------------------------
+      await page.click('[data-nav="/orders"]');
+      await page.waitForSelector('[data-orders-body] tr');
+      const onOrders = await page.evaluate(() => ({
+        orders: document.querySelector('[data-nav="/orders"]').className,
+        home: document.querySelector('[data-nav="/"]').className,
+      }));
+
+      // --- route:programmatic --------------------------------------------
+      // A table row is not a link. Clicking one calls navigate() from an event
+      // handler, and the URL plus the rendered page both have to follow.
+      await page.click('[data-row="NW-2044"]');
+      await page.waitForSelector('[data-order-id]');
+      const detail = await page.evaluate(() => ({
+        url: location.pathname,
+        id: document.querySelector('[data-order-id]').textContent,
+        total: document.querySelector('[data-order-total]').textContent,
+      }));
+      check('route:programmatic',
+        detail.url === '/orders/NW-2044' && detail.id === 'NW-2044' && detail.total === '$529.00',
+        'navigate() from a click handler moves the URL and the rendered page',
+        `url=${detail.url} heading=${detail.id} total=${detail.total}`);
+
+      // A child route keeps its parent link active but not exact-active.
+      const onDetail = await page.evaluate(() =>
+        document.querySelector('[data-nav="/orders"]').className);
+      check('route:link-active',
+        onOrders.orders.includes('active') && onOrders.orders.includes('exact-active')
+          && !onOrders.home.includes('active')
+          && onDetail.includes('active') && !onDetail.includes('exact-active'),
+        'Link marks the current branch active and only the exact match exact-active',
+        `/orders="${onOrders.orders}" /="${onOrders.home}" on-detail="${onDetail}"`);
+
+      // --- route:nested-layout -------------------------------------------
+      await page.click('[data-nav="/settings/profile"]');
+      await page.waitForSelector('[data-profile-name]');
+      const profileNesting = await page.evaluate(() => ({
+        nested: !!document.querySelector('[data-shell] [data-outlet] [data-settings] [data-settings-page] [data-profile-name]'),
+        name: document.querySelector('[data-profile-name]').textContent,
+      }));
+
+      // The sibling route re-uses the same layout, and the layout's own sub-nav
+      // marks it active. A layout that only wrapped one route would fail here.
+      await page.click('[data-settings-nav="team"]');
+      await page.waitForSelector('[data-team-body] tr');
+      const teamNesting = await page.evaluate(() => ({
+        nested: !!document.querySelector('[data-settings] [data-settings-page] [data-team-body]'),
+        subnav: document.querySelector('[data-settings-nav="team"]').className,
+        members: document.querySelectorAll('[data-team-body] tr').length,
+      }));
+      check('route:nested-layout',
+        profileNesting.nested && profileNesting.name === SIGNIN_NAME
+          && teamNesting.nested && teamNesting.members === 4
+          && teamNesting.subnav.includes('active'),
+        'both /settings pages render inside the shared settings layout',
+        `profile=${profileNesting.nested} name="${profileNesting.name}" team=${teamNesting.nested}`
+          + ` members=${teamNesting.members} subnav="${teamNesting.subnav}"`);
+
+      // --- route:loading --------------------------------------------------
+      // The reports rollup is awaited in a beforeNavigate hook, so the router
+      // holds isNavigating true long enough for the destination's `loading:`
+      // component to actually paint.
+      const clickedAt = Date.now();
+      await page.click('[data-nav="/reports"]');
+      await page.waitForSelector('[data-reports-loading]', { timeout: 5000 });
+      const skeletonAt = Date.now() - clickedAt;
+      const skeletonWhileLoading = await page.locator('[data-reports]').count();
+      await page.waitForSelector('[data-report-body] tr', { timeout: 10000 });
+      const reportAt = Date.now() - clickedAt;
+      const regions = await page.locator('[data-report-body] tr').count();
+      check('route:loading',
+        skeletonWhileLoading === 0 && regions === 3 && reportAt > skeletonAt,
+        "the destination route's loading component shows, then the page replaces it",
+        `skeleton@${skeletonAt}ms (page absent) -> ${regions} regions@${reportAt}ms`);
+
+      // --- route:error ----------------------------------------------------
+      await page.click('[data-nav="/diagnostics"]');
+      await page.waitForSelector('[data-route-error]', { timeout: 10000 });
+      const routeError = await page.evaluate(() => ({
+        message: document.querySelector('[data-route-error-msg]').textContent,
+        shellAlive: document.querySelector('[data-sidebar]')?.__shellStamp ?? null,
+        pageContent: document.querySelectorAll('[data-outlet] .page-head').length,
+      }));
+      check('route:error',
+        routeError.message === 'Diagnostics probe failed: metrics agent unreachable'
+          && routeError.pageContent === 0,
+        "a route's error component catches the page's throw",
+        `message="${routeError.message}" page-rendered=${routeError.pageContent}`);
+      reporter.assert(routeError.shellAlive === 'kept',
+        'the globalLayout shell survived six navigations and a route crash',
+        `stamp=${routeError.shellAlive}`);
+
+      // --- route:404 -------------------------------------------------------
+      await page.click('[data-nav="/warehouse"]');
+      await page.waitForSelector('[data-notfound]', { timeout: 10000 });
+      const notFound = await page.evaluate(() => ({
+        url: location.pathname,
+        path: document.querySelector('[data-notfound-path]').textContent,
+        shell: !!document.querySelector('[data-sidebar]'),
+      }));
+      check('route:404',
+        notFound.url === '/warehouse' && notFound.path === '/warehouse' && notFound.shell,
+        'an unmatched path renders the router fallback inside the shell',
+        `url=${notFound.url} rendered-path=${notFound.path}`);
+
+      // --- cmp:keyed-list --------------------------------------------------
+      // Stamp a JS expando on every row, re-sort by a different column, and
+      // require the SAME node objects back. A recreated row loses the expando,
+      // which is the failure this check exists to catch.
+      await page.click('[data-nav="/orders"]');
+      await page.waitForSelector('[data-orders-body] tr');
+      const before = await page.evaluate(() => {
+        const rows = [...document.querySelectorAll('[data-orders-body] tr')];
+        rows.forEach((tr, i) => { tr.__rowStamp = `row-${i}`; });
+        return rows.map((tr) => tr.dataset.row);
+      });
+      await page.click('[data-sort="total"]');
+      await page.waitForFunction(
+        (firstBefore) => {
+          const rows = document.querySelectorAll('[data-orders-body] tr');
+          return rows.length > 0 && rows[0].dataset.row !== firstBefore;
+        },
+        before[0],
+        { timeout: 10000 },
+      );
+      const after = await page.evaluate(() =>
+        [...document.querySelectorAll('[data-orders-body] tr')]
+          .map((tr) => ({ id: tr.dataset.row, stamp: tr.__rowStamp ?? null })));
+
+      const stampById = Object.fromEntries(before.map((id, i) => [id, `row-${i}`]));
+      const reordered = after.map((r) => r.id).join(',') !== before.join(',');
+      const sameSet = after.length === before.length
+        && after.every((r) => stampById[r.id] !== undefined);
+      const identityKept = after.every((r) => r.stamp === stampById[r.id]);
+      check('cmp:keyed-list',
+        reordered && sameSet && identityKept,
+        'sorting a keyed table moves the existing row nodes instead of rebuilding them',
+        `${before.join(' ')} -> ${after.map((r) => r.id).join(' ')} | stamps kept ${after.filter((r) => r.stamp).length}/${after.length}`);
+
+      // --- cmp:portal -------------------------------------------------------
+      await page.click('[data-nav="/"]');
+      await page.waitForSelector('[data-no-drafts]');
+      await page.click('[data-new-order]');
+      await page.waitForSelector('[data-modal]');
+      const portal = await page.evaluate(() => ({
+        inModalRoot: !!document.querySelector('#modal-root [data-modal]'),
+        inApp: !!document.querySelector('#app [data-modal]'),
+        inTopbar: !!document.querySelector('[data-topbar] [data-modal]'),
+      }));
+      await page.fill('[data-modal-customer]', 'Hedy Lamarr');
+      await page.click('[data-modal-save]');
+      await page.waitForSelector('[data-draft-list] li');
+      const draft = await page.textContent('[data-draft-list] li');
+      const modalGone = await page.locator('[data-modal]').count();
+      check('cmp:portal',
+        portal.inModalRoot && !portal.inApp && !portal.inTopbar
+          && draft.includes('Hedy Lamarr') && modalGone === 0,
+        'the dialog renders into #modal-root outside #app and still drives app state',
+        `in-modal-root=${portal.inModalRoot} in-app=${portal.inApp} draft="${draft}" closed=${modalGone === 0}`);
+
+      // --- cmp:error-boundary -----------------------------------------------
+      // The feed renders fine first. The throw arrives later, from a component
+      // CREATED by a reactive re-render, which is the only shape a run-once
+      // model can catch.
+      const feedFirst = await page.locator('[data-feed-item]').count();
+      await page.click('[data-break-feed]');
+      await page.waitForSelector('[data-feed-error]', { timeout: 10000 });
+      const caught = await page.textContent('[data-feed-error-msg]');
+      const feedGone = await page.locator('[data-feed-item]').count();
+      await page.click('[data-feed-retry]');
+      await page.waitForSelector('[data-feed-item]', { timeout: 10000 });
+      const feedBack = await page.locator('[data-feed-item]').count();
+      check('cmp:error-boundary',
+        feedFirst === 4 && feedGone === 0
+          && caught === 'Feed socket closed: upstream returned 502'
+          && feedBack === 4,
+        'a throw after a state change is caught, and reset() restores the subtree',
+        `items=${feedFirst} -> caught "${caught}" -> items=${feedBack}`);
+
+      // Two framework defects produce console noise on every run of this app,
+      // so they are named here rather than filtered silently:
+      //
+      //  - "Redirect cycle detected" on a middleware redirect. navigate() sets
+      //    isNavigating and then defers the URL commit into
+      //    document.startViewTransition. renderMatch reads isNavigating, so the
+      //    flag flip re-runs the match against the STILL-OLD url, the same
+      //    middleware returns the same target, and the duplicate detector fires
+      //    on a redirect that is not cycling. Deleting startViewTransition takes
+      //    the count from 25 to 0.
+      //  - "Transition was skipped" as an uncaught page error. navigate() awaits
+      //    the transition's .finished and swallows it, but the rejection of
+      //    .ready has no handler.
+      //
+      // Anything OUTSIDE that set, and outside this app's two deliberate
+      // throws, is a real problem and fails the run.
+      // The guard is live, not a first-load-only redirect: dropping the session
+      // re-matches the current route and bounces immediately.
+      await page.click('[data-signout]');
+      await page.waitForSelector('[data-signin]', { timeout: 10000 });
+      const afterSignOut = await page.evaluate(() => location.pathname);
+      reporter.assert(afterSignOut === '/signin',
+        'signing out re-runs the guard and bounces off the protected route',
+        `url=${afterSignOut}`);
+
+      const known = /502|metrics agent unreachable|Redirect cycle detected|Transition was skipped/;
+      const noise = diag.all.filter((l) => /Redirect cycle detected|Transition was skipped/.test(l));
+      const unexpected = diag.errors.filter((l) => !known.test(l));
+      log(`known router noise on this run: ${noise.length} message(s)`);
+      reporter.assert(unexpected.length === 0,
+        'no page errors beyond the deliberate throws and the two reported router defects',
+        unexpected.slice(0, 3).join(' | '));
+    });
+
+    log('admin-dashboard checks complete');
+  },
+};

--- a/smoke/apps/admin-dashboard/src/components/NewOrderModal.jsx
+++ b/smoke/apps/admin-dashboard/src/components/NewOrderModal.jsx
@@ -1,0 +1,50 @@
+// A dialog rendered through Portal into #modal-root, which lives outside #app
+// in index.html. The button that opens it sits in the topbar, so if the modal
+// were rendered in place it would be clipped by the topbar's stacking context
+// and its backdrop could never cover the page. That is the whole reason Portal
+// exists, and it is what the smoke check asserts: the dialog is NOT a
+// descendant of the shell.
+
+import { Portal, signal } from 'what-framework';
+import { addDraftOrder, closeNewOrder } from '../state/ui.js';
+
+export function NewOrderModal() {
+  const customer = signal('', 'modal:customer');
+
+  return (
+    <Portal target="#modal-root">
+      <div class="modal-backdrop" data-modal-backdrop onclick={closeNewOrder}>
+        <div
+          class="modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Create order"
+          data-modal
+          onclick={(e) => e.stopPropagation()}
+        >
+          <h2>Create order</h2>
+          <p class="muted">Drafts stay local to this session.</p>
+          <label class="field">
+            Customer
+            <input
+              data-modal-customer
+              placeholder="Ada Lovelace"
+              value={() => customer()}
+              oninput={(e) => customer(e.target.value)}
+            />
+          </label>
+          <div class="modal-actions">
+            <button class="ghost" data-modal-cancel onclick={closeNewOrder}>Cancel</button>
+            <button
+              class="primary"
+              data-modal-save
+              onclick={() => addDraftOrder(customer().trim() || 'Unnamed customer')}
+            >
+              Create draft
+            </button>
+          </div>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/context.js
+++ b/smoke/apps/admin-dashboard/src/context.js
@@ -1,0 +1,16 @@
+// One context carries everything the shell needs: who is signed in, the theme
+// and the way to change it, and the workspace label.
+//
+// The value is an object of ACCESSORS, not a snapshot. Provider destructures
+// `value` once (components run once), so a plain string would freeze at the
+// value it had when the provider first ran. Handing over functions keeps every
+// consumer reactive no matter how deep it sits.
+
+import { createContext } from 'what-framework';
+
+export const Workspace = createContext({
+  user: () => null,
+  theme: () => 'night',
+  toggleTheme: () => {},
+  label: () => 'no workspace',
+});

--- a/smoke/apps/admin-dashboard/src/data.js
+++ b/smoke/apps/admin-dashboard/src/data.js
@@ -1,0 +1,49 @@
+// A frozen dataset. The demo and the smoke run must see identical numbers, so
+// nothing here is random or clock-dependent: every assertion about a sorted
+// order or a total is reproducible.
+
+export const ORDERS = [
+  { id: 'NW-2041', customer: 'Ada Lovelace', email: 'ada@analytical.io', region: 'EU', total: 18400, status: 'paid', placed: '2026-07-02', items: 3 },
+  { id: 'NW-2042', customer: 'Grace Hopper', email: 'grace@cobol.dev', region: 'NA', total: 96250, status: 'paid', placed: '2026-06-28', items: 11 },
+  { id: 'NW-2043', customer: 'Alan Turing', email: 'alan@bletchley.uk', region: 'EU', total: 4100, status: 'refunded', placed: '2026-07-05', items: 1 },
+  { id: 'NW-2044', customer: 'Katherine Johnson', email: 'kj@orbital.space', region: 'NA', total: 52900, status: 'pending', placed: '2026-07-01', items: 6 },
+  { id: 'NW-2045', customer: 'Radia Perlman', email: 'radia@spanning.net', region: 'APAC', total: 133000, status: 'paid', placed: '2026-06-30', items: 24 },
+  { id: 'NW-2046', customer: 'Barbara Liskov', email: 'barbara@substitution.org', region: 'NA', total: 7350, status: 'pending', placed: '2026-07-04', items: 2 },
+  { id: 'NW-2047', customer: 'Jean Bartik', email: 'jean@eniac.mil', region: 'EU', total: 21600, status: 'paid', placed: '2026-07-03', items: 4 },
+];
+
+export const TEAM = [
+  { id: 'u-1', name: 'Ines Okafor', role: 'Owner', email: 'ines@northwind.ops', lastSeen: '2 minutes ago' },
+  { id: 'u-2', name: 'Tomas Vidal', role: 'Admin', email: 'tomas@northwind.ops', lastSeen: '1 hour ago' },
+  { id: 'u-3', name: 'Priya Raman', role: 'Support', email: 'priya@northwind.ops', lastSeen: 'Yesterday' },
+  { id: 'u-4', name: 'Otto Lindqvist', role: 'Billing', email: 'otto@northwind.ops', lastSeen: '3 days ago' },
+];
+
+/** Customers are derived from orders so the two pages can never disagree. */
+export const CUSTOMERS = Object.values(
+  ORDERS.reduce((acc, o) => {
+    acc[o.email] ??= { email: o.email, name: o.customer, region: o.region, orders: 0, lifetime: 0 };
+    acc[o.email].orders += 1;
+    acc[o.email].lifetime += o.total;
+    return acc;
+  }, {}),
+).sort((a, b) => b.lifetime - a.lifetime);
+
+export function findOrder(id) {
+  return ORDERS.find((o) => o.id === id) ?? null;
+}
+
+export function formatMoney(cents) {
+  return `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export const REVENUE = ORDERS.filter((o) => o.status !== 'refunded').reduce((n, o) => n + o.total, 0);
+export const PENDING = ORDERS.filter((o) => o.status === 'pending').length;
+
+/** Seven days of sparkline input. Objects, not numbers, so every list in this
+ *  app can carry a stable key and take the compiler's keyed path. */
+export const TRAFFIC = [
+  { day: 'Mon', value: 12 }, { day: 'Tue', value: 19 }, { day: 'Wed', value: 14 },
+  { day: 'Thu', value: 27 }, { day: 'Fri', value: 31 }, { day: 'Sat', value: 24 },
+  { day: 'Sun', value: 38 },
+];

--- a/smoke/apps/admin-dashboard/src/main.jsx
+++ b/smoke/apps/admin-dashboard/src/main.jsx
@@ -1,0 +1,42 @@
+// Entry point. Nothing here is server-rendered: index.html ships an empty #app
+// and this bundle builds the entire UI in the browser.
+
+import './styles.css';
+
+import { mount } from 'what-framework';
+import { Router, beforeNavigate } from 'what-router';
+
+import { Workspace } from './context.js';
+import { routes } from './routes.jsx';
+import { Shell } from './shell/Shell.jsx';
+import { NotFound } from './pages/NotFound.jsx';
+import { session } from './state/session.js';
+import { theme, toggleTheme } from './state/theme.js';
+import { computeRollup } from './state/reports.js';
+
+// Preload the reports rollup before the URL commits. An awaited guard is the
+// only thing that gives a destination's `loading:` component a window to be
+// seen in: navigate() holds isNavigating true for as long as this hook runs.
+beforeNavigate(async (to) => {
+  if (to.split('?')[0].startsWith('/reports')) await computeRollup();
+  return true;
+});
+
+function App() {
+  // Accessors, not values. Provider destructures `value` once, so a snapshot
+  // here would freeze the whole shell at whatever was true on first render.
+  const workspace = {
+    user: session,
+    theme,
+    toggleTheme,
+    label: () => (session() ? `${session().name.split(' ')[0]}'s workspace` : 'no workspace'),
+  };
+
+  return (
+    <Workspace.Provider value={workspace}>
+      <Router routes={routes} fallback={NotFound} globalLayout={Shell} />
+    </Workspace.Provider>
+  );
+}
+
+mount(<App />, '#app');

--- a/smoke/apps/admin-dashboard/src/nav.js
+++ b/smoke/apps/admin-dashboard/src/nav.js
@@ -1,0 +1,46 @@
+// Sidebar structure and breadcrumb labels, shared by the shell and the
+// settings sub-layout. Kept out of routes.jsx so neither has to import the
+// other.
+
+export const NAV = [
+  {
+    label: 'Workspace',
+    items: [
+      { href: '/', label: 'Overview' },
+      { href: '/orders', label: 'Orders' },
+      { href: '/customers', label: 'Customers' },
+      { href: '/reports', label: 'Reports', tag: 'slow' },
+    ],
+  },
+  {
+    label: 'Settings',
+    items: [
+      { href: '/settings/profile', label: 'Profile' },
+      { href: '/settings/team', label: 'Team' },
+    ],
+  },
+  {
+    label: 'Developer',
+    items: [
+      { href: '/diagnostics', label: 'Diagnostics', tag: 'throws' },
+      { href: '/warehouse', label: 'Warehouse', tag: '404' },
+    ],
+  },
+];
+
+const LABELS = {
+  orders: 'Orders',
+  customers: 'Customers',
+  reports: 'Reports',
+  settings: 'Settings',
+  profile: 'Profile',
+  team: 'Team',
+  diagnostics: 'Diagnostics',
+  signin: 'Sign in',
+};
+
+export function crumbFor(path) {
+  if (path === '/') return ['Overview'];
+  const segments = path.split('/').filter(Boolean);
+  return segments.map((s) => LABELS[s] ?? s);
+}

--- a/smoke/apps/admin-dashboard/src/pages/Customers.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/Customers.jsx
@@ -1,0 +1,61 @@
+// Customers, with a client-side filter over the derived customer list.
+
+import { computed, signal } from 'what-framework';
+
+import { CUSTOMERS, formatMoney } from '../data.js';
+
+export default function Customers() {
+  const term = signal('', 'customers:term');
+
+  const shown = computed(() => {
+    const q = term().trim().toLowerCase();
+    if (!q) return CUSTOMERS;
+    return CUSTOMERS.filter((c) => `${c.name} ${c.email} ${c.region}`.toLowerCase().includes(q));
+  });
+
+  return (
+    <>
+      <div class="page-head">
+        <div>
+          <h1>Customers</h1>
+          <p>Ranked by lifetime value.</p>
+        </div>
+        <div class="page-head-actions">
+          <input
+            data-customer-filter
+            placeholder="Filter customers"
+            value={() => term()}
+            oninput={(e) => term(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Customer</th>
+              <th>Region</th>
+              <th class="num">Orders</th>
+              <th class="num">Lifetime</th>
+            </tr>
+          </thead>
+          <tbody data-customer-body>
+            {() => shown().map((c) => (
+              <tr key={c.email} data-customer={c.email}>
+                <td>
+                  <div>{c.name}</div>
+                  <div class="muted mono">{c.email}</div>
+                </td>
+                <td>{c.region}</td>
+                <td class="num">{String(c.orders)}</td>
+                <td class="num">{formatMoney(c.lifetime)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {() => (shown().length === 0 ? <p class="muted" data-customers-empty>Nothing matches that filter.</p> : null)}
+      </div>
+    </>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/Diagnostics.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/Diagnostics.jsx
@@ -1,0 +1,24 @@
+// Diagnostics: the route that throws on purpose.
+//
+// It stands in for a page that dies on a bad payload from an integration. The
+// route declares `error: RouteCrash`, so the Router wraps the page in an
+// ErrorBoundary whose fallback is that component. The shell stays mounted and
+// the rest of the app keeps navigating, which is the whole point of a
+// per-route error component.
+
+export function RouteCrash({ error, reset }) {
+  return (
+    <div class="notice" data-route-error>
+      <strong>Diagnostics could not load</strong>
+      <p class="muted" data-route-error-msg>{error.message}</p>
+      <p><code>route /diagnostics · handled by the route error component</code></p>
+      <button data-route-error-retry onclick={reset}>Try again</button>
+    </div>
+  );
+}
+
+export default function Diagnostics() {
+  // Deliberate: reading the saved probe definition fails because the metrics
+  // agent has not published a schema yet.
+  throw new Error('Diagnostics probe failed: metrics agent unreachable');
+}

--- a/smoke/apps/admin-dashboard/src/pages/NotFound.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/NotFound.jsx
@@ -1,0 +1,16 @@
+// The Router's `fallback`, rendered for any path the table does not match.
+// The sidebar keeps a deliberately dead "Warehouse" link so this is reachable
+// by clicking rather than only by typing a URL.
+
+import { Link } from 'what-router';
+
+export function NotFound() {
+  return (
+    <div class="empty" data-notfound>
+      <h1>404</h1>
+      <p class="muted">That page is not part of this workspace.</p>
+      <p class="mono muted" data-notfound-path>{() => location.pathname}</p>
+      <Link href="/" class="nav-link">Back to overview</Link>
+    </div>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/OrderDetail.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/OrderDetail.jsx
@@ -1,0 +1,65 @@
+// Order detail.
+//
+// Params arrive as a PROP from the router (h(component, { params, query, route
+// })), not via useParams(). Both work, but reading the params signal inside a
+// component body would subscribe the router's own reactive region to a signal
+// the region itself writes on every match, and matchRoute hands back a fresh
+// object each time.
+
+import { Link, navigate } from 'what-router';
+
+import { findOrder, formatMoney } from '../data.js';
+
+export default function OrderDetail(props) {
+  const id = props.params.id;
+  const order = findOrder(id);
+
+  if (!order) {
+    return (
+      <div class="notice" data-order-missing>
+        <strong>No order {id}</strong>
+        <p class="muted">It may have been archived.</p>
+        <Link href="/orders">Back to orders</Link>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div class="page-head">
+        <div>
+          <h1 data-order-id>{order.id}</h1>
+          <p>{order.customer} · {order.email}</p>
+        </div>
+        <div class="page-head-actions">
+          <button class="ghost" data-back onclick={() => navigate('/orders')}>Back to orders</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <dl class="detail-grid">
+          <div>
+            <dt>Total</dt>
+            <dd data-order-total>{formatMoney(order.total)}</dd>
+          </div>
+          <div>
+            <dt>Status</dt>
+            <dd><span class={`pill ${order.status}`}>{order.status}</span></dd>
+          </div>
+          <div>
+            <dt>Region</dt>
+            <dd>{order.region}</dd>
+          </div>
+          <div>
+            <dt>Line items</dt>
+            <dd>{String(order.items)}</dd>
+          </div>
+          <div>
+            <dt>Placed</dt>
+            <dd>{order.placed}</dd>
+          </div>
+        </dl>
+      </div>
+    </>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/Orders.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/Orders.jsx
@@ -1,0 +1,95 @@
+// Orders.
+//
+// The sortable table is the keyed-reconciliation proof. `.map()` returning JSX
+// with a `key` prop is lowered by what-compiler to mapArray({ key, raw: true }),
+// which MOVES existing rows on a reorder instead of tearing the list down. The
+// smoke check stamps a JS property on each <tr>, sorts by a different column,
+// and asserts the same node objects came back in a new order.
+//
+// This only works because the app is compiled. The runtime h() path never reads
+// vnode.key (smoke/FINDINGS.md A), so the same table in a buildless app would
+// recreate every row.
+
+import { computed, signal } from 'what-framework';
+import { navigate } from 'what-router';
+
+import { ORDERS, formatMoney } from '../data.js';
+
+const COLUMNS = [
+  { key: 'id', label: 'Order', numeric: false },
+  { key: 'customer', label: 'Customer', numeric: false },
+  { key: 'region', label: 'Region', numeric: false },
+  { key: 'status', label: 'Status', numeric: false },
+  { key: 'placed', label: 'Placed', numeric: false },
+  { key: 'total', label: 'Total', numeric: true },
+];
+
+export default function Orders() {
+  const sortKey = signal('id', 'orders:sortKey');
+  const sortDir = signal('asc', 'orders:sortDir');
+
+  const sorted = computed(() => {
+    const key = sortKey();
+    const dir = sortDir() === 'asc' ? 1 : -1;
+    return [...ORDERS].sort((a, b) => {
+      const av = a[key];
+      const bv = b[key];
+      if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * dir;
+      return String(av).localeCompare(String(bv)) * dir;
+    });
+  });
+
+  function sortBy(key) {
+    if (sortKey() === key) sortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else {
+      sortKey(key);
+      // Money reads best largest-first; everything else reads best A to Z.
+      sortDir(key === 'total' ? 'desc' : 'asc');
+    }
+  }
+
+  const ariaSort = (key) => () => {
+    if (sortKey() !== key) return 'none';
+    return sortDir() === 'asc' ? 'ascending' : 'descending';
+  };
+
+  return (
+    <>
+      <div class="page-head">
+        <div>
+          <h1>Orders</h1>
+          <p>Click a column to re-sort, click a row to open it.</p>
+        </div>
+      </div>
+
+      <div class="card">
+        <table data-orders-table>
+          <thead>
+            <tr>
+              {COLUMNS.map((col) => (
+                <th key={col.key} class={col.numeric ? 'num' : ''} aria-sort={ariaSort(col.key)}>
+                  <button data-sort={col.key} onclick={() => sortBy(col.key)}>
+                    {col.label}
+                    <span class="mono">{() => (sortKey() === col.key ? (sortDir() === 'asc' ? '▲' : '▼') : '')}</span>
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody data-orders-body>
+            {() => sorted().map((o) => (
+              <tr key={o.id} data-row={o.id} onclick={() => navigate(`/orders/${o.id}`)}>
+                <td class="mono">{o.id}</td>
+                <td>{o.customer}</td>
+                <td>{o.region}</td>
+                <td><span class={`pill ${o.status}`}>{o.status}</span></td>
+                <td class="muted">{o.placed}</td>
+                <td class="num">{formatMoney(o.total)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/Overview.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/Overview.jsx
@@ -1,0 +1,142 @@
+// Overview.
+//
+// The "Live feed" card is the ErrorBoundary proof. A component that reads a
+// signal in its body and throws would never fire the boundary: components run
+// ONCE, so flipping the signal never re-executes it. The throw has to come from
+// a component CREATED during a reactive re-render, which is why the boundary's
+// child is a thunk that picks between two components.
+
+import { ErrorBoundary, signal } from 'what-framework';
+import { Link, navigate } from 'what-router';
+
+import { CUSTOMERS, ORDERS, PENDING, REVENUE, TRAFFIC, formatMoney } from '../data.js';
+import { draftOrders } from '../state/ui.js';
+
+const feedBroken = signal(false, 'overview:feedBroken');
+
+const FEED = [
+  { id: 'f-1', at: '09:41', text: 'NW-2047 captured — $216.00' },
+  { id: 'f-2', at: '09:38', text: 'Radia Perlman upgraded to Scale' },
+  { id: 'f-3', at: '09:31', text: 'Refund issued on NW-2043' },
+  { id: 'f-4', at: '09:12', text: 'Webhook delivery recovered (eu-west)' },
+];
+
+function LiveFeed() {
+  return (
+    <ul class="feed" data-feed>
+      {FEED.map((e) => (
+        <li key={e.id} data-feed-item={e.id}>
+          <span class="mono muted">{e.at}</span> {e.text}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// Stands in for a component that blows up on a bad payload once the socket has
+// already been rendering fine for a while.
+function BrokenFeed() {
+  throw new Error('Feed socket closed: upstream returned 502');
+}
+
+// Props are read off `props`, not destructured in the parameter list. The
+// compiler classifies every destructured parameter name as a signal, so
+// `data-stat={label}` from a destructured `{ label }` compiles to
+// `setAttr(el, 'data-stat', label())` and throws "label is not a function" at
+// runtime, while the same identifier used as a CHILD compiles to `() => label`
+// and does not. Reported with the run; this is the workaround.
+function Stat(props) {
+  return (
+    <div class="card">
+      <div class="stat-label">{props.label}</div>
+      <div class="stat-value" data-stat={props.label}>{props.value}</div>
+      <div class={`stat-delta ${props.direction}`}>{props.delta}</div>
+    </div>
+  );
+}
+
+export default function Overview() {
+  const peak = Math.max(...TRAFFIC.map((d) => d.value));
+
+  return (
+    <>
+      <div class="page-head">
+        <div>
+          <h1>Overview</h1>
+          <p>Seven day rolling window across every region.</p>
+        </div>
+        <div class="page-head-actions">
+          <button class="primary" data-goto-orders onclick={() => navigate('/orders')}>
+            Review orders
+          </button>
+        </div>
+      </div>
+
+      <div class="stat-grid">
+        <Stat label="Revenue" value={formatMoney(REVENUE)} delta="+12.4% vs last week" direction="up" />
+        <Stat label="Orders" value={String(ORDERS.length)} delta="+3 today" direction="up" />
+        <Stat label="Customers" value={String(CUSTOMERS.length)} delta="+1 this week" direction="up" />
+        <Stat label="Awaiting capture" value={String(PENDING)} delta="2 over 24h" direction="down" />
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <h2>Sessions</h2>
+          <span class="muted mono">peak {peak}k</span>
+        </div>
+        <div class="spark" role="img" aria-label="Seven day session volume">
+          {TRAFFIC.map((d) => (
+            <span key={d.day} title={`${d.day}: ${d.value}k`} style={`height:${(d.value / peak) * 100}%`} />
+          ))}
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <h2>Live feed</h2>
+          <button class="danger" data-break-feed onclick={() => feedBroken(true)}>
+            Simulate socket failure
+          </button>
+        </div>
+
+        <ErrorBoundary
+          fallback={({ error, reset }) => (
+            <div class="notice" data-feed-error>
+              <strong>Live feed unavailable</strong>
+              <p class="muted" data-feed-error-msg>{error.message}</p>
+              <button
+                data-feed-retry
+                onclick={() => {
+                  feedBroken(false);
+                  reset();
+                }}
+              >
+                Reconnect
+              </button>
+            </div>
+          )}
+        >
+          {() => (feedBroken() ? <BrokenFeed /> : <LiveFeed />)}
+        </ErrorBoundary>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <h2>Session drafts</h2>
+          <Link href="/orders" class="muted">All orders</Link>
+        </div>
+        {() =>
+          draftOrders().length === 0
+            ? <p class="muted" data-no-drafts>No drafts yet. Use "New order" in the topbar.</p>
+            : (
+              <ul data-draft-list>
+                {draftOrders().map((d) => (
+                  <li key={d.id} data-draft={d.id}>{d.id} · {d.customer}</li>
+                ))}
+              </ul>
+            )
+        }
+      </div>
+    </>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/Profile.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/Profile.jsx
@@ -1,0 +1,40 @@
+// Profile reads the session and theme MODULES directly.
+//
+// The natural thing would be useContext(Workspace), the way the topbar badge
+// does it. It does not work here, and the reason is a framework defect rather
+// than a choice: on the compiled path, render.js's insert() creates its
+// reactive region without capturing the owning component, so anything the
+// region builds on a RE-RUN gets parentCtx = null. Route pages are exactly
+// that, so useContext falls through to the context default from the first
+// navigation onwards and this page would render "--" forever. dom.js's
+// equivalent branch captures and re-pushes the owner; render.js was never
+// given the same fix. Repro and detail in the run report.
+
+import { session } from '../state/session.js';
+import { theme } from '../state/theme.js';
+
+export default function Profile() {
+  return (
+    <div class="card">
+      <div class="card-head"><h2>Your profile</h2></div>
+      <dl class="detail-grid">
+        <div>
+          <dt>Name</dt>
+          <dd data-profile-name>{() => session()?.name ?? '--'}</dd>
+        </div>
+        <div>
+          <dt>Email</dt>
+          <dd class="mono" data-profile-email>{() => session()?.email ?? '--'}</dd>
+        </div>
+        <div>
+          <dt>Role</dt>
+          <dd>{() => session()?.role ?? '--'}</dd>
+        </div>
+        <div>
+          <dt>Theme</dt>
+          <dd data-profile-theme>{() => theme()}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/Reports.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/Reports.jsx
@@ -1,0 +1,64 @@
+// Reports: the slow route.
+//
+// ReportsSkeleton is wired as the route's `loading:` component. The router shows
+// it while a navigation is IN FLIGHT, and main.jsx holds that window open with
+// an async beforeNavigate hook that awaits computeRollup(). Without that hook
+// the loading arm is unreachable in practice: isNavigating flips true and false
+// inside one synchronous block and effects flush on a microtask, so no frame
+// ever paints the skeleton.
+
+import { rollup, ROLLUP_MS } from '../state/reports.js';
+import { formatMoney } from '../data.js';
+
+export function ReportsSkeleton() {
+  return (
+    <div class="card" data-reports-loading>
+      <div class="card-head">
+        <h2>Recomputing regional rollup</h2>
+        <span class="muted mono">~{String(ROLLUP_MS)}ms</span>
+      </div>
+      <div class="skeleton-row" style="width:82%" />
+      <div class="skeleton-row" style="width:64%" />
+      <div class="skeleton-row" style="width:73%" />
+      <div class="skeleton-row" style="width:48%" />
+    </div>
+  );
+}
+
+export default function Reports() {
+  return (
+    <>
+      <div class="page-head">
+        <div>
+          <h1>Reports</h1>
+          <p>Regional rollup, recomputed on every visit.</p>
+        </div>
+      </div>
+
+      <div class="card" data-reports>
+        <div class="card-head">
+          <h2>Revenue by region</h2>
+          <span class="muted mono" data-report-stamp>{() => `computed ${rollup()?.computedAt ?? '--'}`}</span>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Region</th>
+              <th class="num">Orders</th>
+              <th class="num">Revenue</th>
+            </tr>
+          </thead>
+          <tbody data-report-body>
+            {() => (rollup()?.rows ?? []).map((r) => (
+              <tr key={r.region} data-region={r.region}>
+                <td>{r.region}</td>
+                <td class="num">{String(r.orders)}</td>
+                <td class="num">{formatMoney(r.revenue)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/SettingsLayout.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/SettingsLayout.jsx
@@ -1,0 +1,29 @@
+// The nested layout.
+//
+// Attached with nestedRoutes('/settings', [...], { layout: SettingsLayout }), so
+// the router wraps every /settings/* page in it and hands the page over as
+// props.children. It sits INSIDE the shell's outlet: the DOM nesting the smoke
+// check asserts is [data-shell] > [data-outlet] > [data-settings] > the page.
+
+import { Link } from 'what-router';
+
+export function SettingsLayout(props) {
+  return (
+    <div data-settings>
+      <div class="page-head">
+        <div>
+          <h1>Settings</h1>
+          <p>Workspace configuration for Northwind Ops.</p>
+        </div>
+      </div>
+
+      <div class="settings-layout">
+        <nav class="settings-nav">
+          <Link href="/settings/profile" prefetch={false} data-settings-nav="profile">Profile</Link>
+          <Link href="/settings/team" prefetch={false} data-settings-nav="team">Team</Link>
+        </nav>
+        <div data-settings-page>{props.children}</div>
+      </div>
+    </div>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/SignIn.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/SignIn.jsx
@@ -1,0 +1,51 @@
+// The gate every protected route redirects to.
+//
+// `next` comes from the query PROP the router passes in, not from useSearch():
+// route.query is a signal the router writes on every match, so reading it in a
+// component body would make the router's own reactive region depend on it.
+
+import { signal } from 'what-framework';
+import { navigate } from 'what-router';
+
+import { signIn } from '../state/session.js';
+
+export default function SignIn(props) {
+  const name = signal('Ines Okafor', 'signin:name');
+  const next = props.query?.next || '/';
+
+  function submit(e) {
+    e.preventDefault();
+    signIn(name());
+    // Programmatic navigation: the form has no href to follow.
+    navigate(next, { replace: true });
+  }
+
+  return (
+    <div class="signin-wrap">
+      <form class="signin" data-signin onsubmit={submit}>
+        <div class="brand">
+          <span class="brand-mark">NW</span>
+          <span>
+            <div class="brand-name">Northwind Ops</div>
+            <div class="brand-sub">Operations console</div>
+          </span>
+        </div>
+        <h1>Sign in</h1>
+        <p class="hint" data-signin-next>
+          {next === '/' ? 'Pick a name and continue.' : `You will be sent to ${next}.`}
+        </p>
+        <label class="field">
+          Operator name
+          <input
+            data-signin-name
+            autocomplete="name"
+            value={() => name()}
+            oninput={(e) => name(e.target.value)}
+          />
+        </label>
+        <button class="primary" type="submit" data-signin-submit>Continue</button>
+        <p class="hint">Demo only. Nothing is sent anywhere and a reload signs you out.</p>
+      </form>
+    </div>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/pages/Team.jsx
+++ b/smoke/apps/admin-dashboard/src/pages/Team.jsx
@@ -1,0 +1,28 @@
+// Team roster.
+
+import { TEAM } from '../data.js';
+
+export default function Team() {
+  return (
+    <div class="card">
+      <div class="card-head"><h2>Team</h2></div>
+      <table>
+        <thead>
+          <tr><th>Member</th><th>Role</th><th>Last seen</th></tr>
+        </thead>
+        <tbody data-team-body>
+          {TEAM.map((m) => (
+            <tr key={m.id} data-member={m.id}>
+              <td>
+                <div>{m.name}</div>
+                <div class="muted mono">{m.email}</div>
+              </td>
+              <td>{m.role}</td>
+              <td class="muted">{m.lastSeen}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/routes.jsx
+++ b/smoke/apps/admin-dashboard/src/routes.jsx
@@ -1,0 +1,42 @@
+// The route table.
+//
+// Middleware is SYNC by contract: the Router inspects the return value rather
+// than awaiting it. Returning a string redirects, which is how the sign-in gate
+// works, and reading session() here also subscribes the router's reactive region
+// to it, so signing out re-matches and bounces you to /signin immediately.
+
+import { nestedRoutes } from 'what-router';
+
+import { session } from './state/session.js';
+
+import Overview from './pages/Overview.jsx';
+import Orders from './pages/Orders.jsx';
+import OrderDetail from './pages/OrderDetail.jsx';
+import Customers from './pages/Customers.jsx';
+import Reports, { ReportsSkeleton } from './pages/Reports.jsx';
+import Diagnostics, { RouteCrash } from './pages/Diagnostics.jsx';
+import { SettingsLayout } from './pages/SettingsLayout.jsx';
+import Profile from './pages/Profile.jsx';
+import Team from './pages/Team.jsx';
+import SignIn from './pages/SignIn.jsx';
+
+const requireSession = ({ path }) =>
+  (session() ? undefined : `/signin?next=${encodeURIComponent(path)}`);
+
+const protect = (list) => list.map((r) => ({ ...r, middleware: [requireSession, ...(r.middleware ?? [])] }));
+
+export const routes = [
+  ...protect([
+    { path: '/', component: Overview },
+    { path: '/orders', component: Orders },
+    { path: '/orders/:id', component: OrderDetail },
+    { path: '/customers', component: Customers },
+    { path: '/reports', component: Reports, loading: ReportsSkeleton },
+    { path: '/diagnostics', component: Diagnostics, error: RouteCrash },
+    ...nestedRoutes('/settings', [
+      { path: '/profile', component: Profile },
+      { path: '/team', component: Team },
+    ], { layout: SettingsLayout }),
+  ]),
+  { path: '/signin', component: SignIn },
+];

--- a/smoke/apps/admin-dashboard/src/shell/Shell.jsx
+++ b/smoke/apps/admin-dashboard/src/shell/Shell.jsx
@@ -1,0 +1,94 @@
+// The persistent shell.
+//
+// Passed to <Router globalLayout={Shell}>, so it is instantiated ONCE and the
+// matched page arrives as props.children, which is the router's reactive
+// content thunk. Navigating swaps only that region: the sidebar, the topbar and
+// the portal host below never re-mount. The smoke check proves it by stamping a
+// JS property on the sidebar element and finding it still there after three
+// navigations.
+
+import { useContext } from 'what-framework';
+import { Link, route } from 'what-router';
+
+import { Workspace } from '../context.js';
+import { NAV, crumbFor } from '../nav.js';
+import { signOut } from '../state/session.js';
+import { newOrderOpen, openNewOrder } from '../state/ui.js';
+import { NewOrderModal } from '../components/NewOrderModal.jsx';
+import { UserMenu } from './UserMenu.jsx';
+
+function Sidebar() {
+  return (
+    <aside class="sidebar" data-sidebar>
+      <div class="brand">
+        <span class="brand-mark">NW</span>
+        <span>
+          <div class="brand-name">Northwind</div>
+          <div class="brand-sub">Operations console</div>
+        </span>
+      </div>
+
+      {NAV.map((group) => (
+        <nav class="nav-group" key={group.label}>
+          <div class="nav-label">{group.label}</div>
+          {group.items.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              class="nav-link"
+              prefetch={false}
+              data-nav={item.href}
+            >
+              <span class="dot" />
+              {item.label}
+              {item.tag ? <span class="nav-tag">{item.tag}</span> : null}
+            </Link>
+          ))}
+        </nav>
+      ))}
+
+      <div class="sidebar-foot">
+        <button class="ghost" data-signout onclick={signOut}>Sign out</button>
+      </div>
+    </aside>
+  );
+}
+
+function Topbar() {
+  const ws = useContext(Workspace);
+
+  return (
+    <header class="topbar" data-topbar>
+      <div class="crumbs" data-crumbs>
+        <span>{() => crumbFor(route.path).slice(0, -1).map((c) => `${c} / `).join('')}</span>
+        <strong data-crumb-leaf>{() => crumbFor(route.path).at(-1)}</strong>
+      </div>
+      <div class="topbar-spacer" />
+      <button class="ghost" data-new-order onclick={openNewOrder}>New order</button>
+      <button
+        class="icon ghost"
+        data-theme-toggle
+        aria-label="Toggle colour theme"
+        onclick={ws.toggleTheme}
+      >
+        {() => (ws.theme() === 'night' ? 'Day' : 'Night')}
+      </button>
+      <UserMenu />
+    </header>
+  );
+}
+
+export function Shell(props) {
+  const ws = useContext(Workspace);
+
+  return (
+    <div class={() => `shell${ws.user() ? '' : ' shell-bare'}`} data-shell>
+      <Sidebar />
+      <div class="main">
+        <Topbar />
+        <main class="content" data-outlet>{props.children}</main>
+      </div>
+      {() => (newOrderOpen() ? <NewOrderModal /> : null)}
+    </div>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/shell/UserMenu.jsx
+++ b/smoke/apps/admin-dashboard/src/shell/UserMenu.jsx
@@ -1,0 +1,38 @@
+// The deep context consumer.
+//
+// Nothing in this file imports the session or theme modules. Everything it
+// renders arrives through <Workspace.Provider>, four component levels up
+// (App -> Router -> Shell -> Topbar -> UserMenu -> UserBadge). If context stops
+// reaching this depth, the badge falls back to the context DEFAULT and reads
+// "no workspace", which is exactly what the smoke check looks for.
+
+import { useContext } from 'what-framework';
+import { Workspace } from '../context.js';
+
+function initials(name) {
+  return name.split(/\s+/).slice(0, 2).map((w) => w[0] || '').join('').toUpperCase();
+}
+
+function UserBadge() {
+  const ws = useContext(Workspace);
+  return (
+    <div class="user-badge" data-user-badge>
+      <span class="avatar" aria-hidden="true">{() => initials(ws.user()?.name ?? '?')}</span>
+      <span>
+        <span class="user-badge-name" data-badge-name>{() => ws.user()?.name ?? 'Signed out'}</span>
+        <br />
+        <span class="user-badge-meta" data-badge-meta>
+          {() => `${ws.label()} · ${ws.theme()} theme`}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export function UserMenu() {
+  return (
+    <div class="user-menu">
+      <UserBadge />
+    </div>
+  );
+}

--- a/smoke/apps/admin-dashboard/src/state/reports.js
+++ b/smoke/apps/admin-dashboard/src/state/reports.js
@@ -1,0 +1,32 @@
+// The reports rollup is recomputed on every visit, which is what makes
+// /reports a genuinely slow route.
+//
+// The latency lives here rather than inside the page because the router can
+// only show a route's `loading:` component while a navigation is IN FLIGHT.
+// A page that renders instantly and then fetches would never reach that arm:
+// isNavigating flips true and false inside one synchronous block, and effects
+// flush on a microtask, so nothing ever paints. main.jsx holds the navigation
+// open with an async beforeNavigate hook that awaits this.
+
+import { signal } from 'what-framework';
+import { ORDERS } from '../data.js';
+
+export const ROLLUP_MS = 700;
+
+export const rollup = signal(null, 'reports:rollup');
+
+export function computeRollup() {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const byRegion = {};
+      for (const o of ORDERS) {
+        byRegion[o.region] ??= { region: o.region, orders: 0, revenue: 0 };
+        byRegion[o.region].orders += 1;
+        if (o.status !== 'refunded') byRegion[o.region].revenue += o.total;
+      }
+      const rows = Object.values(byRegion).sort((a, b) => b.revenue - a.revenue);
+      rollup({ rows, computedAt: new Date().toISOString().slice(11, 19) });
+      resolve(rows);
+    }, ROLLUP_MS);
+  });
+}

--- a/smoke/apps/admin-dashboard/src/state/session.js
+++ b/smoke/apps/admin-dashboard/src/state/session.js
@@ -1,0 +1,18 @@
+// The sign-in gate.
+//
+// Deliberately in memory only. A reload signs you out, which keeps the guard
+// observable on every fresh page load instead of only the first one ever.
+
+import { signal } from 'what-framework';
+
+export const session = signal(null, 'session');
+
+export function signIn(name) {
+  const clean = String(name || '').trim() || 'Operator';
+  const handle = clean.toLowerCase().replace(/[^a-z0-9]+/g, '.').replace(/^\.|\.$/g, '');
+  session({ name: clean, email: `${handle}@northwind.ops`, role: 'Admin' });
+}
+
+export function signOut() {
+  session(null);
+}

--- a/smoke/apps/admin-dashboard/src/state/theme.js
+++ b/smoke/apps/admin-dashboard/src/state/theme.js
@@ -1,0 +1,17 @@
+// Theme is a module signal that mirrors itself onto <html data-theme>, so the
+// CSS variables in styles.css switch palettes. Components never read this
+// module directly: the shell hands it down through context.
+
+import { signal, effect } from 'what-framework';
+
+export const theme = signal('night', 'theme');
+
+export function toggleTheme() {
+  theme((t) => (t === 'night' ? 'day' : 'night'));
+}
+
+if (typeof document !== 'undefined') {
+  effect(() => {
+    document.documentElement.dataset.theme = theme();
+  });
+}

--- a/smoke/apps/admin-dashboard/src/state/ui.js
+++ b/smoke/apps/admin-dashboard/src/state/ui.js
@@ -1,0 +1,17 @@
+// Shell-level UI state. It lives in a module rather than in the Shell
+// component so the topbar can open a dialog the shell renders, without either
+// of them knowing about the other.
+
+import { signal } from 'what-framework';
+
+export const newOrderOpen = signal(false, 'ui:newOrderOpen');
+export const draftOrders = signal([], 'ui:draftOrders');
+
+export function openNewOrder() { newOrderOpen(true); }
+export function closeNewOrder() { newOrderOpen(false); }
+
+export function addDraftOrder(customer) {
+  const n = draftOrders().length + 1;
+  draftOrders((list) => [...list, { id: `NW-DRAFT-${n}`, customer }]);
+  newOrderOpen(false);
+}

--- a/smoke/apps/admin-dashboard/src/styles.css
+++ b/smoke/apps/admin-dashboard/src/styles.css
@@ -1,0 +1,298 @@
+/* Northwind Ops.
+ *
+ * Two palettes, switched by data-theme on <html>. The theme value itself is
+ * delivered through context, so the toggle in the topbar and the deep user
+ * badge are reading the same provided object rather than importing a store. */
+
+:root {
+  --radius: 10px;
+  --sidebar: 244px;
+  --font: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --mono: ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace;
+}
+
+[data-theme='night'] {
+  --bg: #0b0d12;
+  --panel: #12151d;
+  --panel-2: #171b25;
+  --line: #232838;
+  --text: #e8ebf2;
+  --muted: #8a93a8;
+  --accent: #6ea8fe;
+  --accent-soft: rgba(110, 168, 254, 0.14);
+  --good: #4ade80;
+  --warn: #fbbf24;
+  --bad: #f87171;
+  --shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+[data-theme='day'] {
+  --bg: #f5f6f9;
+  --panel: #ffffff;
+  --panel-2: #f0f2f7;
+  --line: #e0e4ed;
+  --text: #131722;
+  --muted: #66708a;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.1);
+  --good: #15803d;
+  --warn: #b45309;
+  --bad: #b91c1c;
+  --shadow: 0 14px 34px rgba(20, 28, 55, 0.12);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; text-decoration: none; }
+h1, h2, h3 { margin: 0; letter-spacing: -0.02em; }
+h1 { font-size: 22px; }
+h2 { font-size: 16px; }
+.muted { color: var(--muted); }
+.mono { font-family: var(--mono); font-size: 12px; }
+
+/* --- Shell --------------------------------------------------------------- */
+
+.shell {
+  display: grid;
+  grid-template-columns: var(--sidebar) 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: var(--panel);
+  border-right: 1px solid var(--line);
+  padding: 18px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.brand { display: flex; align-items: center; gap: 10px; padding: 0 8px; }
+.brand-mark {
+  width: 30px; height: 30px; border-radius: 9px;
+  background: linear-gradient(135deg, var(--accent), #a78bfa);
+  display: grid; place-items: center;
+  font-weight: 700; color: #06070c; font-size: 13px;
+}
+.brand-name { font-weight: 650; letter-spacing: -0.01em; }
+.brand-sub { font-size: 11px; color: var(--muted); }
+
+.nav-group { display: flex; flex-direction: column; gap: 2px; }
+.nav-label {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.09em;
+  color: var(--muted); padding: 0 8px 6px;
+}
+.nav-link {
+  display: flex; align-items: center; gap: 9px;
+  padding: 8px 10px; border-radius: 8px;
+  color: var(--muted); font-weight: 500;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.nav-link:hover { background: var(--panel-2); color: var(--text); }
+.nav-link.active { background: var(--accent-soft); color: var(--accent); }
+.nav-link .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor; opacity: 0.55;
+}
+.nav-tag {
+  margin-left: auto; font-size: 10px; color: var(--muted);
+  border: 1px solid var(--line); border-radius: 5px; padding: 0 5px;
+}
+
+.sidebar-foot { margin-top: auto; font-size: 11px; color: var(--muted); padding: 0 8px; }
+
+/* Signed out. The chrome is hidden with a reactive CLASS rather than by
+ * swapping the shell's structure: the shell is the router's globalLayout and is
+ * meant to be instantiated exactly once, so rebuilding it on every sign-in
+ * would defeat the thing it exists to demonstrate. */
+.shell-bare { grid-template-columns: 1fr; }
+.shell-bare .sidebar, .shell-bare .topbar { display: none; }
+.shell-bare .content { padding: 0; }
+
+/* --- Topbar -------------------------------------------------------------- */
+
+.main { display: flex; flex-direction: column; min-width: 0; }
+
+.topbar {
+  display: flex; align-items: center; gap: 14px;
+  padding: 14px 26px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: blur(8px);
+  position: sticky; top: 0; z-index: 20;
+}
+.crumbs { font-size: 13px; color: var(--muted); display: flex; gap: 7px; align-items: center; }
+.crumbs strong { color: var(--text); font-weight: 600; }
+.topbar-spacer { flex: 1; }
+
+.user-badge {
+  display: flex; align-items: center; gap: 9px;
+  padding: 5px 11px 5px 5px;
+  border: 1px solid var(--line); border-radius: 999px;
+  background: var(--panel);
+}
+.avatar {
+  width: 26px; height: 26px; border-radius: 50%;
+  background: var(--accent-soft); color: var(--accent);
+  display: grid; place-items: center; font-weight: 700; font-size: 11px;
+}
+.user-badge-name { font-weight: 600; font-size: 13px; line-height: 1.1; }
+.user-badge-meta { font-size: 10.5px; color: var(--muted); line-height: 1.1; }
+
+/* --- Buttons ------------------------------------------------------------- */
+
+button {
+  font: inherit; cursor: pointer;
+  border: 1px solid var(--line); background: var(--panel);
+  color: var(--text); border-radius: 8px; padding: 7px 13px;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+button:hover { border-color: var(--accent); }
+button.primary { background: var(--accent); border-color: var(--accent); color: #06070c; font-weight: 600; }
+button.ghost { background: transparent; }
+button.danger { border-color: var(--bad); color: var(--bad); background: transparent; }
+button.icon { padding: 6px 9px; }
+
+/* --- Content ------------------------------------------------------------- */
+
+.content { padding: 26px; display: flex; flex-direction: column; gap: 20px; }
+.page-head { display: flex; align-items: flex-end; gap: 14px; }
+.page-head p { margin: 4px 0 0; color: var(--muted); }
+.page-head-actions { margin-left: auto; display: flex; gap: 8px; }
+
+.card {
+  background: var(--panel); border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 18px;
+}
+.card-head { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; }
+.card-head h2 { flex: 1; }
+
+.stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 14px; }
+.stat-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.stat-value { font-size: 27px; font-weight: 680; letter-spacing: -0.03em; margin-top: 6px; }
+.stat-delta { font-size: 12px; margin-top: 4px; }
+.stat-delta.up { color: var(--good); }
+.stat-delta.down { color: var(--bad); }
+
+.spark { display: flex; align-items: flex-end; gap: 6px; height: 84px; margin-top: 14px; }
+.spark span {
+  flex: 1; min-height: 6px;
+  background: var(--accent-soft); border-radius: 4px 4px 0 0;
+  border-top: 2px solid var(--accent);
+}
+
+/* --- Tables -------------------------------------------------------------- */
+
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--line); }
+th {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.07em;
+  color: var(--muted); font-weight: 600;
+}
+th button {
+  border: 0; background: none; padding: 0; color: inherit;
+  font: inherit; text-transform: inherit; letter-spacing: inherit;
+  display: inline-flex; align-items: center; gap: 5px;
+}
+th button:hover { color: var(--accent); }
+th[aria-sort]:not([aria-sort='none']) button { color: var(--accent); }
+tbody tr { transition: background 0.12s ease; }
+tbody tr:hover { background: var(--panel-2); cursor: pointer; }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+th.num { text-align: right; }
+
+.pill {
+  display: inline-block; padding: 2px 9px; border-radius: 999px;
+  font-size: 11px; font-weight: 600; border: 1px solid transparent;
+}
+.pill.paid { color: var(--good); border-color: color-mix(in srgb, var(--good) 40%, transparent); }
+.pill.pending { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 40%, transparent); }
+.pill.refunded { color: var(--bad); border-color: color-mix(in srgb, var(--bad) 40%, transparent); }
+
+.feed { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 9px; }
+.feed li { display: flex; gap: 10px; align-items: baseline; }
+
+/* --- Forms --------------------------------------------------------------- */
+
+label.field { display: flex; flex-direction: column; gap: 6px; font-size: 12px; color: var(--muted); }
+input, select, textarea {
+  font: inherit; color: var(--text); background: var(--panel-2);
+  border: 1px solid var(--line); border-radius: 8px; padding: 9px 11px;
+}
+input:focus-visible, select:focus-visible, textarea:focus-visible, button:focus-visible, a:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
+
+/* --- Sign-in ------------------------------------------------------------- */
+
+.signin-wrap { min-height: 100vh; display: grid; place-items: center; padding: 24px; }
+.signin {
+  width: 100%; max-width: 380px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 14px; padding: 26px;
+  box-shadow: var(--shadow); display: flex; flex-direction: column; gap: 14px;
+}
+.signin h1 { font-size: 19px; }
+.signin .hint { font-size: 12px; color: var(--muted); }
+
+/* --- Skeleton / loading -------------------------------------------------- */
+
+.skeleton-row {
+  height: 14px; border-radius: 6px; margin-bottom: 10px;
+  background: linear-gradient(90deg, var(--panel-2) 25%, var(--line) 37%, var(--panel-2) 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.2s ease-in-out infinite;
+}
+@keyframes shimmer { 0% { background-position: 100% 0; } 100% { background-position: 0 0; } }
+
+/* --- Error / 404 --------------------------------------------------------- */
+
+.notice {
+  border: 1px solid var(--line); border-left: 3px solid var(--bad);
+  background: var(--panel); border-radius: var(--radius); padding: 18px;
+}
+.notice.warn { border-left-color: var(--warn); }
+.notice code { font-family: var(--mono); font-size: 12px; color: var(--muted); }
+
+.empty { display: grid; place-items: center; gap: 10px; padding: 60px 20px; text-align: center; }
+
+/* --- Modal (Portal) ------------------------------------------------------ */
+
+.modal-backdrop {
+  position: fixed; inset: 0; z-index: 100;
+  background: rgba(4, 6, 12, 0.6);
+  display: grid; place-items: center; padding: 20px;
+}
+.modal {
+  width: 100%; max-width: 440px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 14px; padding: 22px;
+  box-shadow: var(--shadow); display: flex; flex-direction: column; gap: 14px;
+}
+.modal-actions { display: flex; gap: 8px; justify-content: flex-end; }
+
+.detail-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 14px; }
+.detail-grid dt { font-size: 11px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); }
+.detail-grid dd { margin: 4px 0 0; font-size: 15px; font-weight: 600; }
+
+.settings-layout { display: grid; grid-template-columns: 180px 1fr; gap: 20px; align-items: start; }
+.settings-nav { display: flex; flex-direction: column; gap: 2px; }
+.settings-nav a { padding: 7px 10px; border-radius: 8px; color: var(--muted); }
+.settings-nav a.active { background: var(--accent-soft); color: var(--accent); }
+
+@media (max-width: 860px) {
+  .shell { grid-template-columns: 1fr; }
+  .sidebar { position: static; height: auto; }
+  .settings-layout { grid-template-columns: 1fr; }
+}

--- a/smoke/apps/admin-dashboard/tsconfig.json
+++ b/smoke/apps/admin-dashboard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "//": "Editor hints only. Nothing runs tsc: what-compiler owns the JSX transform, and the Vite plugin sets jsx:'preserve' so the bundler never touches it.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "what-framework",
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/smoke/apps/admin-dashboard/vite.config.js
+++ b/smoke/apps/admin-dashboard/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import what from 'what-compiler/vite';
+
+// The plugin owns JSX end to end: it sets `jsx: 'preserve'` on the bundler so
+// only the What babel plugin touches .jsx, and it excludes what-* from
+// dependency pre-bundling. Overriding either splits the runtime into two module
+// instances and getCurrentComponent() silently stops resolving.
+export default defineConfig({
+  plugins: [what()],
+  server: { host: '127.0.0.1', strictPort: true },
+  preview: { host: '127.0.0.1', strictPort: true },
+});

--- a/smoke/apps/ops-console/.gitignore
+++ b/smoke/apps/ops-console/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/smoke/apps/ops-console/package.json
+++ b/smoke/apps/ops-console/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "smoke-ops-console",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Ops console smoke app: infinite event feed, optimistic acknowledge, lazy detail pane, validated forms, focus-trapped dialog.",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  },
+  "dependencies": {
+    "what-framework": "0.12.2",
+    "what-router": "0.12.2",
+    "what-server": "0.12.2"
+  }
+}

--- a/smoke/apps/ops-console/package.json
+++ b/smoke/apps/ops-console/package.json
@@ -9,8 +9,8 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "what-framework": "0.12.2",
-    "what-router": "0.12.2",
-    "what-server": "0.12.2"
+    "what-framework": "0.12.3",
+    "what-router": "0.12.3",
+    "what-server": "0.12.3"
   }
 }

--- a/smoke/apps/ops-console/public/favicon.svg
+++ b/smoke/apps/ops-console/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#0b1220"/>
+  <path d="M4 20h5l3-9 4 14 3-9 2 4h7" fill="none" stroke="#38bdf8" stroke-width="2.4"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/smoke/apps/ops-console/server.js
+++ b/smoke/apps/ops-console/server.js
@@ -1,0 +1,233 @@
+// Ops console server. `npm run dev` (auto-restart) or `node server.js`.
+// Serves http://localhost:3000.
+//
+// Buildless: the browser loads /src/entry-client.js as a native ES module and
+// the import map below resolves its bare specifiers to sources under
+// node_modules. No bundler, no CDN.
+//
+// There is no ISR cache here and no server actions. Both are the storefront
+// app's territory; this one is about the async and accessibility surfaces, so
+// its server is deliberately the smallest thing that can render a document and
+// answer a JSON API.
+
+import http from 'node:http';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { renderDocument } from 'what-framework/server';
+
+import { matchPath } from './src/routes.js';
+import {
+  acknowledge,
+  createIncident,
+  getIncident,
+  listAcks,
+  listEvents,
+  listServices,
+  listSeverities,
+} from './src/data/incidents.js';
+
+const ROOT = fileURLToPath(new URL('.', import.meta.url));
+
+// A round trip an operator would actually feel. It is also what makes the
+// optimistic acknowledge worth having: without latency there is nothing to
+// paper over.
+const ACK_LATENCY_MS = 140;
+
+const importMap = {
+  imports: {
+    'what-framework': '/node_modules/what-framework/src/index.js',
+    'what-core': '/node_modules/what-core/src/index.js',
+    'what-router': '/node_modules/what-router/src/index.js',
+    // The client-safe half of the server package: useOptimistic lives in
+    // actions.js, which imports nothing from node:*.
+    'what-server/actions': '/node_modules/what-server/src/actions.js',
+  },
+};
+
+const sharedHead =
+  '<link rel="stylesheet" href="/src/styles.css">' +
+  '<link rel="icon" type="image/svg+xml" href="/favicon.svg">';
+
+const hydratedDocument = {
+  clientEntry: '/src/entry-client.js',
+  head: `<script type="importmap">${JSON.stringify(importMap)}</script>${sharedHead}`,
+};
+
+// No client entry and no import map: a page that ships zero JavaScript should
+// not ship the machinery for JavaScript either.
+const staticDocument = { head: sharedHead };
+
+// --- Static files ----------------------------------------------------------
+
+const MIME = {
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+};
+
+// Deny by default. src/data/** (the incident store), src/routes.js and
+// src/pages/health.js are importable by Node and 404 over HTTP, so seed data,
+// mutation logic and the diagnostics renderer never reach a browser. Add new
+// client-side files here explicitly.
+const SERVED_FILES = new Set([
+  '/src/entry-client.js',
+  '/src/styles.css',
+  '/src/pane-routes.js',
+  '/src/pages/console.js',
+]);
+
+const SERVED_PREFIXES = [
+  '/src/components/',
+  '/src/lib/',
+  '/src/panels/',
+  '/node_modules/what-framework/',
+  '/node_modules/what-core/',
+  '/node_modules/what-router/',
+  '/node_modules/what-server/',
+];
+
+function resolveStaticFile(pathname) {
+  if (pathname.includes('..') || pathname.includes(' ')) return null;
+  const allowed = SERVED_FILES.has(pathname) || SERVED_PREFIXES.some((p) => pathname.startsWith(p));
+  const file = allowed
+    ? resolve(join(ROOT, pathname))
+    : resolve(join(ROOT, 'public', pathname));
+  if (!file.startsWith(resolve(ROOT))) return null;
+  if (!existsSync(file) || !statSync(file).isFile()) return null;
+  return file;
+}
+
+// --- JSON API --------------------------------------------------------------
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  res.end(payload);
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > 16 * 1024) throw new Error('body too large');
+    chunks.push(chunk);
+  }
+  if (chunks.length === 0) return {};
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+const ACK_PATH = /^\/api\/incidents\/([^/]+)\/ack$/;
+const INCIDENT_PATH = /^\/api\/incidents\/([^/]+)$/;
+
+async function handleApi(req, res, url) {
+  const { pathname, searchParams } = url;
+
+  if (req.method === 'GET' && pathname === '/api/events') {
+    return sendJson(res, 200, listEvents(searchParams.get('cursor'), searchParams.get('limit')));
+  }
+
+  if (req.method === 'GET' && pathname === '/api/acks') {
+    return sendJson(res, 200, listAcks());
+  }
+
+  if (req.method === 'POST' && pathname === '/api/incidents') {
+    const body = await readJsonBody(req);
+    const title = String(body.title ?? '').trim();
+    // The client validates first; the server refuses anyway, because a client
+    // that can be bypassed is not a validator.
+    if (title.length < 10) return sendJson(res, 422, { message: 'title too short' });
+    if (!listServices().includes(body.service)) return sendJson(res, 422, { message: 'unknown service' });
+    if (!listSeverities().includes(body.severity)) return sendJson(res, 422, { message: 'unknown severity' });
+    return sendJson(res, 201, {
+      incident: createIncident({ title, service: body.service, severity: body.severity }),
+    });
+  }
+
+  const ack = ACK_PATH.exec(pathname);
+  if (req.method === 'POST' && ack) {
+    await new Promise((r) => setTimeout(r, ACK_LATENCY_MS));
+    const acks = acknowledge(decodeURIComponent(ack[1]));
+    if (!acks) return sendJson(res, 404, { message: 'no such incident' });
+    return sendJson(res, 200, { acks });
+  }
+
+  const detail = INCIDENT_PATH.exec(pathname);
+  if (req.method === 'GET' && detail) {
+    const incident = getIncident(decodeURIComponent(detail[1]));
+    if (!incident) return sendJson(res, 404, { message: 'no such incident' });
+    return sendJson(res, 200, incident);
+  }
+
+  return sendJson(res, 404, { message: 'no such endpoint' });
+}
+
+// --- Document rendering ----------------------------------------------------
+
+async function renderRoute(match, url) {
+  const reqCtx = {
+    params: match.params,
+    query: Object.fromEntries(url.searchParams),
+  };
+  const pageModule = { default: match.route.component, loader: match.route.loader };
+  return renderDocument(pageModule, reqCtx, match.route.hydrate ? hydratedDocument : staticDocument);
+}
+
+const NOT_FOUND = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">` +
+  `<title>Unknown view | Northwind Ops</title>` +
+  `<link rel="stylesheet" href="/src/styles.css"></head>` +
+  `<body><div class="app"><main class="container"><h1>Unknown view</h1>` +
+  `<p class="lede">No console route answers that path.</p>` +
+  `<p><a href="/">Back to the event feed</a></p></main></div></body></html>`;
+
+// --- Start (node server.js / npm run dev), not when imported ----------------
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+
+    try {
+      if (url.pathname.startsWith('/api/')) return await handleApi(req, res, url);
+
+      if (req.method === 'GET' || req.method === 'HEAD') {
+        const file = resolveStaticFile(decodeURIComponent(url.pathname));
+        if (file) {
+          res.writeHead(200, { 'content-type': MIME[extname(file)] || 'application/octet-stream' });
+          if (req.method === 'HEAD') return res.end();
+          return createReadStream(file).pipe(res);
+        }
+
+        const match = matchPath(url.pathname);
+        if (!match) {
+          res.writeHead(404, { 'content-type': 'text/html; charset=utf-8' });
+          return res.end(NOT_FOUND);
+        }
+        const html = await renderRoute(match, url);
+        res.writeHead(200, {
+          'content-type': 'text/html; charset=utf-8',
+          'cache-control': 'no-store',
+        });
+        return res.end(html);
+      }
+
+      res.writeHead(405, { 'content-type': 'text/plain; charset=utf-8' });
+      return res.end('method not allowed');
+    } catch (err) {
+      console.error('[ops-console]', err);
+      if (res.headersSent) return res.end();
+      res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+      return res.end('internal error');
+    }
+  });
+
+  const port = Number(process.env.PORT) || 3000;
+  server.listen(port, () => console.log(`ops console ready at http://localhost:${port}`));
+}

--- a/smoke/apps/ops-console/smoke.config.mjs
+++ b/smoke/apps/ops-console/smoke.config.mjs
@@ -1,0 +1,498 @@
+// Ops console smoke contract.
+//
+// The theme is "prove the intermediate state", not just the end state. An async
+// capability that is only asserted after it settles is indistinguishable from a
+// synchronous one, so every check here pins the state in the middle:
+//
+//   - the lazy chunk request is HELD so the Suspense fallback is observed
+//   - the acknowledge response is HELD so the optimistic row is observed before
+//     the server has said anything, and then again after it has
+//   - the acknowledge response is FORCED to fail so the rollback is observed
+//
+// Ordering matters twice. The infinite-feed assertions run before anything
+// creates an incident, because creating one refetches the feed and replaces the
+// loaded pages. And the lazy-chunk hold is installed before the first
+// navigation, because the module is only ever fetched once.
+
+import { startProcess, waitForHttp, withPage } from '../../harness/index.mjs';
+
+const PAGE_SIZE = 8;
+
+/** Pull the hydration payload the server inlined into the document. */
+function hydrationPayload(html) {
+  const match = /<script id="__what_data" type="application\/json">([\s\S]*?)<\/script>/.exec(html);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read one attribute out of the raw server bytes. `marker` is any literal text
+ * that appears inside the opening tag (a data-* attribute name works well).
+ * Parsing HTML with a regex is fine here and only here: the point is to read
+ * what the SERVER sent, before a parser or a script has had a chance to
+ * normalize it.
+ */
+function attr(html, marker, name) {
+  const re = new RegExp(`<[^>]*${marker}[^>]*>`);
+  const tag = re.exec(html);
+  if (!tag) return null;
+  const found = new RegExp(`${name}="([^"]*)"`).exec(tag[0]);
+  return found ? found[1] : null;
+}
+
+export default {
+  description: 'Ops console: infinite feed, optimistic acknowledge, lazy detail pane, validated forms, focus-trapped dialog.',
+
+  covers: [
+    'cmp:suspense-lazy',
+    'data:resource-suspense',
+    'data:infinite',
+    'data:optimistic',
+    'form:validation',
+    'form:submit',
+    'a11y:ids',
+    'a11y:focus-trap',
+    'a11y:live-region',
+  ],
+
+  async check({ workDir, appPort, browser, check, reporter, log }) {
+    const base = `http://127.0.0.1:${appPort}`;
+
+    const server = startProcess('node', ['server.js'], {
+      cwd: workDir,
+      env: { ...process.env, PORT: String(appPort) },
+    });
+    await waitForHttp(`${base}/api/acks`, { child: server });
+
+    // === Server-rendered ids ==============================================
+    // Read from the raw bytes, before any script has run: whatever useId
+    // allocated on the server is what assistive tech gets if JavaScript never
+    // arrives, and it is what the client has to reproduce if it does.
+    const consoleHtml = await (await fetch(`${base}/`)).text();
+
+    const labelFor = attr(consoleHtml, 'class="filter-label"', 'for');
+    const inputId = attr(consoleHtml, 'data-filter-input', 'id');
+    const inputDescribedBy = attr(consoleHtml, 'data-filter-input', 'aria-describedby');
+    const hintId = attr(consoleHtml, 'data-filter-hint', 'id');
+    const errorSlotId = attr(consoleHtml, 'data-filter-error', 'id');
+
+    reporter.assert(
+      Boolean(labelFor && inputId && hintId && errorSlotId),
+      'the filter form ships label/input/description ids in the server HTML',
+      `for=${labelFor} id=${inputId} hint=${hintId} error=${errorSlotId}`,
+    );
+    reporter.assert(labelFor === inputId && inputDescribedBy === hintId,
+      'the server-rendered pairing is internally consistent',
+      `for=${labelFor} id=${inputId} describedby=${inputDescribedBy} hint=${hintId}`);
+
+    // === createResource suspends and resolves under Suspense ==============
+    const healthHtml = await (await fetch(`${base}/health`)).text();
+    const payload = hydrationPayload(healthHtml);
+
+    const openMetric = /<dd data-metric-open="">(\d+)<\/dd>/.exec(healthHtml);
+    const trackedMetric = /<dd data-metric-total="">(\d+)<\/dd>/.exec(healthHtml);
+    const syncPass = /<pre class="code" data-selftest-sync="">([\s\S]*?)<\/pre>/.exec(healthHtml);
+    const asyncPass = /<pre class="code" data-selftest-async="">([\s\S]*?)<\/pre>/.exec(healthHtml);
+
+    // The fallback is not merely absent from the finished page: the SAME panel
+    // rendered synchronously produces it, which is the only state in which the
+    // suspension is visible from outside.
+    const fallbackObserved = Boolean(syncPass)
+      && syncPass[1].includes('data-summary-skeleton')
+      && !syncPass[1].includes('data-metric-open');
+    const resolvedObserved = Boolean(asyncPass)
+      && asyncPass[1].includes('data-metric-open')
+      && !asyncPass[1].includes('data-summary-skeleton');
+    const inPayload = Boolean(payload && payload.resources && payload.resources['ops-summary']);
+    const pageResolved = Boolean(openMetric && trackedMetric)
+      && !healthHtml.includes('data-summary-skeleton="">Rolling');
+
+    check('data:resource-suspense',
+      fallbackObserved && resolvedObserved && inPayload && pageResolved,
+      'createResource suspends to the fallback and the async pass resolves it',
+      `sync=${fallbackObserved ? 'skeleton' : 'NOT skeleton'} async=${resolvedObserved ? 'resolved' : 'NOT resolved'}`
+      + ` payloadKey=${inPayload} open=${openMetric ? openMetric[1] : 'missing'}`);
+
+    reporter.assert(
+      inPayload && payload.resources['ops-summary'].total === Number(trackedMetric && trackedMetric[1]),
+      'the resolved resource is inlined for hydration, matching the rendered numbers',
+      inPayload ? JSON.stringify(payload.resources['ops-summary']) : 'no ops-summary in __what_data');
+
+    reporter.assert(healthHtml.includes('data-selftest="pass"'),
+      'the page reports its own SSR suspense self-test as passing');
+
+    reporter.assert(!/<script type="module"/.test(healthHtml),
+      'the diagnostics page ships no client entry',
+      /<script type="module"[^>]*>/.exec(healthHtml)?.[0] ?? 'none');
+
+    // === Browser ==========================================================
+    await withPage(browser, `${base}/`, async (page, diag) => {
+      await page.waitForFunction(
+        (n) => document.querySelectorAll('[data-row]').length === n,
+        PAGE_SIZE,
+        { timeout: 15000 },
+      );
+
+      // --- a11y:ids: what the client rebuilt must be what the server sent ---
+      const domIds = await page.evaluate(() => {
+        const input = document.querySelector('[data-filter-input]');
+        return {
+          labelFor: document.querySelector('.filter-label').getAttribute('for'),
+          inputId: input.id,
+          describedBy: input.getAttribute('aria-describedby'),
+          hintId: document.querySelector('[data-filter-hint]').id,
+          errorId: document.querySelector('[data-filter-error]').id,
+        };
+      });
+
+      // Force the error branch. `aria-describedby` is rewritten from the
+      // CLIENT's useId sequence, so a sequence that drifted from the server's
+      // would leave it pointing at an id that is not in the document.
+      await page.fill('[data-filter-input]', 'p');
+      await page.click('[data-filter-apply]');
+      await page.waitForFunction(
+        () => document.querySelector('[data-filter-error]').textContent.trim().length > 0,
+        undefined,
+        { timeout: 5000 },
+      );
+      const described = await page.getAttribute('[data-filter-input]', 'aria-describedby');
+      const describedTargetsExist = await page.evaluate(
+        (value) => value.split(/\s+/).every((id) => document.getElementById(id) !== null),
+        described,
+      );
+
+      check('a11y:ids',
+        domIds.labelFor === inputId
+        && domIds.inputId === inputId
+        && domIds.hintId === hintId
+        && domIds.errorId === errorSlotId
+        && described === `${errorSlotId} ${hintId}`
+        && describedTargetsExist,
+        'useId pairs label/input/description and the ids survive hydration unchanged',
+        `ssr for=${labelFor} id=${inputId} error=${errorSlotId}`
+        + ` | client for=${domIds.labelFor} id=${domIds.inputId} describedby=${described}`);
+
+      // The rejected filter must not have been applied either.
+      reporter.assert(
+        (await page.locator('[data-row]').count()) === PAGE_SIZE,
+        'an invalid filter surfaces its error and is not applied',
+        `rows=${await page.locator('[data-row]').count()}`);
+
+      // A valid filter narrows the feed, which proves the error above was the
+      // form refusing rather than the handler being broken.
+      await page.fill('[data-filter-input]', 'payments');
+      await page.click('[data-filter-apply]');
+      await page.waitForFunction(
+        () => document.querySelectorAll('[data-row]').length > 0
+          && [...document.querySelectorAll('[data-row]')].every((r) => r.dataset.service === 'payments-worker'),
+        undefined,
+        { timeout: 5000 },
+      );
+      const filtered = await page.locator('[data-row]').count();
+      reporter.assert(filtered > 0 && filtered < PAGE_SIZE,
+        'a valid filter narrows the feed to one service', `rows=${filtered}`);
+
+      await page.fill('[data-filter-input]', '');
+      await page.click('[data-filter-apply]');
+      await page.waitForFunction((n) => document.querySelectorAll('[data-row]').length === n,
+        PAGE_SIZE, { timeout: 5000 });
+
+      // --- cmp:suspense-lazy ---------------------------------------------
+      // Hold the detail module in flight. The fallback is a real state on a
+      // cold cache; holding the request is how it stays on screen long enough
+      // to be read.
+      let releaseChunk;
+      const chunkGate = new Promise((resolve) => { releaseChunk = resolve; });
+      let chunkRequests = 0;
+      const holdChunk = async (route) => {
+        chunkRequests += 1;
+        await chunkGate;
+        await route.continue();
+      };
+      await page.route('**/panels/incident-detail.js', holdChunk);
+
+      const firstRowId = await page.getAttribute('[data-row]:nth-child(1)', 'data-row');
+      const firstRowTitle = (await page.textContent(`[data-row="${firstRowId}"] .row-title`)).trim();
+
+      const paneBefore = await page.locator('[data-pane-empty]').count();
+      await page.click(`[data-open="${firstRowId}"]`);
+      await page.waitForSelector('[data-pane-skeleton]', { timeout: 10000 });
+      const skeletonShown = await page.locator('[data-pane-skeleton]').count();
+      const detailWhileHeld = await page.locator('[data-detail]').count();
+
+      releaseChunk();
+      await page.waitForSelector(`[data-detail="${firstRowId}"]`, { timeout: 15000 });
+      await page.waitForFunction(
+        (id) => document.querySelector('[data-detail-title]')?.textContent.trim() === id,
+        firstRowTitle,
+        { timeout: 10000 },
+      );
+      const skeletonAfter = await page.locator('[data-pane-skeleton]').count();
+      const detailService = await page.textContent('[data-detail-service]');
+
+      check('cmp:suspense-lazy',
+        paneBefore === 1 && chunkRequests === 1 && skeletonShown === 1 && detailWhileHeld === 0
+        && skeletonAfter === 0 && detailService.trim().length > 0,
+        'a lazy route reached by navigation shows the fallback, then replaces it',
+        `emptyPaneFirst=${paneBefore} chunkRequests=${chunkRequests}`
+        + ` fallbackWhileHeld=${skeletonShown} detailWhileHeld=${detailWhileHeld}`
+        + ` fallbackAfter=${skeletonAfter} resolvedService=${detailService.trim()}`);
+
+      await page.unroute('**/panels/incident-detail.js', holdChunk);
+
+      // --- data:infinite ---------------------------------------------------
+      const firstPageIds = await page.$$eval('[data-row]', (rows) => rows.map((r) => r.dataset.row));
+      await page.click('[data-load-more]');
+      await page.waitForFunction((n) => document.querySelectorAll('[data-row]').length === n,
+        PAGE_SIZE * 2, { timeout: 10000 });
+      const twoPageIds = await page.$$eval('[data-row]', (rows) => rows.map((r) => r.dataset.row));
+
+      const appended = firstPageIds.every((id, i) => twoPageIds[i] === id);
+      const unique = new Set(twoPageIds).size === twoPageIds.length;
+      const status = (await page.textContent('[data-feed-status]')).trim();
+
+      check('data:infinite',
+        twoPageIds.length === PAGE_SIZE * 2 && appended && unique,
+        'fetchNextPage appends a page and keeps the rows already on screen',
+        `${firstPageIds.length} -> ${twoPageIds.length} rows, firstRowKept=${twoPageIds[0] === firstPageIds[0]}`
+        + `, unique=${unique}, status="${status}"`);
+
+      // --- data:optimistic: apply, then reconcile --------------------------
+      const ackTarget = twoPageIds[2];
+      let releaseAck;
+      const ackGate = new Promise((resolve) => { releaseAck = resolve; });
+      const holdAck = async (route) => { await ackGate; await route.continue(); };
+      await page.route('**/api/incidents/*/ack', holdAck);
+
+      await page.click(`[data-ack="${ackTarget}"]`);
+      await page.waitForSelector(`[data-row="${ackTarget}"][data-ack-state="pending"]`, { timeout: 5000 });
+      const whilePending = await page.evaluate((id) => {
+        const row = document.querySelector(`[data-row="${id}"]`);
+        return {
+          state: row.dataset.ackState,
+          ackedBy: row.dataset.ackedBy,
+          label: row.querySelector('[data-ack-label]').textContent.trim(),
+        };
+      }, ackTarget);
+
+      releaseAck();
+      await page.waitForSelector(`[data-row="${ackTarget}"][data-ack-state="confirmed"]`, { timeout: 10000 });
+      const afterConfirm = await page.evaluate((id) => {
+        const row = document.querySelector(`[data-row="${id}"]`);
+        return { state: row.dataset.ackState, ackedBy: row.dataset.ackedBy };
+      }, ackTarget);
+      await page.unroute('**/api/incidents/*/ack', holdAck);
+
+      // --- data:optimistic: rollback ---------------------------------------
+      const rollbackTarget = twoPageIds[3];
+      const failAck = async (route) => {
+        // A slice of delay so the optimistic state is observable before the
+        // failure lands, exactly as it would be on a real timeout.
+        await new Promise((r) => setTimeout(r, 150));
+        await route.fulfill({
+          status: 503,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'ack service unavailable' }),
+        });
+      };
+      await page.route('**/api/incidents/*/ack', failAck);
+
+      await page.click(`[data-ack="${rollbackTarget}"]`);
+      await page.waitForSelector(`[data-row="${rollbackTarget}"][data-ack-state="pending"]`, { timeout: 5000 });
+      const rollbackPendingLabel = (await page.textContent(`[data-ack-label="${rollbackTarget}"]`)).trim();
+      await page.waitForSelector(`[data-row="${rollbackTarget}"][data-ack-state="open"]`, { timeout: 10000 });
+      const rolledBackState = await page.getAttribute(`[data-row="${rollbackTarget}"]`, 'data-ack-state');
+      await page.waitForFunction(
+        (id) => document.querySelector('[data-announcer] [aria-live]').textContent.includes(id),
+        rollbackTarget,
+        { timeout: 5000 },
+      );
+      const rollbackAnnouncement = (await page.textContent('[data-announcer] [aria-live]')).trim();
+      await page.unroute('**/api/incidents/*/ack', failAck);
+
+      // The acknowledged row must have survived the failure of a different one.
+      const survivor = await page.getAttribute(`[data-row="${ackTarget}"]`, 'data-ack-state');
+
+      check('data:optimistic',
+        whilePending.state === 'pending' && whilePending.ackedBy === ''
+        && afterConfirm.state === 'confirmed' && afterConfirm.ackedBy === 'ops-bot'
+        && rollbackPendingLabel === 'acknowledging...' && rolledBackState === 'open'
+        && /rolled back/i.test(rollbackAnnouncement)
+        && survivor === 'confirmed',
+        'an acknowledge applies before the server answers, reconciles, and rolls back on failure',
+        `pending(by="${whilePending.ackedBy}", label="${whilePending.label}")`
+        + ` -> confirmed(by="${afterConfirm.ackedBy}")`
+        + ` | failed ack showed "${rollbackPendingLabel}" then ended as "${rolledBackState}", survivor="${survivor}"`);
+
+      // --- a11y:focus-trap --------------------------------------------------
+      let incidentPosts = 0;
+      page.on('request', (request) => {
+        if (request.method() === 'POST' && new URL(request.url()).pathname === '/api/incidents') {
+          incidentPosts += 1;
+        }
+      });
+
+      await page.click('[data-new-incident]');
+      await page.waitForSelector('[data-dialog]', { timeout: 5000 });
+      // FocusTrap focuses the first focusable itself; wait for it rather than
+      // assuming, because it activates on a microtask after the ref lands.
+      await page.waitForFunction(
+        () => document.activeElement?.hasAttribute('data-dialog-close'),
+        undefined,
+        { timeout: 5000 },
+      );
+
+      const focusables = await page.evaluate(() => {
+        const dialog = document.querySelector('[data-dialog]');
+        return [...dialog.querySelectorAll('button, input, select, textarea, a[href], [tabindex]:not([tabindex="-1"])')]
+          .filter((el) => !el.disabled).length;
+      });
+
+      // Tab all the way round and one past the end. Focus must never leave.
+      const tabWalk = [];
+      for (let i = 0; i < focusables + 1; i++) {
+        await page.keyboard.press('Tab');
+        tabWalk.push(await page.evaluate(() => ({
+          inside: !!document.activeElement.closest('[data-dialog]'),
+          tag: document.activeElement.tagName.toLowerCase(),
+        })));
+      }
+      const escapedForward = tabWalk.filter((s) => !s.inside).length;
+      const wrappedToFirst = await page.evaluate(
+        () => !!document.activeElement.closest('[data-dialog]'));
+
+      // Shift+Tab off the first element is the other direction the trap has to
+      // hold, and the one a naive implementation forgets.
+      await page.evaluate(() => document.querySelector('[data-dialog-close]').focus());
+      await page.keyboard.press('Shift+Tab');
+      const afterShiftTab = await page.evaluate(() => ({
+        inside: !!document.activeElement.closest('[data-dialog]'),
+        isSubmit: document.activeElement.hasAttribute('data-dialog-submit'),
+      }));
+
+      check('a11y:focus-trap',
+        focusables >= 5 && escapedForward === 0 && wrappedToFirst
+        && afterShiftTab.inside && afterShiftTab.isSubmit,
+        'Tab and Shift+Tab both wrap inside the open dialog',
+        `focusables=${focusables} tabs=${tabWalk.length} escaped=${escapedForward}`
+        + ` shiftTabLanded=${afterShiftTab.isSubmit ? 'submit button' : 'outside the dialog'}`);
+
+      // --- form:validation --------------------------------------------------
+      await page.fill('[data-dialog-title]', 'too short');
+      await page.click('[data-dialog-submit]');
+      await page.waitForFunction(
+        () => document.querySelector('[data-dialog-error]')?.textContent.trim().length > 0,
+        undefined,
+        { timeout: 5000 },
+      );
+      const dialogError = (await page.textContent('[data-dialog-error]')).trim();
+      const stillOpen = await page.locator('[data-dialog]').count();
+      const postsAfterInvalid = incidentPosts;
+
+      check('form:validation',
+        /at least 10 characters/i.test(dialogError) && stillOpen === 1 && postsAfterInvalid === 0,
+        'useForm blocks the submit, surfaces the field error and never reaches the network',
+        `error="${dialogError}" dialogOpen=${stillOpen === 1} posts=${postsAfterInvalid}`);
+
+      // --- form:submit ------------------------------------------------------
+      const newTitle = 'search-index: shard 3 refusing writes';
+      await page.fill('[data-dialog-title]', newTitle);
+      await page.selectOption('[data-dialog-service]', 'search-index');
+      await page.selectOption('[data-dialog-severity]', 'critical');
+      await page.click('[data-dialog-submit]');
+
+      await page.waitForFunction(
+        (title) => document.querySelector('[data-row]:nth-child(1) .row-title')?.textContent.trim() === title,
+        newTitle,
+        { timeout: 10000 },
+      );
+      const dialogClosed = (await page.locator('[data-dialog]').count()) === 0;
+      const newRowId = await page.getAttribute('[data-row]:nth-child(1)', 'data-row');
+      const newRowSeverity = await page.getAttribute(`[data-row="${newRowId}"] [data-severity]`, 'data-severity');
+
+      check('form:submit',
+        dialogClosed && incidentPosts === 1 && /^INC-\d+$/.test(newRowId) && newRowSeverity === 'critical',
+        'a valid submit posts once, closes the dialog and puts the incident at the top of the feed',
+        `posts=${incidentPosts} dialogClosed=${dialogClosed} row=${newRowId} severity=${newRowSeverity}`);
+
+      // The server has to agree, not just the optimistic UI.
+      const stored = await (await fetch(`${base}/api/incidents/${newRowId}`)).json();
+      reporter.assert(stored.title === newTitle && stored.service === 'search-index',
+        'the created incident is readable from the server',
+        `${stored.id}: ${stored.title}`);
+
+      // --- a11y:live-region --------------------------------------------------
+      const liveRegion = await page.evaluate(() => {
+        const el = document.querySelector('[data-announcer] [aria-live]');
+        return el && {
+          text: el.textContent.trim(),
+          live: el.getAttribute('aria-live'),
+          atomic: el.getAttribute('aria-atomic'),
+        };
+      });
+
+      check('a11y:live-region',
+        Boolean(liveRegion) && liveRegion.live === 'polite' && liveRegion.atomic === 'true'
+        && liveRegion.text.includes(newRowId) && liveRegion.text.includes(newTitle),
+        'the result of the submit is announced in an aria-live region',
+        liveRegion ? `aria-live=${liveRegion.live} text="${liveRegion.text}"` : 'no live region found');
+
+      // --- the acknowledgement outlives the tab ------------------------------
+      // A reload throws away every optimistic value. The confirmed row can only
+      // come back from the boot read, so this is the check that would notice
+      // the client-side boot fetch silently never running.
+      await page.reload({ waitUntil: 'networkidle' });
+      await page.waitForFunction(
+        (id) => document.querySelector(`[data-row="${id}"]`)?.dataset.ackState === 'confirmed',
+        ackTarget,
+        { timeout: 10000 },
+      );
+      const afterReload = await page.getAttribute(`[data-row="${ackTarget}"]`, 'data-acked-by');
+      reporter.assert(afterReload === 'ops-bot',
+        'the server-side acknowledgement is read back after a full reload',
+        `${ackTarget} acked-by="${afterReload}"`);
+
+      // The 503 the rollback check injected is the browser reporting OUR fault
+      // injection, not the app misbehaving. Everything else has to be silent.
+      const realErrors = diag.errors.filter((line) => !/503 \(Service Unavailable\)/.test(line));
+      reporter.assert(realErrors.length === 0,
+        'the console page produced no page errors beyond the injected 503',
+        realErrors.slice(0, 3).join(' | '));
+
+      const mismatches = diag.all.filter((line) => /Hydration mismatch/i.test(line));
+      reporter.assert(mismatches.length === 0,
+        'hydration reused the server DOM without mismatch warnings',
+        mismatches.slice(0, 2).join(' | '));
+    });
+
+    // === Diagnostics page in a real browser ===============================
+    // Asserting on the bytes is not enough: a client entry that hydrated the
+    // wrong component against this page's DOM would leave the HTML above
+    // untouched and still throw on load.
+    await withPage(browser, `${base}/health`, async (page, diag) => {
+      const metrics = await page.locator('.metric').count();
+      const verdict = await page.getAttribute('[data-selftest]', 'data-selftest');
+      reporter.assert(metrics >= 5 && verdict === 'pass' && diag.errors.length === 0,
+        'the diagnostics page loads clean with no scripting of its own',
+        `metrics=${metrics} selftest=${verdict} errors=${diag.errors.slice(0, 2).join(' | ')}`);
+    });
+
+    // === Deep link ========================================================
+    // /incidents/:id has no server route of its own: the shell is the console
+    // and the client router resolves the pane. A reload has to land on the
+    // detail, not on an empty pane.
+    await withPage(browser, `${base}/incidents/INC-1042`, async (page, diag) => {
+      await page.waitForSelector('[data-detail="INC-1042"]', { timeout: 15000 });
+      const title = (await page.textContent('[data-detail-title]')).trim();
+      reporter.assert(title.length > 0 && diag.errors.length === 0,
+        'a deep link into the client-routed pane renders the detail on first load',
+        `title="${title}" errors=${diag.errors.length}`);
+    });
+
+    log('ops-console checks complete');
+  },
+};

--- a/smoke/apps/ops-console/src/components/chrome.js
+++ b/smoke/apps/ops-console/src/components/chrome.js
@@ -1,0 +1,39 @@
+// Shared page chrome. Client-safe (no server-only imports) so the hydrated
+// console and the zero-JS /health page can both use it.
+//
+// The nav uses plain <a> rather than the router's <Link>: these are full
+// document loads between two server-rendered pages, and <Link> is for the
+// client-routed detail pane inside the console.
+
+import { h } from 'what-framework';
+
+export function TopBar({ current = '' }) {
+  const link = (href, label, id) =>
+    h('a', {
+      href,
+      class: current === id ? 'nav-link is-active' : 'nav-link',
+      'data-nav': id,
+      ...(current === id ? { 'aria-current': 'page' } : {}),
+    }, label);
+
+  return h('header', { class: 'topbar' },
+    h('a', { href: '/', class: 'brand' },
+      h('span', { class: 'brand-dot', 'aria-hidden': 'true' }),
+      'Northwind Ops',
+    ),
+    h('nav', { 'aria-label': 'Primary' },
+      link('/', 'Console', 'console'),
+      link('/health', 'Health', 'health'),
+    ),
+  );
+}
+
+export function SeverityTag({ severity }) {
+  return h('span', { class: `sev sev-${severity}`, 'data-severity': severity }, severity);
+}
+
+export function Footer() {
+  return h('footer', { class: 'site-footer' },
+    h('p', {}, 'Northwind Ops Console, a What Framework smoke app. In-memory data, resets on restart.'),
+  );
+}

--- a/smoke/apps/ops-console/src/components/incident-dialog.js
+++ b/smoke/apps/ops-console/src/components/incident-dialog.js
@@ -1,0 +1,143 @@
+// "Declare incident" dialog: a Portal out to #dialog-root, a FocusTrap around
+// the card, and a useForm that refuses to submit a title nobody could act on.
+//
+// The whole component is mounted and unmounted rather than toggled: FocusTrap
+// destructures `active` once and components run once, so flipping that prop
+// would do nothing. Mount/unmount is the supported way to open and close.
+
+import {
+  FocusTrap,
+  Portal,
+  h,
+  rules,
+  signal,
+  simpleResolver,
+  useForm,
+  useId,
+} from 'what-framework';
+
+export function IncidentDialog({ services, severities, onClose, onCreate }) {
+  const titleId = useId('dialog-title');
+  const errorId = useId('dialog-error');
+  const submitting = signal(false, 'dialog:submitting');
+  const serverError = signal('', 'dialog:serverError');
+
+  const form = useForm({
+    defaultValues: { title: '', service: services[0], severity: 'major' },
+    resolver: simpleResolver({
+      title: [
+        rules.required('Give the incident a title.'),
+        rules.minLength(10, 'Use at least 10 characters: this is what the pager shows at 3am.'),
+      ],
+    }),
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    submitting(true);
+    serverError('');
+    try {
+      await onCreate(values);
+    } catch (err) {
+      serverError(err.message);
+    } finally {
+      submitting(false);
+    }
+  });
+
+  // Never `...register(name)`: `value` is a defineProperty getter, so spreading
+  // it snapshots the value at component-creation time (components run once) and
+  // the control stops tracking reset()/setValue().
+  const bind = (name) => ({
+    oninput: form.register(name).oninput,
+    onblur: form.register(name).onBlur,
+  });
+
+  const textField = (name) => ({ ...bind(name), value: () => form.getValue(name) });
+
+  const option = (name) => (value) =>
+    h('option', {
+      key: value,
+      value,
+      ...(form.getValue(name) === value ? { selected: true } : {}),
+    }, value);
+
+  // One ELEMENT child, never a component and never a list. A component realizes
+  // to a DocumentFragment, and appending a fragment empties it, so Portal's
+  // cleanup ends up holding an empty fragment and removes nothing: the dialog
+  // stays in #dialog-root after close and the next open stacks a second one.
+  // Wrapping everything in a real element gives the cleanup a node to remove.
+  const card = h('div', {
+    class: 'dialog',
+    role: 'dialog',
+    'aria-modal': 'true',
+    'aria-labelledby': titleId(),
+    'data-dialog': '',
+    onkeydown: (event) => { if (event.key === 'Escape') onClose(); },
+  },
+    h('div', { class: 'dialog-head' },
+      h('h2', { id: titleId() }, 'Declare incident'),
+      h('button', {
+        type: 'button',
+        class: 'icon-button',
+        'aria-label': 'Close dialog',
+        'data-dialog-close': '',
+        onclick: onClose,
+      }, '×'),
+    ),
+
+    h('form', { class: 'dialog-body', onsubmit: onSubmit, 'data-dialog-form': '' },
+      h('label', { class: 'field' },
+        h('span', {}, 'What is happening?'),
+        h('input', {
+          type: 'text',
+          name: 'title',
+          placeholder: 'checkout-api: 5xx on POST /orders',
+          autocomplete: 'off',
+          'data-dialog-title': '',
+          'aria-describedby': errorId(),
+          ...textField('title'),
+        }),
+      ),
+
+      h('div', { class: 'field-row' },
+        h('label', { class: 'field' },
+          h('span', {}, 'Service'),
+          h('select', { name: 'service', 'data-dialog-service': '', ...bind('service') },
+            services.map(option('service')),
+          ),
+        ),
+        h('label', { class: 'field' },
+          h('span', {}, 'Severity'),
+          h('select', { name: 'severity', 'data-dialog-severity': '', ...bind('severity') },
+            severities.map(option('severity')),
+          ),
+        ),
+      ),
+
+      // One error slot, reactive text. `role="alert"` so the message is
+      // announced the moment validation writes it.
+      h('p', {
+        id: errorId(),
+        class: 'field-error',
+        role: 'alert',
+        'data-dialog-error': '',
+      }, () => form.formState.error('title')?.message || serverError()),
+
+      h('div', { class: 'dialog-actions' },
+        h('button', { type: 'button', class: 'ghost', onclick: onClose }, 'Cancel'),
+        h('button', {
+          type: 'submit',
+          class: 'primary',
+          'data-dialog-submit': '',
+        }, () => (submitting() ? 'Declaring...' : 'Declare incident')),
+      ),
+    ),
+  );
+
+  return h(Portal, { target: '#dialog-root' },
+    h('div', { class: 'dialog-layer' },
+      h('div', { class: 'scrim', onclick: onClose, 'aria-hidden': 'true' }),
+      h(FocusTrap, {}, card),
+    ),
+  );
+}

--- a/smoke/apps/ops-console/src/data/incidents.js
+++ b/smoke/apps/ops-console/src/data/incidents.js
@@ -1,0 +1,135 @@
+// The incident store. SERVER ONLY: this module is never served over HTTP (see
+// the allowlist in server.js), so the seed data and the mutation logic stay off
+// the wire.
+//
+// Everything is derived from a fixed seed rather than Math.random(), because a
+// demo whose feed reshuffles on every restart is impossible to reason about and
+// impossible to assert on.
+
+const SERVICES = [
+  'checkout-api',
+  'payments-worker',
+  'edge-cdn',
+  'search-index',
+  'auth-gateway',
+];
+
+const SEVERITIES = ['critical', 'major', 'minor'];
+
+const SYMPTOMS = [
+  'p99 latency above SLO',
+  'error rate spike on POST /orders',
+  'queue depth growing without drain',
+  'origin 5xx bursts behind the CDN',
+  'replica lag past the failover threshold',
+  'token refresh storm from one tenant',
+  'disk pressure on the primary',
+  'upstream timeout cascade',
+];
+
+/** Fixed reference point so relative times in the UI are stable within a run. */
+export const BOOT_AT = Date.parse('2026-03-14T09:00:00.000Z');
+
+let sequence = 1040;
+const incidents = [];
+const acks = new Map(); // id -> { id, by, at }
+
+// 26 seeded incidents, newest first. The modulo walk is deliberate: it gives
+// every service and severity several rows, so a filter always has something to
+// find and the severity legend is never empty.
+for (let i = 0; i < 26; i++) {
+  const id = `INC-${sequence++}`;
+  incidents.unshift({
+    id,
+    title: `${SERVICES[i % SERVICES.length]}: ${SYMPTOMS[i % SYMPTOMS.length]}`,
+    service: SERVICES[i % SERVICES.length],
+    severity: SEVERITIES[i % SEVERITIES.length],
+    // Older rows further down the feed.
+    openedAt: BOOT_AT - i * 7 * 60 * 1000,
+    source: i % 3 === 0 ? 'prometheus' : 'synthetic-probe',
+  });
+}
+
+export function listServices() {
+  return [...SERVICES];
+}
+
+export function listSeverities() {
+  return [...SEVERITIES];
+}
+
+/** One page of the feed, newest first. `cursor` is an offset into the list. */
+export function listEvents(cursor = 0, limit = 8) {
+  const start = Math.max(0, Number(cursor) || 0);
+  const size = Math.min(Math.max(1, Number(limit) || 8), 25);
+  const slice = incidents.slice(start, start + size);
+  const next = start + size < incidents.length ? start + size : null;
+  return { events: slice, nextCursor: next, total: incidents.length };
+}
+
+export function getIncident(id) {
+  const incident = incidents.find((i) => i.id === id);
+  if (!incident) return null;
+  const ack = acks.get(id) || null;
+  return {
+    ...incident,
+    ack,
+    // A small synthetic timeline so the detail pane has something to render.
+    timeline: [
+      { at: incident.openedAt, label: `Detected by ${incident.source}` },
+      { at: incident.openedAt + 60 * 1000, label: `Paged ${incident.service} on-call` },
+      ...(ack ? [{ at: Date.parse(ack.at), label: `Acknowledged by ${ack.by}` }] : []),
+    ],
+  };
+}
+
+export function listAcks() {
+  return [...acks.values()];
+}
+
+/**
+ * Acknowledge an incident and return the AUTHORITATIVE ack list. The client
+ * applies its own optimistic entry first and then reconciles onto whatever this
+ * returns, so the server owning `by`/`at` is what makes the reconcile visible:
+ * the optimistic row cannot know who acknowledged it.
+ */
+export function acknowledge(id, by = 'ops-bot') {
+  if (!incidents.some((i) => i.id === id)) return null;
+  if (!acks.has(id)) {
+    acks.set(id, { id, by, at: new Date(BOOT_AT).toISOString() });
+  }
+  return listAcks();
+}
+
+export function createIncident({ title, service, severity }) {
+  const incident = {
+    id: `INC-${sequence++}`,
+    title,
+    service,
+    severity,
+    openedAt: BOOT_AT + incidents.length * 1000,
+    source: 'console',
+  };
+  incidents.unshift(incident);
+  return incident;
+}
+
+/**
+ * The metrics roll-up behind the Suspense boundary on /health. Async on purpose:
+ * a synchronous "resource" would resolve during the first render pass and prove
+ * nothing about suspension.
+ */
+export async function summarize() {
+  await new Promise((resolve) => setTimeout(resolve, 15));
+  const bySeverity = {};
+  for (const severity of SEVERITIES) {
+    bySeverity[severity] = incidents.filter((i) => i.severity === severity).length;
+  }
+  return {
+    total: incidents.length,
+    acknowledged: acks.size,
+    open: incidents.length - acks.size,
+    bySeverity,
+    services: SERVICES.length,
+  };
+}

--- a/smoke/apps/ops-console/src/entry-client.js
+++ b/smoke/apps/ops-console/src/entry-client.js
@@ -1,0 +1,28 @@
+// Client entry.
+//
+// Two mounts, on purpose:
+//
+//   hydrate() claims the server's DOM for the console shell, the filter form
+//   and the feed.
+//
+//   mount() then starts the detail pane inside the <aside> the server shipped
+//   empty. Keeping the client router OUT of the hydrated tree means the server
+//   never has to render a route it cannot resolve, and a direct hit on
+//   /incidents/INC-1042 still gets the full console shell in the first byte.
+//
+// Page modules are imported directly rather than through src/routes.js: the
+// route table also pulls in the incident store, which is server-only.
+
+import { h, hydrate, mount } from 'what-framework';
+import Console from './pages/console.js';
+import { DetailPane } from './pane-routes.js';
+
+// The server only ships this entry on console routes, but check anyway: an
+// entry that hydrates one page's component against another page's DOM (and
+// another page's loader data) fails in a way that reads as a framework bug.
+const isConsoleRoute = location.pathname === '/' || location.pathname.startsWith('/incidents/');
+
+if (isConsoleRoute) {
+  hydrate(h(Console, {}), document.body);
+  mount(h(DetailPane, {}), '#detail-pane');
+}

--- a/smoke/apps/ops-console/src/lib/api.js
+++ b/smoke/apps/ops-console/src/lib/api.js
@@ -1,0 +1,44 @@
+// The console's HTTP client. Client-safe: served to the browser, imported by
+// the hydrated page and by the lazily loaded detail panel.
+
+export const PAGE_SIZE = 8;
+
+async function json(url, init) {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    // The message is surfaced in the live region, so keep it short and human.
+    throw new Error(`${res.status} ${res.statusText || 'request failed'}`);
+  }
+  return res.json();
+}
+
+/** One page of the event feed. `cursor` is the offset returned as `nextCursor`. */
+export function fetchEvents(cursor = 0, limit = PAGE_SIZE, signal) {
+  return json(`/api/events?cursor=${cursor}&limit=${limit}`, { signal });
+}
+
+export function fetchIncident(id, signal) {
+  return json(`/api/incidents/${encodeURIComponent(id)}`, { signal });
+}
+
+/** The acknowledgements the server already knows about, read once on boot. */
+export function fetchAcks(signal) {
+  return json('/api/acks', { signal });
+}
+
+/**
+ * Acknowledge. Returns the AUTHORITATIVE ack list, which is what the optimistic
+ * update reconciles onto: the client cannot invent `by`/`at`, so the reconcile
+ * is visible in the row rather than being a no-op that looks like success.
+ */
+export function postAck(id) {
+  return json(`/api/incidents/${encodeURIComponent(id)}/ack`, { method: 'POST' });
+}
+
+export function postIncident(body) {
+  return json('/api/incidents', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/smoke/apps/ops-console/src/lib/format.js
+++ b/smoke/apps/ops-console/src/lib/format.js
@@ -1,0 +1,18 @@
+// Presentation helpers shared by the console page and the detail panel.
+// Client-safe.
+
+/**
+ * Clock time in UTC. Deliberately NOT "3 minutes ago": a relative label computed
+ * from Date.now() differs between the server render and the hydration a moment
+ * later, which is a hydration mismatch the framework would be right to warn
+ * about and an app has no way to win.
+ */
+export function clock(ms) {
+  const d = new Date(ms);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}Z`;
+}
+
+export function shortDate(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}

--- a/smoke/apps/ops-console/src/pages/console.js
+++ b/smoke/apps/ops-console/src/pages/console.js
@@ -1,0 +1,291 @@
+// The console. Server-rendered shell, hydrated, then live.
+//
+// Three async surfaces meet here:
+//   - useInfiniteQuery drives the event feed and APPENDS a page per "load older"
+//   - useOptimistic acknowledges a row instantly and reconciles onto whatever
+//     the server says, or rolls the row back when the server refuses
+//   - the detail pane is a separate client-routed region mounted by
+//     entry-client.js; this page only renders the empty <aside> it lands in
+//
+// The feed itself is deliberately NOT server-rendered: it is a live tail, and
+// the first page arrives from /api/events after hydration. What IS
+// server-rendered is everything an operator needs before JavaScript lands: the
+// chrome, the filter form, the counts from the loader.
+
+import {
+  LiveRegion,
+  Show,
+  computed,
+  effect,
+  h,
+  Head,
+  rules,
+  signal,
+  simpleResolver,
+  useForm,
+  useId,
+  useInfiniteQuery,
+  useLoaderData,
+} from 'what-framework';
+import { useOptimistic } from 'what-server/actions';
+import { Link } from 'what-router';
+
+import { Footer, SeverityTag, TopBar } from '../components/chrome.js';
+import { IncidentDialog } from '../components/incident-dialog.js';
+import { PAGE_SIZE, fetchAcks, fetchEvents, postAck, postIncident } from '../lib/api.js';
+import { clock } from '../lib/format.js';
+
+export const loader = async () => {
+  const { listServices, listSeverities, listEvents } = await import('../data/incidents.js');
+  return {
+    services: listServices(),
+    severities: listSeverities(),
+    total: listEvents(0, 1).total,
+  };
+};
+
+export default function Console() {
+  const { services, severities, total } = useLoaderData();
+
+  const announcement = signal('Console ready. Feed is live.', 'ops:announcement');
+  const serviceFilter = signal('', 'ops:filter');
+  const dialogOpen = signal(false, 'ops:dialogOpen');
+
+  // --- Event feed: one page appended per fetchNextPage() ------------------
+  const feed = useInfiniteQuery({
+    queryKey: ['events'],
+    initialPageParam: 0,
+    queryFn: async ({ pageParam, signal: abort }) => {
+      // The initial fetch lives in an effect, and effects run during SSR too.
+      // Node has no base URL for a relative fetch, so the server render yields
+      // an empty page and the browser performs the real request. Everything
+      // below is written to render that empty state without complaining.
+      if (typeof window === 'undefined') return { events: [], nextCursor: null, total };
+      return fetchEvents(pageParam, PAGE_SIZE, abort);
+    },
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+  });
+
+  const loaded = computed(() => (feed.data().pages || []).flatMap((p) => p.events || []));
+  const rows = computed(() => {
+    const term = serviceFilter();
+    const all = loaded();
+    return term ? all.filter((event) => event.service.includes(term)) : all;
+  });
+
+  // --- Optimistic acknowledge --------------------------------------------
+  // The reducer appends an ack with no `by`: that missing field IS the pending
+  // state. Only the server can fill it in, so a row that says "acknowledged by
+  // ops-bot" cannot be the optimistic guess.
+  const acks = useOptimistic([], (list, action) => [...list, { id: action.id, by: null, at: null }]);
+  const ackIndex = computed(() => new Map(acks.value().map((ack) => [ack.id, ack])));
+
+  // Read the acknowledgements the server already has, so a reload does not
+  // pretend every incident is unacknowledged.
+  //
+  // This wants to be onMount(), and is not. In what-framework 0.12.2 as
+  // published, renderToString calls a component function directly with no
+  // component context, so onMount (and onCleanup, useState, useRef, useEffect,
+  // ...) throws "can only be called inside a component function" and takes the
+  // whole server render down with a 500. A component runs exactly once, and on
+  // the client that once is hydration, so a guarded call in the body does the
+  // same job and works on every build.
+  if (typeof window !== 'undefined') {
+    fetchAcks()
+      .then((list) => acks.set(list))
+      .catch(() => announcement('Could not load existing acknowledgements.'));
+  }
+
+  async function acknowledge(id) {
+    const action = { id };
+    try {
+      const confirmed = await acks.withOptimistic(action, async () => (await postAck(id)).acks);
+      const record = confirmed.find((ack) => ack.id === id);
+      announcement(`${id} acknowledged by ${record ? record.by : 'the server'}.`);
+    } catch (err) {
+      // withOptimistic has already rolled the row back by the time we get here.
+      announcement(`Could not acknowledge ${id}: ${err.message}. Rolled back.`);
+    }
+  }
+
+  // --- Filter form --------------------------------------------------------
+  // useId pairs the label with the input and the input with its two description
+  // slots. The ids have to survive the trip from SSR to hydration or every one
+  // of those relationships points at nothing.
+  const inputId = useId('svc');
+  const hintId = useId('svc-hint');
+  const errorId = useId('svc-error');
+
+  const filterForm = useForm({
+    defaultValues: { service: '' },
+    resolver: simpleResolver({
+      service: [rules.custom((value) => (
+        typeof value === 'string' && value.trim().length === 1
+          ? 'Use at least two characters, or leave it blank to show every service.'
+          : undefined
+      ))],
+    }),
+  });
+
+  const filterError = () => filterForm.formState.error('service');
+
+  const applyFilter = filterForm.handleSubmit((values) => {
+    const term = values.service.trim().toLowerCase();
+    serviceFilter(term);
+    announcement(term ? `Feed filtered to services matching "${term}".` : 'Service filter cleared.');
+  });
+
+  // `aria-describedby` has to point at the error slot only while there IS an
+  // error, and a function-valued attribute prop does not survive SSR (the
+  // server serializes the thunk itself). So the server writes the static hint
+  // pairing and the client takes over through a ref-scoped effect, which is
+  // also what proves the client's useId sequence matches the server's: a drifted
+  // id would leave this attribute pointing at an element that does not exist.
+  const describeInput = (el) => {
+    if (!el) return;
+    effect(() => {
+      el.setAttribute('aria-describedby', filterError() ? `${errorId()} ${hintId()}` : hintId());
+    });
+  };
+
+  // --- Create ------------------------------------------------------------
+  async function createIncident(values) {
+    const { incident } = await postIncident(values);
+    dialogOpen(false);
+    // refetch() replaces the loaded pages with a fresh first page, which is
+    // where a brand new incident lands (the feed is newest first).
+    await feed.refetch();
+    announcement(`${incident.id} declared: ${incident.title}`);
+  }
+
+  return h('div', { class: 'app' },
+    h(Head, {
+      title: 'Northwind Ops Console',
+      meta: [{ name: 'description', content: 'Incident feed, acknowledgements and service health.' }],
+    }),
+    h(TopBar, { current: 'console' }),
+
+    h('main', { class: 'grid' },
+      h('section', { class: 'col feed-col', 'aria-labelledby': 'feed-heading' },
+        h('div', { class: 'col-head' },
+          h('h1', { id: 'feed-heading' }, 'Event feed'),
+          h('button', {
+            type: 'button',
+            class: 'primary',
+            'data-new-incident': '',
+            onclick: () => dialogOpen(true),
+          }, 'Declare incident'),
+        ),
+
+        h('form', { class: 'filter', onsubmit: applyFilter, 'data-filter-form': '' },
+          h('label', { for: inputId(), class: 'filter-label' }, 'Service'),
+          h('input', {
+            id: inputId(),
+            name: 'service',
+            type: 'search',
+            autocomplete: 'off',
+            placeholder: 'payments',
+            'data-filter-input': '',
+            'aria-describedby': hintId(),
+            ref: describeInput,
+            oninput: filterForm.register('service').oninput,
+            onblur: filterForm.register('service').onBlur,
+          }),
+          h('button', { type: 'submit', class: 'ghost', 'data-filter-apply': '' }, 'Apply'),
+          h('p', { id: errorId(), class: 'field-error', role: 'alert', 'data-filter-error': '' },
+            () => filterError()?.message || ''),
+          h('p', { id: hintId(), class: 'hint', 'data-filter-hint': '' },
+            `Filter the loaded events by service. ${services.length} services reporting.`),
+        ),
+
+        h('ul', { class: 'feed', 'data-feed': '' }, () => {
+          const index = ackIndex();
+          const list = rows();
+          if (list.length === 0) {
+            return h('li', { class: 'feed-empty', 'data-feed-empty': '' },
+              serviceFilter() ? 'No loaded events match that service.' : 'Waiting for the event stream...');
+          }
+          return list.map((event) => {
+            const ack = index.get(event.id);
+            const state = !ack ? 'open' : (ack.by ? 'confirmed' : 'pending');
+            return h('li', {
+              key: event.id,
+              class: `row row-${state}`,
+              'data-row': event.id,
+              'data-service': event.service,
+              'data-ack-state': state,
+              'data-acked-by': ack && ack.by ? ack.by : '',
+            },
+              h(Link, {
+                href: `/incidents/${event.id}`,
+                class: 'row-main',
+                'data-open': event.id,
+                prefetch: false,
+                transition: false,
+              },
+                h('span', { class: 'row-id' }, event.id),
+                h('span', { class: 'row-title' }, event.title),
+              ),
+              h('span', { class: 'row-meta' },
+                h(SeverityTag, { severity: event.severity }),
+                h('span', { class: 'row-service' }, event.service),
+                h('time', { class: 'row-time' }, clock(event.openedAt)),
+              ),
+              h('span', { class: 'row-ack', 'data-ack-label': event.id },
+                state === 'open' ? '' : (state === 'pending' ? 'acknowledging...' : `ack ${ack.by}`)),
+              state === 'open'
+                ? h('button', {
+                  type: 'button',
+                  class: 'ack',
+                  'data-ack': event.id,
+                  onclick: () => acknowledge(event.id),
+                }, 'Ack')
+                : h('button', { type: 'button', class: 'ack', disabled: true }, 'Ack'),
+            );
+          });
+        }),
+
+        h('div', { class: 'feed-actions' },
+          h('button', {
+            type: 'button',
+            class: 'ghost',
+            'data-load-more': '',
+            onclick: () => feed.fetchNextPage(),
+          }, 'Load older events'),
+          h('span', { class: 'muted', 'data-feed-status': '' }, () => {
+            if (feed.isFetchingNextPage()) return 'Loading...';
+            const shown = rows().length;
+            const all = loaded().length;
+            const suffix = shown === all ? '' : ` (${all} loaded)`;
+            return feed.hasNextPage()
+              ? `${shown} of ${total} events${suffix}`
+              : `all ${all} events loaded${suffix}`;
+          }),
+        ),
+      ),
+
+      // Client-routed region. entry-client.js mounts a Suspense boundary and a
+      // Router here; the server ships it empty so there is nothing to mismatch.
+      h('aside', { id: 'detail-pane', class: 'col pane', 'aria-label': 'Incident detail' }),
+    ),
+
+    // The status strip is the live region. Visible on purpose: an operator
+    // should see the same thing a screen reader hears.
+    h('div', { class: 'statusbar', 'data-announcer': '' },
+      h(LiveRegion, { priority: 'polite' }, () => announcement()),
+    ),
+
+    h('div', { id: 'dialog-root' }),
+
+    h(Show, { when: dialogOpen },
+      h(IncidentDialog, {
+        services,
+        severities,
+        onClose: () => dialogOpen(false),
+        onCreate: createIncident,
+      }),
+    ),
+
+    h(Footer, {}),
+  );
+}

--- a/smoke/apps/ops-console/src/pages/health.js
+++ b/smoke/apps/ops-console/src/pages/health.js
@@ -1,0 +1,118 @@
+// /health: the console's own diagnostics page. Server-rendered, zero JavaScript
+// shipped for it (entry-client.js hydrates the console and nothing else).
+//
+// Two things live here:
+//
+//   1. The metrics roll-up, behind a Suspense boundary. createResource on the
+//      server throws its pending promise, so the FIRST render pass emits the
+//      fallback; renderToStringAsync awaits the resource and re-renders with
+//      real numbers, and those numbers are also emitted into #__what_data.
+//
+//   2. An SSR self-test that renders the exact same panel twice, once
+//      synchronously and once asynchronously, and shows both results. A
+//      synchronous render cannot await, so it can only produce the fallback.
+//      That is the difference an operator is looking at, and it is also the
+//      only way to SEE the fallback: by the time the page is served, the async
+//      render has already replaced it.
+//
+// This module is deliberately NOT in the static allowlist in server.js, so it
+// can import the incident store directly.
+
+import { Head, Suspense, createResource, h } from 'what-framework';
+import { renderToString, renderToStringAsync } from 'what-framework/server';
+
+import { Footer, TopBar } from '../components/chrome.js';
+import { BOOT_AT, summarize } from '../data/incidents.js';
+import { clock } from '../lib/format.js';
+
+const SUMMARY_KEY = 'ops-summary';
+
+function SummarySkeleton() {
+  return h('p', { class: 'skeleton', 'data-summary-skeleton': '' },
+    'Rolling up incident metrics...');
+}
+
+function metric(label, value, key) {
+  return h('div', { class: 'metric' },
+    h('dt', {}, label),
+    h('dd', { [`data-metric-${key}`]: '' }, String(value)),
+  );
+}
+
+function SummaryPanel() {
+  // `key` matters twice: it names the entry in #__what_data, and it is what a
+  // client-side createResource would seed from instead of refetching.
+  const [summary] = createResource(summarize, { key: SUMMARY_KEY });
+  const s = summary();
+  return h('dl', { class: 'metrics', 'data-summary': '' },
+    metric('Open', s.open, 'open'),
+    metric('Acknowledged', s.acknowledged, 'acknowledged'),
+    metric('Tracked', s.total, 'total'),
+    metric('Critical', s.bySeverity.critical, 'critical'),
+    metric('Services', s.services, 'services'),
+  );
+}
+
+const probe = () => h(Suspense, { fallback: h(SummarySkeleton, {}) }, h(SummaryPanel, {}));
+
+export const loader = async () => {
+  const syncPass = renderToString(probe());
+  const { body: asyncPass } = await renderToStringAsync(probe());
+  return { syncPass, asyncPass, bootAt: BOOT_AT };
+};
+
+export default function Health({ loaderData }) {
+  const { syncPass, asyncPass, bootAt } = loaderData;
+  const fallbackFirst = syncPass.includes('data-summary-skeleton');
+  const resolvedAfter = asyncPass.includes('data-summary')
+    && !asyncPass.includes('data-summary-skeleton');
+
+  return h('div', { class: 'app' },
+    h(Head, {
+      title: 'Health | Northwind Ops',
+      meta: [{ name: 'description', content: 'Render pipeline diagnostics and incident metrics.' }],
+    }),
+    h(TopBar, { current: 'health' }),
+
+    h('main', { class: 'container' },
+      h('h1', {}, 'Health'),
+      h('p', { class: 'lede' },
+        'Everything on this page is server-rendered. The panel below sits behind a ',
+        h('code', {}, 'Suspense'),
+        ' boundary and its data arrives from a ',
+        h('code', {}, 'createResource'),
+        ' that suspends during SSR.'),
+
+      h('section', { class: 'card' },
+        h('h2', {}, 'Incident metrics'),
+        h(Suspense, { fallback: h(SummarySkeleton, {}) }, h(SummaryPanel, {})),
+      ),
+
+      h('section', { class: 'card' },
+        h('h2', {}, 'SSR suspense self-test'),
+        h('p', {
+          class: fallbackFirst && resolvedAfter ? 'verdict pass' : 'verdict fail',
+          'data-selftest': fallbackFirst && resolvedAfter ? 'pass' : 'fail',
+        }, fallbackFirst && resolvedAfter
+          ? 'PASS: the synchronous pass emits the fallback, the async pass emits resolved data.'
+          : 'FAIL: the two render passes did not differ as expected.'),
+
+        h('h3', {}, 'renderToString (synchronous, cannot await)'),
+        h('pre', { class: 'code', 'data-selftest-sync': '' }, syncPass),
+
+        h('h3', {}, 'renderToStringAsync (awaits the resource, re-renders)'),
+        h('pre', { class: 'code', 'data-selftest-async': '' }, asyncPass),
+      ),
+
+      h('section', { class: 'card' },
+        h('h2', {}, 'Process'),
+        h('dl', { class: 'metrics' },
+          metric('Feed epoch', clock(bootAt), 'epoch'),
+          metric('Store', 'in-memory', 'store'),
+        ),
+      ),
+    ),
+
+    h(Footer, {}),
+  );
+}

--- a/smoke/apps/ops-console/src/pane-routes.js
+++ b/smoke/apps/ops-console/src/pane-routes.js
@@ -1,0 +1,43 @@
+// The detail pane: a client-routed region mounted into the <aside> the server
+// shipped empty.
+//
+// The Suspense boundary sits ABOVE the Router on purpose. A lazy component
+// suspends by throwing its load promise, and the boundary has to be an ancestor
+// of whatever the router builds for the current URL, or the throw escapes as an
+// uncaught error and the route renders permanently blank.
+//
+// The detail module is a real dynamic import, so on a cold cache the fallback
+// below is what an operator sees while the chunk is in flight.
+
+import { Suspense, h, lazy } from 'what-framework';
+import { Router } from 'what-router';
+
+const IncidentDetail = lazy(() => import('./panels/incident-detail.js'));
+
+function EmptyPane() {
+  return h('div', { class: 'pane-empty', 'data-pane-empty': '' },
+    h('p', {}, 'Select an incident'),
+    h('p', { class: 'muted' }, 'The detail panel loads on demand.'),
+  );
+}
+
+function PaneSkeleton() {
+  return h('div', { class: 'pane-skeleton', 'data-pane-skeleton': '' },
+    h('p', { class: 'muted' }, 'Loading detail panel...'),
+    h('div', { class: 'skeleton-bar' }),
+    h('div', { class: 'skeleton-bar short' }),
+    h('div', { class: 'skeleton-bar' }),
+  );
+}
+
+export function DetailPane() {
+  return h(Suspense, { fallback: h(PaneSkeleton, {}) },
+    h(Router, {
+      routes: [
+        { path: '/', component: EmptyPane },
+        { path: '/incidents/:id', component: IncidentDetail },
+      ],
+      fallback: EmptyPane,
+    }),
+  );
+}

--- a/smoke/apps/ops-console/src/panels/incident-detail.js
+++ b/smoke/apps/ops-console/src/panels/incident-detail.js
@@ -1,0 +1,66 @@
+// The lazily loaded detail panel. Its own module, reached only by navigating to
+// /incidents/:id, so it is never in the first byte the browser parses.
+
+import { h, useQuery } from 'what-framework';
+import { useParams } from 'what-router';
+
+import { SeverityTag } from '../components/chrome.js';
+import { fetchIncident } from '../lib/api.js';
+import { clock, shortDate } from '../lib/format.js';
+
+export default function IncidentDetail() {
+  // The router rebuilds this component for every navigation, so reading the
+  // param once in the body is correct: a second incident is a second instance.
+  const { id } = useParams();
+
+  const query = useQuery({
+    queryKey: ['incident', id],
+    queryFn: ({ signal }) => fetchIncident(id, signal),
+    staleTime: 15_000,
+  });
+
+  return h('article', { class: 'detail', 'data-detail': id },
+    h('header', { class: 'detail-head' },
+      h('p', { class: 'detail-id' }, id),
+      h('h2', { 'data-detail-title': '' }, () => query.data()?.title ?? 'Loading incident...'),
+    ),
+
+    h('div', { class: 'detail-body' }, () => {
+      if (query.isError()) {
+        return h('p', { class: 'field-error' }, `Could not load ${id}: ${query.error()?.message}`);
+      }
+      const incident = query.data();
+      if (!incident) return h('p', { class: 'muted', 'data-detail-loading': '' }, 'Fetching detail...');
+
+      return [
+        h('dl', { class: 'metrics' },
+          h('div', { class: 'metric' },
+            h('dt', {}, 'Service'),
+            h('dd', { 'data-detail-service': '' }, incident.service)),
+          h('div', { class: 'metric' },
+            h('dt', {}, 'Severity'),
+            h('dd', {}, h(SeverityTag, { severity: incident.severity }))),
+          h('div', { class: 'metric' },
+            h('dt', {}, 'Opened'),
+            h('dd', {}, `${shortDate(incident.openedAt)} ${clock(incident.openedAt)}`)),
+          h('div', { class: 'metric' },
+            h('dt', {}, 'Source'),
+            h('dd', {}, incident.source)),
+        ),
+
+        h('h3', {}, 'Timeline'),
+        h('ol', { class: 'timeline', 'data-detail-timeline': '' },
+          incident.timeline.map((entry, i) =>
+            h('li', { key: `${incident.id}-${i}` },
+              h('time', {}, clock(entry.at)),
+              h('span', {}, entry.label))),
+        ),
+
+        h('p', { class: 'muted', 'data-detail-ack': '' },
+          incident.ack
+            ? `Acknowledged by ${incident.ack.by}.`
+            : 'Not acknowledged yet.'),
+      ];
+    }),
+  );
+}

--- a/smoke/apps/ops-console/src/routes.js
+++ b/smoke/apps/ops-console/src/routes.js
@@ -1,0 +1,40 @@
+// Server route table. Importing this pulls in the incident store, so it is
+// never served to the browser.
+
+import Console, { loader as consoleLoader } from './pages/console.js';
+import Health, { loader as healthLoader } from './pages/health.js';
+
+// `hydrate: false` means the page ships no client entry at all. /health is
+// static diagnostics with no interactive state, so sending it a bundle that
+// would then try to hydrate the CONSOLE component is worse than useless: it
+// throws on the loader data of a different page.
+export const routes = [
+  { path: '/', component: Console, loader: consoleLoader, hydrate: true },
+  // A deep link to an incident renders the same shell: the pane is client-routed,
+  // so the server's job is to ship the console and let the router resolve the id.
+  { path: '/incidents/:id', component: Console, loader: consoleLoader, hydrate: true },
+  { path: '/health', component: Health, loader: healthLoader, hydrate: false },
+];
+
+/** Tiny matcher: one optional `:param` segment is all this app's paths need. */
+export function matchPath(pathname) {
+  for (const route of routes) {
+    const routeParts = route.path.split('/');
+    const urlParts = pathname.split('/');
+    if (routeParts.length !== urlParts.length) continue;
+
+    const params = {};
+    let matched = true;
+    for (let i = 0; i < routeParts.length; i++) {
+      if (routeParts[i].startsWith(':')) {
+        if (!urlParts[i]) { matched = false; break; }
+        params[routeParts[i].slice(1)] = decodeURIComponent(urlParts[i]);
+      } else if (routeParts[i] !== urlParts[i]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return { route, params };
+  }
+  return null;
+}

--- a/smoke/apps/ops-console/src/styles.css
+++ b/smoke/apps/ops-console/src/styles.css
@@ -1,0 +1,486 @@
+/* Northwind Ops Console. Dark by default: this is a wallboard, and a wallboard
+   that glows white at 3am is a wallboard nobody looks at. */
+
+:root {
+  color-scheme: dark;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --bg: #080d16;
+  --panel: #0e1626;
+  --panel-2: #131f33;
+  --line: #1f2d45;
+  --ink: #e6edf7;
+  --muted: #8697b0;
+  --accent: #38bdf8;
+  --accent-ink: #052437;
+  --critical: #f87171;
+  --major: #fbbf24;
+  --minor: #60a5fa;
+  --ok: #34d399;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(1100px 480px at 12% -8%, #12233c 0%, transparent 60%),
+    var(--bg);
+  color: var(--ink);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+a { color: var(--accent); }
+
+code, pre, .row-id, .row-time, time {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+}
+
+/* --- chrome ------------------------------------------------------------- */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.85rem 1.5rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(8, 13, 22, 0.85);
+  backdrop-filter: blur(6px);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.brand-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--ok);
+  box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.16);
+}
+
+.topbar nav { display: flex; gap: 0.35rem; }
+
+.nav-link {
+  padding: 0.3rem 0.7rem;
+  border-radius: 8px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.nav-link:hover { color: var(--ink); background: var(--panel-2); }
+.nav-link.is-active { color: var(--accent); background: rgba(56, 189, 248, 0.1); }
+
+.site-footer {
+  padding: 1.5rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+/* --- layout ------------------------------------------------------------- */
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.85fr) minmax(0, 1fr);
+  gap: 1.25rem;
+  padding: 1.25rem 1.5rem 2rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .grid { grid-template-columns: minmax(0, 1fr); }
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+}
+
+.col {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1.1rem 1.15rem 1.25rem;
+}
+
+.col-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.9rem;
+}
+
+h1 { font-size: 1.25rem; margin: 0; letter-spacing: -0.01em; }
+h2 { font-size: 1.02rem; margin: 0 0 0.55rem; }
+h3 { font-size: 0.85rem; margin: 1.1rem 0 0.35rem; color: var(--muted); font-weight: 600; }
+
+.lede, .muted, .hint { color: var(--muted); }
+.lede { margin-top: 0.35rem; }
+
+/* --- buttons ------------------------------------------------------------ */
+
+button {
+  font: inherit;
+  border-radius: 9px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--ink);
+  padding: 0.38rem 0.85rem;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) { border-color: var(--accent); }
+button:disabled { opacity: 0.4; cursor: default; }
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+
+button.ghost { background: transparent; }
+
+.icon-button {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 1.15rem;
+  line-height: 1;
+  padding: 0.2rem 0.45rem;
+}
+
+/* --- filter form -------------------------------------------------------- */
+
+.filter {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.5rem 0.7rem;
+  align-items: center;
+  padding: 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--panel-2);
+  margin-bottom: 0.9rem;
+}
+
+.filter-label { font-size: 0.85rem; color: var(--muted); }
+
+.filter input {
+  font: inherit;
+  padding: 0.35rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: #0a1120;
+  color: var(--ink);
+  width: 100%;
+}
+
+.filter .hint,
+.filter .field-error {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.field-error { color: var(--critical); }
+.field-error:empty { display: none; }
+
+/* --- feed --------------------------------------------------------------- */
+
+.feed {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 9px;
+  border: 1px solid transparent;
+}
+
+.row:hover { background: var(--panel-2); }
+.row-pending { opacity: 0.62; }
+.row-confirmed { border-color: rgba(52, 211, 153, 0.28); }
+
+.row-main {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  min-width: 0;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.row-main.exact-active { color: var(--accent); }
+
+.row-id { color: var(--muted); font-size: 0.78rem; white-space: nowrap; }
+
+.row-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-meta { display: flex; align-items: center; gap: 0.55rem; }
+.row-service { color: var(--muted); font-size: 0.78rem; }
+.row-time { color: var(--muted); font-size: 0.75rem; }
+
+.row-ack {
+  font-size: 0.72rem;
+  color: var(--ok);
+  min-width: 5.75rem;
+  text-align: right;
+}
+
+.row-pending .row-ack { color: var(--muted); font-style: italic; }
+
+.feed-empty {
+  padding: 1.5rem 0.6rem;
+  color: var(--muted);
+}
+
+.feed-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.9rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--line);
+  font-size: 0.82rem;
+}
+
+.sev {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+  padding: 0.1rem 0.42rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+}
+
+.sev-critical { color: var(--critical); }
+.sev-major { color: var(--major); }
+.sev-minor { color: var(--minor); }
+
+/* --- detail pane -------------------------------------------------------- */
+
+.pane { min-height: 22rem; position: sticky; top: 4.5rem; }
+
+.pane-empty {
+  display: grid;
+  place-content: center;
+  gap: 0.2rem;
+  min-height: 18rem;
+  text-align: center;
+}
+
+.pane-skeleton { display: grid; gap: 0.55rem; }
+
+.skeleton-bar {
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, var(--panel-2), #1c2b45, var(--panel-2));
+  background-size: 200% 100%;
+  animation: sweep 1.1s linear infinite;
+}
+
+.skeleton-bar.short { width: 55%; }
+
+.skeleton {
+  color: var(--muted);
+  animation: pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes sweep {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+@keyframes pulse {
+  50% { opacity: 0.45; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-bar, .skeleton { animation: none; }
+}
+
+.detail-head { border-bottom: 1px solid var(--line); padding-bottom: 0.6rem; }
+.detail-id { margin: 0; color: var(--muted); font-size: 0.75rem; }
+.detail-head h2 { margin: 0.15rem 0 0; }
+.detail-body { padding-top: 0.7rem; }
+
+/* The pane is the narrow column, so its metrics get two fixed columns rather
+   than auto-fit, which otherwise squeezes a service name onto three lines. */
+.detail .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.detail .metric dd { font-size: 0.95rem; font-weight: 600; }
+
+.timeline {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+}
+
+.timeline time { color: var(--muted); margin-right: 0.5rem; }
+
+/* --- metrics ------------------------------------------------------------ */
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+  gap: 0.6rem;
+  margin: 0.4rem 0 0;
+}
+
+.metric {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+}
+
+.metric dt { color: var(--muted); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.metric dd { margin: 0.15rem 0 0; font-size: 1.3rem; font-weight: 650; }
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1rem 1.1rem 1.2rem;
+  margin-top: 1.1rem;
+}
+
+.verdict {
+  font-size: 0.85rem;
+  border-radius: 9px;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid;
+}
+
+.verdict.pass { color: var(--ok); border-color: rgba(52, 211, 153, 0.4); background: rgba(52, 211, 153, 0.08); }
+.verdict.fail { color: var(--critical); border-color: rgba(248, 113, 113, 0.4); background: rgba(248, 113, 113, 0.08); }
+
+.code {
+  background: #060b14;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.74rem;
+  overflow-x: auto;
+  color: #a9bdd8;
+  margin: 0;
+}
+
+/* --- status bar (the live region) --------------------------------------- */
+
+.statusbar {
+  position: sticky;
+  bottom: 0;
+  margin: 0 1.5rem 1.25rem;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel-2);
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.statusbar::before {
+  content: "status";
+  color: var(--accent);
+  text-transform: uppercase;
+  font-size: 0.66rem;
+  letter-spacing: 0.09em;
+  margin-right: 0.6rem;
+}
+
+/* --- dialog ------------------------------------------------------------- */
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 15, 0.72);
+  z-index: 20;
+}
+
+.dialog {
+  position: fixed;
+  z-index: 21;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(31rem, calc(100vw - 2rem));
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 15px;
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55);
+  padding: 1rem 1.1rem 1.15rem;
+}
+
+.dialog-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.7rem;
+}
+
+.dialog-head h2 { margin: 0; }
+
+.dialog-body { display: grid; gap: 0.7rem; }
+
+.field { display: grid; gap: 0.25rem; font-size: 0.85rem; }
+.field > span { color: var(--muted); }
+
+.field input,
+.field select {
+  font: inherit;
+  padding: 0.4rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: #0a1120;
+  color: var(--ink);
+  width: 100%;
+}
+
+.field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 0.7rem; }
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.2rem;
+}

--- a/smoke/apps/scrollytelling/.gitignore
+++ b/smoke/apps/scrollytelling/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/smoke/apps/scrollytelling/package.json
+++ b/smoke/apps/scrollytelling/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "smoke-scrollytelling",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Scrollytelling smoke app: a server-rendered narrative page with five island hydration modes and scroll-driven animation.",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  },
+  "dependencies": {
+    "what-framework": "0.12.2",
+    "what-server": "0.12.2"
+  }
+}

--- a/smoke/apps/scrollytelling/package.json
+++ b/smoke/apps/scrollytelling/package.json
@@ -9,7 +9,7 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "what-framework": "0.12.2",
-    "what-server": "0.12.2"
+    "what-framework": "0.12.3",
+    "what-server": "0.12.3"
   }
 }

--- a/smoke/apps/scrollytelling/public/favicon.svg
+++ b/smoke/apps/scrollytelling/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#141210"/>
+  <path d="M9 13 L23 13 L19.5 20 L12.5 20 Z" fill="#c8912f"/>
+  <path d="M16 20 L16 27" stroke="#c8912f" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="16" cy="8" r="2" fill="#f0d9a8"/>
+</svg>

--- a/smoke/apps/scrollytelling/server.js
+++ b/smoke/apps/scrollytelling/server.js
@@ -1,0 +1,93 @@
+// Scrollytelling smoke app: one server-rendered page. `npm run dev` (auto-restart)
+// or `node server.js`, then open http://localhost:3000.
+//
+// There is one route and no data layer, so there is no adapter and no ISR
+// engine here: renderDocument() is the whole server. Buildless, like the
+// storefront: the browser loads /src/entry-client.js as a native ES module and
+// the import map below resolves its bare specifiers.
+
+import http from 'node:http';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { renderDocument } from 'what-framework/server';
+
+import StoryPage from './src/page.js';
+
+const ROOT = fileURLToPath(new URL('.', import.meta.url));
+
+const importMap = {
+  imports: {
+    'what-framework': '/node_modules/what-framework/src/index.js',
+    'what-core': '/node_modules/what-core/src/index.js',
+  },
+};
+
+export const documentOptions = {
+  clientEntry: '/src/entry-client.js',
+  head:
+    `<script type="importmap">${JSON.stringify(importMap)}</script>`
+    + '<link rel="stylesheet" href="/src/styles.css">'
+    + '<link rel="icon" type="image/svg+xml" href="/favicon.svg">',
+};
+
+export function renderStory() {
+  return renderDocument({ default: StoryPage }, {}, documentOptions);
+}
+
+// --- Static files -----------------------------------------------------------
+
+const MIME = {
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+};
+
+// Deny by default: only the client half of the app and the framework sources
+// are reachable over HTTP. server.js itself is never served.
+const SERVED_PREFIXES = [
+  '/src/',
+  '/node_modules/what-framework/',
+  '/node_modules/what-core/',
+];
+
+function resolveStaticFile(pathname) {
+  if (pathname.includes('..') || pathname.includes(' ')) return null;
+  const allowed = SERVED_PREFIXES.some((p) => pathname.startsWith(p));
+  const file = allowed ? resolve(join(ROOT, pathname)) : resolve(join(ROOT, 'public', pathname));
+  if (!file.startsWith(resolve(ROOT))) return null;
+  if (!existsSync(file) || !statSync(file).isFile()) return null;
+  return file;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const pathname = decodeURIComponent(url.pathname);
+
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      const file = resolveStaticFile(pathname);
+      if (file) {
+        res.writeHead(200, { 'content-type': MIME[extname(file)] || 'application/octet-stream' });
+        if (req.method === 'HEAD') return res.end();
+        return createReadStream(file).pipe(res);
+      }
+      if (pathname === '/') {
+        const html = await renderStory();
+        res.writeHead(200, {
+          'content-type': 'text/html; charset=utf-8',
+          'cache-control': 'no-store',
+        });
+        return res.end(html);
+      }
+    }
+
+    res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+    res.end('Not found');
+  });
+
+  const port = Number(process.env.PORT) || 3000;
+  server.listen(port, () => console.log(`Northline 01 ready at http://localhost:${port}`));
+}

--- a/smoke/apps/scrollytelling/smoke.config.mjs
+++ b/smoke/apps/scrollytelling/smoke.config.mjs
@@ -1,0 +1,473 @@
+// Scrollytelling smoke contract.
+//
+// The whole difficulty of this app is proving an island hydrated when it should
+// and NOT BEFORE. "It eventually became interactive" is true of every mode, so
+// every deferred mode below is asserted twice: once while its trigger has not
+// happened, once after it has. The signal for "hydrated" is the island
+// runtime's own bookkeeping (`data-hydrate` removed, `data-island-hydrated`
+// added, plus a bubbling `island:hydrated` event), read out of the DOM rather
+// than inferred from behaviour.
+//
+// Session A runs at 800px wide on purpose: `(min-width: 900px)` must be FALSE
+// at load, otherwise the media island hydrates in the same microtask as the
+// load island and the two are no longer distinguishable.
+//
+// ---------------------------------------------------------------------------
+// THREE FRAMEWORK DEFECTS THIS APP HAD TO WORK AROUND (0.12.2, both sources)
+//
+// 1. Every component-scoped hook THROWS during SSR, so a component that uses
+//    one cannot be server-rendered at all. `renderToString` (what-server
+//    index.js) calls a component as `vnode.tag(props)` directly instead of
+//    going through `createComponent`, so `getCurrentComponent()` is null and
+//    `getCtx()` in what-core hooks.js raises. Measured: useState, useRef,
+//    useEffect, useMemo, onMount and onCleanup all throw; useId and
+//    useLoaderData survive because they never ask for a component context.
+//
+//      import { h, onMount } from 'what-framework';
+//      import { renderToString } from 'what-framework/server';
+//      renderToString(h(() => { onMount(() => {}); return h('p', {}, 'hi'); }, {}));
+//      // -> Error: [what] onMount() can only be called inside a component function
+//
+//    onMount is the documented way to run client-only setup, and this makes it
+//    unusable in any SSR'd component. Worked around by doing that setup from a
+//    `ref` (skipped on the server, fires on the client) and from entry-client.
+//
+// 2. A function-valued attribute prop serializes its SOURCE TEXT in SSR.
+//    `setProp` in what-core dom.js wraps a function prop in an effect, so
+//    `style={() => ...}` is the documented reactive-attribute form on the
+//    client. `renderAttrs` in what-server never calls it and falls through to
+//    `String(val)`:
+//
+//      renderToString(h('div', { style: () => 'width:50%' }))
+//      // -> <div style="() =&gt; &#39;width:50%&#39;">
+//
+//    Every reactive attribute on this page is therefore driven from a ref plus
+//    an effect (see `bindEl` in src/motion.js). The supporting check below
+//    ("no function source leaked") pins the workaround.
+//
+// 3. The scheduler drops a read queued from inside a write, which hangs
+//    `cssTransition()`. `flushScheduler` clears its `scheduled` flag only after
+//    BOTH queues drain, so a `schedule()` call made during the flush is a
+//    no-op and no frame is ever requested:
+//
+//      scheduleWrite(() => { scheduleRead(() => console.log('never runs')); });
+//      // silent until unrelated code touches the scheduler, then it drains
+//
+//    cssTransition does exactly that (write -> read for the reflow -> write),
+//    so an enter/leave transition stalls after its first class unless
+//    something else happens to poke the scheduler. That is why the enter half
+//    of this page's notes drawer appeared to work and the exit half did not.
+//    `runTransition` in src/motion.js pumps a frame while a transition is in
+//    flight; the classes asserted below are still cssTransition's own.
+// ---------------------------------------------------------------------------
+
+import { startProcess, waitForHttp, withPage } from '../../harness/index.mjs';
+
+/**
+ * The server HTML between one island marker and the next. Islands are never
+ * nested here, so this slice is exactly one island's server-rendered content.
+ */
+function islandSlice(html, name) {
+  const start = html.indexOf(`data-island="${name}"`);
+  if (start === -1) return '';
+  const rest = html.slice(start);
+  const next = rest.indexOf('data-island=', 1);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+export default {
+  description: 'Scrollytelling essay: five island hydration modes, scroll progress, intersect reveals, spring/tween and an enter/leave transition.',
+
+  covers: [
+    'island:load',
+    'island:idle',
+    'island:visible',
+    'island:interaction',
+    'island:media',
+    'island:ssr-content',
+    'anim:scroll-progress',
+    'anim:intersect',
+    'anim:spring-tween',
+    'anim:transition',
+  ],
+
+  async check({ workDir, appPort, browser, check, reporter, log }) {
+    const base = `http://127.0.0.1:${appPort}`;
+
+    const server = startProcess('node', ['server.js'], {
+      cwd: workDir,
+      env: { ...process.env, PORT: String(appPort), NODE_ENV: '' },
+    });
+    await waitForHttp(`${base}/`, { child: server });
+
+    // === Server HTML: islands ship real content ===========================
+    const html = await (await fetch(`${base}/`)).text();
+
+    const slices = {
+      ChapterNav: { needle: 'Where it starts', mode: 'idle' },
+      Colorway: { needle: 'Oxblood', mode: 'load' },
+      LumenMeter: { needle: '1,240 lm', mode: 'visible' },
+      SpecExplorer: { needle: 'Colour temperature', mode: 'interaction' },
+      WideCompare: { needle: 'The 60 W bulb it replaces', mode: 'media' },
+    };
+
+    const ssr = {};
+    for (const [name, { needle, mode }] of Object.entries(slices)) {
+      const slice = islandSlice(html, name);
+      ssr[name] = {
+        bytes: slice.length,
+        hasContent: slice.includes(needle),
+        mode: slice.includes(`data-island-mode="${mode}"`),
+      };
+    }
+
+    const specSlice = islandSlice(html, 'SpecExplorer');
+    const specRows = (specSlice.match(/<tr\b/g) || []).length;
+
+    check('island:ssr-content',
+      Object.values(ssr).every((s) => s.hasContent && s.mode)
+        && specSlice.includes('<table class="spec-table"')
+        && specRows === 12 // 11 spec rows plus the header row
+        && specSlice.includes('2700K'),
+      'every island renders its component into the server HTML, not a placeholder',
+      Object.entries(ssr).map(([n, s]) => `${n}=${s.bytes}B/${s.hasContent ? 'real' : 'EMPTY'}`).join(' ')
+        + ` specRows=${specRows}`);
+
+    // The counterpart claim: nothing is hydrated in the bytes the server sent.
+    reporter.assert(
+      !html.includes('data-island-hydrated') && (html.match(/data-hydrate="/g) || []).length === 5,
+      'server HTML marks all five islands as awaiting hydration',
+      `hydrate-markers=${(html.match(/data-hydrate="/g) || []).length}`);
+
+    // A reactive attribute would betray itself here as serialized source text.
+    reporter.assert(!/=("|')\s*\(?[^"']*=>/.test(html),
+      'no function source leaked into a server-rendered attribute');
+
+    // === Session A: island lifecycle ======================================
+    // 800px wide so `(min-width: 900px)` is false and the media island stays
+    // asleep; 720px tall so six 100vh chapters are genuinely six screens.
+    const narrow = await browser.newContext({
+      viewport: { width: 800, height: 720 },
+      reducedMotion: 'no-preference',
+    });
+
+    try {
+      await withPage(browser, `${base}/`, async (page, diag) => {
+        // `attached`, not `visible`: the chapter rail is display:none below
+        // 1100px, and hydration has nothing to do with whether CSS shows it.
+        await page.waitForSelector('[data-island="ChapterNav"][data-island-hydrated]',
+          { state: 'attached', timeout: 10000 });
+
+        const atLoad = await page.evaluate(() => ({
+          atMicrotask: document.documentElement.dataset.islandsAtMicrotask ?? '(unset)',
+          live: [...document.querySelectorAll('[data-island-hydrated]')].map((el) => el.getAttribute('data-island')).sort(),
+          pending: [...document.querySelectorAll('[data-hydrate]')]
+            .map((el) => `${el.getAttribute('data-island')}:${el.getAttribute('data-hydrate')}`).sort(),
+          logged: [...document.querySelectorAll('[data-hydrated-island]')].map((el) => el.getAttribute('data-hydrated-island')),
+          revealed: Object.fromEntries([...document.querySelectorAll('[data-chapter]')]
+            .map((el) => [el.getAttribute('data-chapter'), el.hasAttribute('data-revealed')])),
+        }));
+
+        // `load` schedules with queueMicrotask; every other mode waits for a
+        // task. So the microtask snapshot taken right after hydrate() is the
+        // line between "immediately" and "later", and only Colorway is on the
+        // near side of it.
+        check('island:load', atLoad.atMicrotask === 'Colorway',
+          'client:load hydrates in the microtask that follows hydrate(), alone',
+          `at-microtask=[${atLoad.atMicrotask}] live-later=[${atLoad.live.join(',')}]`);
+
+        check('island:idle',
+          !atLoad.atMicrotask.includes('ChapterNav')
+            && atLoad.live.includes('ChapterNav')
+            && atLoad.logged.includes('ChapterNav'),
+          'client:idle hydrates after the microtask window, on an idle callback',
+          `at-microtask=[${atLoad.atMicrotask}] settled=[${atLoad.live.join(',')}]`);
+
+        reporter.assert(
+          atLoad.pending.join(',') === 'LumenMeter:visible,SpecExplorer:interaction,WideCompare:media',
+          'the three untriggered islands are still marked for their trigger',
+          `pending=[${atLoad.pending.join(' ')}]`);
+
+        // --- anim:spring-tween, half one: the tweened counter --------------
+        const tweenRun = await page.evaluate(async () => {
+          const el = document.querySelector('[data-tween]');
+          const section = document.getElementById('origin');
+          const samples = [];
+          window.scrollTo({ top: window.scrollY + section.getBoundingClientRect().top + 8, behavior: 'instant' });
+          const t0 = performance.now();
+          while (performance.now() - t0 < 4000) {
+            samples.push(Number(el.getAttribute('data-tween')));
+            if (samples[samples.length - 1] === 4200) break;
+            await new Promise((r) => requestAnimationFrame(r));
+          }
+          return { first: samples[0], last: samples[samples.length - 1], steps: new Set(samples).size };
+        });
+
+        // --- island:visible + anim:spring-tween, half two: the spring ------
+        const meterBefore = await page.locator('[data-island="LumenMeter"][data-island-hydrated]').count();
+
+        const springRun = await page.evaluate(async () => {
+          const island = document.querySelector('[data-island="LumenMeter"]');
+          const fill = document.querySelector('[data-lumen-meter] .meter-fill');
+          const samples = [];
+          window.scrollTo({ top: window.scrollY + island.getBoundingClientRect().top - 80, behavior: 'instant' });
+          const t0 = performance.now();
+          while (performance.now() - t0 < 5000) {
+            samples.push(fill.getAttribute('data-spring'));
+            if (samples[samples.length - 1] === '1240.0') break;
+            await new Promise((r) => requestAnimationFrame(r));
+          }
+          return {
+            hydrated: island.hasAttribute('data-island-hydrated'),
+            first: samples[0],
+            last: samples[samples.length - 1],
+            steps: new Set(samples).size,
+            width: fill.style.width,
+            readout: document.querySelector('[data-lumen]').textContent.trim(),
+          };
+        });
+
+        check('island:visible', meterBefore === 0 && springRun.hydrated,
+          'client:visible stays asleep two screens down and hydrates when scrolled to',
+          `before-scroll=${meterBefore} after-scroll=${springRun.hydrated ? 1 : 0}`);
+
+        check('anim:spring-tween',
+          tweenRun.first === 0 && tweenRun.last === 4200 && tweenRun.steps >= 8
+            && springRun.first === '0.0' && springRun.last === '1240.0' && springRun.steps >= 8,
+          'a tween and a spring animate through intermediate values and settle on target',
+          `tween ${tweenRun.first}->${tweenRun.last} in ${tweenRun.steps} steps; `
+            + `spring ${springRun.first}->${springRun.last} in ${springRun.steps} steps, `
+            + `width=${springRun.width} readout=${springRun.readout}`);
+
+        // --- island:interaction --------------------------------------------
+        // Scrolled to, on screen, and given time to prove it stays asleep: this
+        // island only answers to a pointer or a focus.
+        await page.evaluate(() => {
+          const section = document.getElementById('materials');
+          window.scrollTo({ top: window.scrollY + section.getBoundingClientRect().top + 8, behavior: 'instant' });
+        });
+        await page.waitForSelector('#materials[data-revealed]', { timeout: 5000 });
+        await page.waitForTimeout(600);
+        const specBefore = await page.locator('[data-island="SpecExplorer"][data-island-hydrated]').count();
+        const rowsBefore = await page.locator('[data-spec-row]:not([hidden])').count();
+
+        // The first click only wakes the island: the handler it installs did
+        // not exist when this event was dispatched. That is the mode's real
+        // shape, so the check spells it out rather than hiding it.
+        await page.click('[data-spec-filter="body"]');
+        await page.waitForSelector('[data-island="SpecExplorer"][data-island-hydrated]', { timeout: 5000 });
+        const specAfter = await page.locator('[data-island="SpecExplorer"][data-island-hydrated]').count();
+
+        await page.click('[data-spec-filter="body"]');
+        await page.waitForFunction(
+          () => document.querySelector('[data-spec-root]')?.getAttribute('data-spec-group') === 'body',
+          undefined,
+          { timeout: 5000 },
+        );
+        const rowsAfter = await page.locator('[data-spec-row]:not([hidden])').count();
+
+        check('island:interaction',
+          specBefore === 0 && specAfter === 1 && rowsBefore === 11 && rowsAfter === 4,
+          'client:interaction ignores scroll and hydrates on the first pointer event',
+          `on-screen-unhydrated=${specBefore === 0} after-click=${specAfter} rows ${rowsBefore} -> ${rowsAfter}`);
+
+        // --- anim:intersect --------------------------------------------------
+        // One-shot per section, so the honest pair is the whole page: at load
+        // only the chapter on screen is revealed, and after the scroll-through
+        // every one of them is.
+        // Chapter by chapter, not one jump to the bottom: an IntersectionObserver
+        // reports the state it finds, so a section teleported straight past is
+        // never seen intersecting and would never reveal.
+        for (const id of ['compare', 'notes']) {
+          await page.evaluate((target) => {
+            const section = document.getElementById(target);
+            window.scrollTo({ top: window.scrollY + section.getBoundingClientRect().top + 8, behavior: 'instant' });
+          }, id);
+          await page.waitForSelector(`#${id}[data-revealed]`, { timeout: 5000 });
+        }
+        const revealAfter = await page.evaluate(() => Object.fromEntries(
+          [...document.querySelectorAll('[data-chapter]')]
+            .map((el) => [el.getAttribute('data-chapter'), el.hasAttribute('data-revealed')]),
+        ));
+
+        const hiddenAtLoad = Object.entries(atLoad.revealed).filter(([, v]) => !v).map(([k]) => k);
+        check('anim:intersect',
+          atLoad.revealed.open === true
+            && hiddenAtLoad.join(',') === 'origin,light,materials,compare,notes'
+            && Object.values(revealAfter).every(Boolean),
+          'onIntersect reveals each section as it enters the viewport, and not before',
+          `at-load revealed=[open] pending=[${hiddenAtLoad.join(' ')}] `
+            + `-> after scroll-through revealed=[${Object.keys(revealAfter).join(' ')}]`);
+
+        // --- island:media ---------------------------------------------------
+        const wideBefore = await page.locator('[data-island="WideCompare"][data-island-hydrated]').count();
+        await page.setViewportSize({ width: 1200, height: 720 });
+        await page.waitForSelector('[data-island="WideCompare"][data-island-hydrated]', { timeout: 5000 });
+        const wideAfter = await page.locator('[data-island="WideCompare"][data-island-hydrated]').count();
+
+        await page.evaluate(() => {
+          const input = document.querySelector('[data-wipe-input]');
+          input.value = '72';
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+        await page.waitForFunction(
+          () => document.querySelector('[data-compare-root]')?.getAttribute('data-wipe') === '72',
+          undefined,
+          { timeout: 5000 },
+        );
+        const wipe = await page.getAttribute('[data-compare-root]', 'data-wipe');
+
+        check('island:media',
+          wideBefore === 0 && wideAfter === 1 && wipe === '72',
+          'client:media hydrates only once (min-width: 900px) starts matching',
+          `at-800px=${wideBefore} at-1200px=${wideAfter} wipe=${wipe}`);
+
+        reporter.assert(diag.errors.length === 0, 'story page drove all five islands with no page errors',
+          diag.errors.slice(0, 2).join(' | '));
+
+        // Islands hydrate their own subtree in a nested pass, which is exactly
+        // the shape that produces silent mismatches if the server and client
+        // trees disagree.
+        const mismatches = diag.all.filter((line) => /Hydration mismatch/i.test(line));
+        reporter.assert(mismatches.length === 0,
+          'no island reported a hydration mismatch against its server HTML',
+          mismatches.slice(0, 2).join(' | '));
+      }, { context: narrow });
+    } finally {
+      await narrow.close();
+    }
+
+    // === Session B: scroll progress and the enter/leave transition ========
+    const motion = await browser.newContext({
+      viewport: { width: 1280, height: 800 },
+      reducedMotion: 'no-preference',
+    });
+
+    try {
+      await withPage(browser, `${base}/`, async (page, diag) => {
+        const prog = await page.evaluate(async () => {
+          const bar = document.querySelector('[data-progress]');
+          const pct = document.querySelector('[data-progress-pct]');
+          const settle = async () => { for (let i = 0; i < 5; i++) await new Promise((r) => requestAnimationFrame(r)); };
+          const read = () => ({ p: bar.getAttribute('data-progress'), t: pct.textContent, x: bar.style.transform });
+          const max = document.documentElement.scrollHeight - window.innerHeight;
+
+          window.scrollTo({ top: 0, behavior: 'instant' });
+          await settle();
+          const top = read();
+          window.scrollTo({ top: Math.round(max * 0.5), behavior: 'instant' });
+          await settle();
+          const mid = read();
+          window.scrollTo({ top: max, behavior: 'instant' });
+          await settle();
+          const bottom = read();
+          return { top, mid, bottom, max, screens: Math.round(((max + window.innerHeight) / window.innerHeight) * 10) / 10 };
+        });
+
+        const midValue = Number(prog.mid.p);
+        const scaleOf = (transform) => Number((/scaleX\(([\d.]+)\)/.exec(transform) || [])[1]);
+        check('anim:scroll-progress',
+          prog.top.p === '0.000' && prog.top.t === '0%' && scaleOf(prog.top.x) === 0
+            && midValue > 0.45 && midValue < 0.55 && Math.abs(scaleOf(prog.mid.x) - midValue) < 0.002
+            && prog.bottom.p === '1.000' && prog.bottom.t === '100%' && scaleOf(prog.bottom.x) === 1,
+          'scroll position drives the progress value, the bar transform and the readout',
+          `${prog.top.p}/${prog.top.t} -> ${prog.mid.p}/${prog.mid.t} -> ${prog.bottom.p}/${prog.bottom.t} `
+            + `over ${prog.screens} screens (${prog.max}px of scroll)`);
+
+        // --- anim:transition -------------------------------------------------
+        // Recorded rather than sampled: the -active class exists for one
+        // transition's worth of time, and a poll can walk straight past it.
+        await page.evaluate(() => {
+          const section = document.getElementById('notes');
+          window.scrollTo({ top: window.scrollY + section.getBoundingClientRect().top + 8, behavior: 'instant' });
+          window.__fadeLog = [];
+          const record = () => {
+            const panel = document.querySelector('[data-notes-panel]');
+            const seen = panel ? panel.className : '(removed)';
+            if (window.__fadeLog[window.__fadeLog.length - 1] !== seen) window.__fadeLog.push(seen);
+          };
+          new MutationObserver(record).observe(document.querySelector('.notes-block'), {
+            subtree: true, childList: true, attributes: true, attributeFilter: ['class'],
+          });
+        });
+
+        await page.click('[data-notes-toggle]');
+        await page.waitForSelector('[data-notes-panel].fade-enter-done', { timeout: 5000 });
+        const enterLog = await page.evaluate(() => window.__fadeLog.slice());
+
+        await page.click('[data-notes-toggle]');
+        await page.waitForFunction(() => !document.querySelector('[data-notes-panel]'), undefined, { timeout: 5000 });
+        const fullLog = await page.evaluate(() => window.__fadeLog.slice());
+
+        const entered = enterLog.join(' | ');
+        const exited = fullLog.slice(enterLog.length).join(' | ');
+        check('anim:transition',
+          enterLog[0] === 'notes'
+            && enterLog[1] === 'notes fade-enter'
+            && entered.includes('fade-enter fade-enter-active')
+            && entered.includes('fade-enter-done')
+            && exited.includes('fade-exit fade-exit-active')
+            && fullLog[fullLog.length - 1] === '(removed)',
+          'a mounted panel runs the enter classes, and the leave classes run before it is removed',
+          `enter: ${entered} || leave: ${exited}`);
+
+        reporter.assert(diag.errors.length === 0, 'progress and transition page ran with no page errors',
+          diag.errors.slice(0, 2).join(' | '));
+      }, { context: motion });
+    } finally {
+      await motion.close();
+    }
+
+    // === Session C: prefers-reduced-motion ================================
+    // Not a declared capability, but the checks above would be dishonest if the
+    // page only animated: they run with motion allowed, so this asserts the
+    // other branch actually exists.
+    const reduced = await browser.newContext({
+      viewport: { width: 800, height: 720 },
+      reducedMotion: 'reduce',
+    });
+
+    try {
+      await withPage(browser, `${base}/`, async (page) => {
+        const run = await page.evaluate(async () => {
+          const sampleFor = async (read, ms) => {
+            const seen = [];
+            const t0 = performance.now();
+            while (performance.now() - t0 < ms) {
+              seen.push(read());
+              await new Promise((r) => requestAnimationFrame(r));
+            }
+            return [...new Set(seen)];
+          };
+          const scrollToId = (id, offset) => {
+            const el = document.getElementById(id);
+            window.scrollTo({ top: window.scrollY + el.getBoundingClientRect().top + offset, behavior: 'instant' });
+          };
+
+          const counter = document.querySelector('[data-tween]');
+          scrollToId('origin', 8);
+          const tween = await sampleFor(() => counter.getAttribute('data-tween'), 1500);
+
+          const fill = document.querySelector('[data-lumen-meter] .meter-fill');
+          scrollToId('light', -80);
+          const spring = await sampleFor(() => fill.getAttribute('data-spring'), 2000);
+
+          return { spring, tween, revealed: document.getElementById('light').hasAttribute('data-revealed') };
+        });
+
+        reporter.assert(
+          run.spring.length <= 2 && run.spring[run.spring.length - 1] === '1240.0'
+            && run.tween.length <= 2 && run.tween[run.tween.length - 1] === '4200',
+          'prefers-reduced-motion snaps the spring and the tween to their final value',
+          `spring=[${run.spring.join(',')}] tween=[${run.tween.join(',')}]`);
+
+        reporter.assert(run.revealed,
+          'reduced motion still reveals sections, so no content is hidden from that visitor');
+      }, { context: reduced });
+    } finally {
+      await reduced.close();
+    }
+
+    log('scrollytelling checks complete');
+  },
+};

--- a/smoke/apps/scrollytelling/src/entry-client.js
+++ b/smoke/apps/scrollytelling/src/entry-client.js
@@ -1,0 +1,32 @@
+// Client entry. Hydrates the one page this app has, then gets out of the way.
+
+import { h, hydrate } from 'what-framework';
+import StoryPage from './page.js';
+import { trackScroll, watchIslandHydration } from './motion.js';
+
+// Sections are only hidden-until-revealed when scripting is on. Without this
+// flag a no-JS visitor would get a page of invisible chapters, which is the
+// classic way a scroll reveal turns into a blank document.
+document.documentElement.dataset.js = 'on';
+
+// Listen before hydrating: the `load` island announces itself in the microtask
+// right after hydrate() returns, and chapter 05's log would otherwise miss it.
+watchIslandHydration();
+
+hydrate(h(StoryPage, {}), document.body);
+
+// Page-level scroll wiring lives here rather than in an onMount() inside the
+// page: onMount() throws during SSR in 0.12.2, so a server-rendered component
+// cannot use it. The listener is document-lifetime anyway.
+trackScroll();
+
+// A snapshot of which islands were live by the end of the microtask queue that
+// follows hydration. `load` schedules with queueMicrotask and every other mode
+// waits for a task (idle callback, observer, listener), so this attribute is
+// the visible line between "immediately" and "later". Handy in devtools, and it
+// is what the smoke suite reads to tell client:load apart from client:idle.
+queueMicrotask(() => queueMicrotask(() => {
+  document.documentElement.dataset.islandsAtMicrotask = [...document.querySelectorAll('[data-island-hydrated]')]
+    .map((el) => el.getAttribute('data-island'))
+    .join(',');
+}));

--- a/smoke/apps/scrollytelling/src/islands/chapter-nav.js
+++ b/smoke/apps/scrollytelling/src/islands/chapter-nav.js
@@ -1,0 +1,43 @@
+// client:idle: the chapter rail.
+//
+// `idle` because the server already ships it as working fragment links. The
+// only thing hydration adds is the smooth scroll and the current-chapter mark,
+// so it can wait until the browser has nothing better to do.
+
+import { h, smoothScrollTo } from 'what-framework';
+import { chapters } from '../story.js';
+import { activeChapter, bindEl, prefersReducedMotion } from '../motion.js';
+
+export default function ChapterNav() {
+  const jump = (event, id) => {
+    const target = document.getElementById(id);
+    if (!target) return; // let the browser follow the fragment
+    event.preventDefault();
+    if (prefersReducedMotion()) target.scrollIntoView();
+    else smoothScrollTo(target, { duration: 450 });
+    history.replaceState(null, '', `#${id}`);
+  };
+
+  return h('nav', { class: 'chapter-nav', 'aria-label': 'Chapters', 'data-chapter-nav': '' },
+    h('p', { class: 'island-tag' }, 'client:idle'),
+    h('ol', {},
+      chapters.map((chapter) => h('li', {},
+        h('a', {
+          href: `#${chapter.id}`,
+          class: 'chapter-link',
+          'data-chapter-link': chapter.id,
+          onclick: (event) => jump(event, chapter.id),
+          ref: (el) => bindEl(el, () => {
+            const on = activeChapter() === chapter.id;
+            el.classList.toggle('is-current', on);
+            if (on) el.setAttribute('aria-current', 'true');
+            else el.setAttribute('aria-current', 'false');
+          }),
+        },
+        h('span', { class: 'chapter-num' }, chapter.num),
+        h('span', { class: 'chapter-title' }, chapter.title),
+        ),
+      )),
+    ),
+  );
+}

--- a/smoke/apps/scrollytelling/src/islands/colorway.js
+++ b/smoke/apps/scrollytelling/src/islands/colorway.js
@@ -1,0 +1,42 @@
+// client:load: the finish picker in the hero.
+//
+// `load` because it is the first thing on screen and the only control above the
+// fold: deferring it would mean a visitor can click it before it answers.
+
+import { h, signal } from 'what-framework';
+import { colorways } from '../story.js';
+import { bindEl } from '../motion.js';
+
+const DEFAULT = colorways[0];
+
+export default function Colorway() {
+  const active = signal(DEFAULT.id, 'colorway');
+
+  const pick = (choice) => {
+    active(choice.id);
+    // The hero's lamp is painted from a custom property, so one write repaints
+    // the shade, the pool of light and the accent rule together.
+    document.documentElement.style.setProperty('--lamp', choice.tint);
+  };
+
+  return h('div', { class: 'colorway', 'data-colorway-root': '' },
+    h('p', { class: 'island-tag' }, 'client:load'),
+    h('div', { class: 'swatches', role: 'group', 'aria-label': 'Finish' },
+      colorways.map((choice) => h('button', {
+        type: 'button',
+        class: 'swatch',
+        'data-colorway': choice.id,
+        style: `--swatch: ${choice.tint}`,
+        // Static for the server, then re-bound on the client. Both spellings
+        // matter: an absent aria-pressed means "not a toggle at all".
+        'aria-pressed': choice.id === DEFAULT.id ? 'true' : 'false',
+        ref: (el) => bindEl(el, () => {
+          el.setAttribute('aria-pressed', String(active() === choice.id));
+        }),
+        onclick: () => pick(choice),
+      }, choice.label)),
+    ),
+    h('p', { class: 'colorway-name', 'data-colorway-name': '' },
+      () => `Finish: ${(colorways.find((c) => c.id === active()) || DEFAULT).label}`),
+  );
+}

--- a/smoke/apps/scrollytelling/src/islands/lumen-meter.js
+++ b/smoke/apps/scrollytelling/src/islands/lumen-meter.js
@@ -1,0 +1,55 @@
+// client:visible: the output meter in chapter 02.
+//
+// `visible` because the whole point of the meter is the fill: hydrating it at
+// load would spend the animation two screens above where anyone can see it.
+// The island wakes when the chapter arrives, and the spring starts from rest,
+// so the arrival IS the animation.
+
+import { h, spring } from 'what-framework';
+import { RATED_LUMENS } from '../story.js';
+import { bindEl, prefersReducedMotion } from '../motion.js';
+
+export default function LumenMeter() {
+  // Server-rendered at rest (0), so the client hydrates onto identical text and
+  // then animates. Printing the rated figure in the caption keeps the static
+  // HTML informative without pretending the meter has moved.
+  // Slightly overdamped: a meter that overshoots its rated figure and settles
+  // back reads as a measurement error rather than an animation.
+  const lumens = spring(0, { stiffness: 120, damping: 24 });
+  let running = false;
+
+  // A ref, not onMount(): onMount() throws during SSR in 0.12.2 (see
+  // smoke.config.mjs). Refs are skipped by the server renderer and fire on the
+  // client, which is the same "client only, once" guarantee without the throw.
+  const start = (el) => {
+    if (!el || running) return;
+    running = true;
+    if (prefersReducedMotion()) lumens.snap(RATED_LUMENS);
+    else lumens.set(RATED_LUMENS);
+  };
+
+  return h('figure', { class: 'meter', 'data-lumen-meter': '', ref: start },
+    h('p', { class: 'island-tag' }, 'client:visible'),
+    h('figcaption', {},
+      'Integrating-sphere output at full draw. Rated ',
+      h('strong', {}, `${RATED_LUMENS.toLocaleString('en-US')} lm`),
+      '.',
+    ),
+    h('div', { class: 'meter-track' },
+      h('div', {
+        class: 'meter-fill',
+        'data-spring': '0.0',
+        ref: (el) => bindEl(el, () => {
+          const value = lumens.current();
+          el.style.width = `${Math.max(0, Math.min(100, (value / RATED_LUMENS) * 100)).toFixed(2)}%`;
+          el.setAttribute('data-spring', value.toFixed(1));
+        }),
+      }),
+    ),
+    h('output', { class: 'meter-readout', 'data-lumen': '' },
+      () => `${Math.round(lumens.current()).toLocaleString('en-US')} lm`),
+    h('ul', { class: 'meter-scale', 'aria-hidden': 'true' },
+      [0, 400, 800, 1200].map((tick) => h('li', {}, String(tick))),
+    ),
+  );
+}

--- a/smoke/apps/scrollytelling/src/islands/spec-explorer.js
+++ b/smoke/apps/scrollytelling/src/islands/spec-explorer.js
@@ -1,0 +1,55 @@
+// client:interaction: the spec table in chapter 03.
+//
+// `interaction` because the table is complete in the server HTML. Filtering is
+// a convenience on top of something that already reads fine, so the JS cost is
+// only paid by a visitor who reaches for it. The marker listens for click,
+// focus, mouseenter and touchstart, so a pointer arriving at the table hydrates
+// it before the click lands.
+
+import { h, signal } from 'what-framework';
+import { specGroups, specs } from '../story.js';
+import { bindEl } from '../motion.js';
+
+export default function SpecExplorer() {
+  const group = signal('all', 'specGroup');
+  const shown = (row) => group() === 'all' || group() === row.group;
+
+  return h('div', {
+    class: 'spec-explorer',
+    'data-spec-root': '',
+    'data-spec-group': 'all',
+    ref: (el) => bindEl(el, () => el.setAttribute('data-spec-group', group())),
+  },
+    h('p', { class: 'island-tag' }, 'client:interaction'),
+    h('div', { class: 'spec-filters', role: 'group', 'aria-label': 'Filter specifications' },
+      specGroups.map((entry) => h('button', {
+        type: 'button',
+        class: 'chip',
+        'data-spec-filter': entry.id,
+        'aria-pressed': entry.id === 'all' ? 'true' : 'false',
+        onclick: () => group(entry.id),
+        ref: (el) => bindEl(el, () => {
+          const on = group() === entry.id;
+          el.setAttribute('aria-pressed', String(on));
+          el.classList.toggle('is-on', on);
+        }),
+      }, entry.label)),
+    ),
+    h('table', { class: 'spec-table' },
+      h('caption', {}, 'Northline 01, as measured on the bench'),
+      h('thead', {}, h('tr', {},
+        h('th', { scope: 'col' }, 'Measure'),
+        h('th', { scope: 'col' }, 'Value'),
+      )),
+      h('tbody', {},
+        specs.map((row) => h('tr', {
+          'data-spec-row': row.group,
+          ref: (el) => bindEl(el, () => { el.hidden = !shown(row); }),
+        },
+          h('th', { scope: 'row' }, row.label),
+          h('td', {}, row.value),
+        )),
+      ),
+    ),
+  );
+}

--- a/smoke/apps/scrollytelling/src/islands/wide-compare.js
+++ b/smoke/apps/scrollytelling/src/islands/wide-compare.js
@@ -1,0 +1,54 @@
+// client:media, (min-width: 900px): the comparison in chapter 04.
+//
+// The wipe control needs two columns side by side to mean anything. On a phone
+// the same markup stacks and reads as two plain tables, which is the better
+// answer there, so the island simply never hydrates and never downloads a
+// behaviour nobody can use.
+
+import { h, signal } from 'what-framework';
+import { comparison } from '../story.js';
+import { bindEl } from '../motion.js';
+
+const panel = (side, data) => h('div', { class: `compare-panel compare-${side}`, 'data-compare-panel': side },
+  h('h3', {}, data.name),
+  h('dl', {},
+    data.rows.flatMap((row) => [
+      h('dt', {}, row.label),
+      h('dd', {},
+        h('span', { class: 'compare-value' }, row.value),
+        h('span', { class: 'compare-bar', style: `--fill: ${row.fill}%` }),
+      ),
+    ]),
+  ),
+);
+
+export default function WideCompare() {
+  const wipe = signal(50, 'compareWipe');
+
+  return h('div', {
+    class: 'compare',
+    'data-compare-root': '',
+    'data-wipe': '50',
+    ref: (el) => bindEl(el, () => {
+      el.style.setProperty('--wipe', `${wipe()}%`);
+      el.setAttribute('data-wipe', String(wipe()));
+    }),
+  },
+    h('p', { class: 'island-tag' }, 'client:media (min-width: 900px)'),
+    h('div', { class: 'compare-grid' },
+      panel('left', comparison.left),
+      panel('right', comparison.right),
+    ),
+    h('label', { class: 'wipe-control' },
+      h('span', {}, 'Wipe'),
+      h('input', {
+        type: 'range',
+        min: '0',
+        max: '100',
+        value: '50',
+        'data-wipe-input': '',
+        oninput: (event) => wipe(Number(event.target.value)),
+      }),
+    ),
+  );
+}

--- a/smoke/apps/scrollytelling/src/motion.js
+++ b/smoke/apps/scrollytelling/src/motion.js
@@ -1,0 +1,120 @@
+// Scroll and motion plumbing shared by the page shell and the islands.
+//
+// Client-safe: nothing here touches `window` at module scope, so the server can
+// import it while rendering and simply never call the browser halves.
+
+import { cssTransition, effect, flushScheduler, onIntersect, raf, signal } from 'what-framework';
+import { chapters } from './story.js';
+
+/** 0..1 for the whole document. Drives the bar under the header. */
+export const progress = signal(0, 'scrollProgress');
+
+/** Id of the chapter currently owning the viewport. Drives the chapter nav. */
+export const activeChapter = signal(chapters[0].id, 'activeChapter');
+
+/** Appended to as islands wake up; chapter 05 renders it as a live list. */
+export const hydrationLog = signal([], 'hydrationLog');
+
+export function prefersReducedMotion() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Bind an element's attributes/styles to signals.
+ *
+ * What has no SSR-safe reactive attribute: a function passed as a prop is
+ * wrapped in an effect on the client, but `renderAttrs` in what-server does not
+ * call it and serializes the function's SOURCE TEXT into the HTML instead
+ * (see this app's smoke.config.mjs, which pins that). Refs are skipped during
+ * SSR, so driving attributes from a ref keeps the server HTML clean and the
+ * client fully reactive.
+ */
+export function bindEl(el, apply) {
+  if (!el) return () => {};
+  return effect(() => apply(el));
+}
+
+/**
+ * cssTransition() with the scheduler pumped underneath it.
+ *
+ * cssTransition queues a scheduleRead from inside a scheduleWrite callback, and
+ * the scheduler drops that request: flushScheduler() clears its `scheduled`
+ * flag only after BOTH queues have drained, so the re-entrant schedule() sees
+ * `scheduled === true` and never asks for another frame. The transition then
+ * hangs after the first class is applied until some unrelated code touches the
+ * scheduler. Draining a frame at a time while a transition is in flight is the
+ * smallest honest fix an app can apply from the outside. See smoke.config.mjs
+ * for the two-line repro.
+ */
+export function runTransition(el, name, type, duration) {
+  let settled = false;
+  const pump = () => {
+    if (settled) return;
+    flushScheduler();
+    requestAnimationFrame(pump);
+  };
+  requestAnimationFrame(pump);
+  return cssTransition(el, name, type, duration).finally(() => { settled = true; });
+}
+
+/**
+ * Reveal a section the first time it crosses 80% of the viewport height.
+ * The negative bottom margin is what makes this fire on the way in rather than
+ * the instant a tall section's top edge appears.
+ */
+export function revealOnIntersect(el) {
+  if (!el) return;
+  let stop = null;
+  let done = false;
+  stop = onIntersect(el, (entry) => {
+    if (done || !entry.isIntersecting) return;
+    done = true;
+    el.setAttribute('data-revealed', '');
+    if (stop) stop();
+  }, { rootMargin: '0px 0px -20% 0px', threshold: 0 });
+}
+
+/**
+ * Drive `progress` and `activeChapter` from the window scroll position.
+ * `raf()` collapses a burst of scroll events into one read per frame, which is
+ * the difference between a smooth bar and a layout thrash on every wheel tick.
+ */
+export function trackScroll() {
+  if (typeof window === 'undefined') return () => {};
+
+  const update = () => raf('story-scroll', () => {
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    progress(max > 0 ? Math.min(1, Math.max(0, window.scrollY / max)) : 0);
+
+    const line = window.innerHeight * 0.4;
+    let current = chapters[0].id;
+    for (const chapter of chapters) {
+      const el = document.getElementById(chapter.id);
+      if (el && el.getBoundingClientRect().top <= line) current = chapter.id;
+    }
+    activeChapter(current);
+  });
+
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update);
+  update();
+  return () => {
+    window.removeEventListener('scroll', update);
+    window.removeEventListener('resize', update);
+  };
+}
+
+/**
+ * Islands announce themselves with a bubbling `island:hydrated` event. Listening
+ * at the document is how chapter 05 can show the wake-up order without any
+ * island knowing the log exists.
+ */
+export function watchIslandHydration() {
+  if (typeof document === 'undefined') return;
+  document.addEventListener('island:hydrated', (event) => {
+    const { name, mode } = event.detail || {};
+    hydrationLog([...hydrationLog.peek(), { name, mode, at: Math.round(performance.now()) }]);
+  });
+}

--- a/smoke/apps/scrollytelling/src/page.js
+++ b/smoke/apps/scrollytelling/src/page.js
@@ -1,0 +1,259 @@
+// The story page.
+//
+// Almost all of this is static server HTML. The reactive parts are the scroll
+// bar, the section reveals and one tweened counter; everything genuinely
+// interactive is an island with its own hydration trigger, placed where its
+// trigger is reachable.
+//
+// Client-safe by construction: the server imports this module to render, and
+// the browser imports the same file to hydrate.
+
+import {
+  Head,
+  Island,
+  easings,
+  h,
+  onIntersect,
+  signal,
+  tween,
+} from 'what-framework';
+
+import {
+  BURN_IN_HOURS,
+  chapters,
+  productionNotes,
+} from './story.js';
+import {
+  bindEl,
+  hydrationLog,
+  prefersReducedMotion,
+  progress,
+  revealOnIntersect,
+  runTransition,
+} from './motion.js';
+
+import Colorway from './islands/colorway.js';
+import ChapterNav from './islands/chapter-nav.js';
+import LumenMeter from './islands/lumen-meter.js';
+import SpecExplorer from './islands/spec-explorer.js';
+import WideCompare from './islands/wide-compare.js';
+
+const chapterOf = (id) => chapters.find((c) => c.id === id);
+
+/** A full-height section that reveals itself once, on the way in. */
+function Chapter({ id, children }) {
+  const meta = chapterOf(id);
+  const kids = children == null ? [] : (Array.isArray(children) ? children : [children]);
+  return h('section', {
+    id,
+    class: 'chapter',
+    'data-chapter': id,
+    'aria-labelledby': `${id}-heading`,
+    ref: revealOnIntersect,
+  },
+    h('p', { class: 'chapter-eyebrow' }, meta.num),
+    h('h2', { id: `${id}-heading`, class: 'chapter-heading' }, meta.title),
+    ...kids,
+  );
+}
+
+/**
+ * Chapter 01's counter. Not an island: it is three lines of behaviour attached
+ * to text that is already on screen, so it rides the page's own hydration and
+ * waits for its section instead of a bundle.
+ */
+function BurnInCounter() {
+  const shown = signal(0, 'burnIn');
+  let started = false;
+
+  return h('p', {
+    class: 'stat',
+    'data-tween': '0',
+    ref: (el) => {
+      if (!el) return;
+      bindEl(el, () => el.setAttribute('data-tween', String(Math.round(shown()))));
+      let stop = null;
+      stop = onIntersect(el, (entry) => {
+        if (started || !entry.isIntersecting) return;
+        started = true;
+        if (stop) stop();
+        if (prefersReducedMotion()) shown(BURN_IN_HOURS);
+        else tween(0, BURN_IN_HOURS, {
+          duration: 1100,
+          easing: easings.easeOutCubic,
+          onUpdate: (value) => shown(value),
+        });
+      }, { rootMargin: '0px 0px -20% 0px', threshold: 0 });
+    },
+  },
+    h('span', { class: 'stat-num' }, () => Math.round(shown()).toLocaleString('en-US')),
+    h('span', { class: 'stat-unit' }, 'hours on the bench before a unit ships'),
+  );
+}
+
+/**
+ * Chapter 05's notes drawer. The panel is created and destroyed, and
+ * `runTransition` drives both halves: enter runs from the ref as the node
+ * appears, exit is awaited BEFORE the signal drops it, because a node removed
+ * first has nothing left to animate.
+ */
+function ProductionNotes() {
+  const open = signal(false, 'notesOpen');
+  let panel = null;
+  const duration = () => (prefersReducedMotion() ? 0 : 420);
+
+  const toggle = async () => {
+    if (!open()) { open(true); return; }
+    if (panel) await runTransition(panel, 'fade', 'exit', duration());
+    panel = null;
+    open(false);
+  };
+
+  return h('div', { class: 'notes-block' },
+    h('button', {
+      type: 'button',
+      class: 'ghost',
+      'data-notes-toggle': '',
+      'aria-controls': 'production-notes',
+      'aria-expanded': 'false',
+      onclick: toggle,
+      ref: (el) => bindEl(el, () => el.setAttribute('aria-expanded', String(open()))),
+    }, () => (open() ? 'Hide production notes' : 'Read the production notes')),
+
+    () => (open()
+      ? h('aside', {
+        id: 'production-notes',
+        class: 'notes',
+        'data-notes-panel': '',
+        ref: (el) => {
+          if (!el) return;
+          panel = el;
+          runTransition(el, 'fade', 'enter', duration());
+        },
+      },
+        h('h3', {}, 'From the bench'),
+        h('ul', {}, productionNotes.map((note) => h('li', {}, note))),
+      )
+      : null),
+  );
+}
+
+export default function StoryPage() {
+  // Scroll tracking is wired from entry-client.js after hydrate(), not from
+  // onMount(): every component-scoped hook throws during SSR in 0.12.2, so a
+  // component that calls onMount cannot be server-rendered at all. See the
+  // repro in smoke.config.mjs.
+  return h('div', { class: 'story' },
+    h(Head, {
+      title: 'Northline 01 | Northline Works',
+      meta: [{
+        name: 'description',
+        content: 'A desk lamp, told from the inside out: five chapters, five islands, one scroll.',
+      }],
+    }),
+
+    // --- Fixed chrome ---------------------------------------------------
+    h('header', { class: 'story-header' },
+      h('a', { class: 'wordmark', href: '#open' }, 'Northline Works'),
+      h('p', { class: 'read-out' },
+        h('span', { 'data-progress-pct': '' }, () => `${Math.round(progress() * 100)}%`),
+        ' read',
+      ),
+      h('div', { class: 'progress-track', role: 'presentation' },
+        h('div', {
+          class: 'progress-bar',
+          'data-progress': '0.000',
+          ref: (el) => bindEl(el, () => {
+            const value = progress();
+            el.style.transform = `scaleX(${value})`;
+            el.setAttribute('data-progress', value.toFixed(3));
+          }),
+        }),
+      ),
+    ),
+
+    h(Island, { component: ChapterNav, mode: 'idle' }),
+
+    h('main', { class: 'story-main' },
+
+      // --- 00 -----------------------------------------------------------
+      h(Chapter, { id: 'open' },
+        h('p', { class: 'lede' },
+          'A desk lamp, told from the inside out. Scroll for five chapters: '
+          + 'where it starts, what it puts out, what it is made of, what it '
+          + 'replaces, and who made it.'),
+        h('div', { class: 'lamp', 'aria-hidden': 'true' },
+          h('span', { class: 'lamp-shade' }),
+          h('span', { class: 'lamp-cone' }),
+          h('span', { class: 'lamp-pool' }),
+        ),
+        h(Island, { component: Colorway, mode: 'load' }),
+        h('p', { class: 'scroll-cue' }, 'Keep scrolling'),
+      ),
+
+      // --- 01 -----------------------------------------------------------
+      h(Chapter, { id: 'origin' },
+        h('p', {},
+          'Northline 01 began as a complaint about a lamp that buzzed. Two years '
+          + 'later the buzzing is gone, and what is left is a shade, an arm and a '
+          + 'driver that runs cool enough to touch.'),
+        h(BurnInCounter, {}),
+        h('p', { class: 'muted' },
+          'Every unit runs 4,200 hours on a test bench before it is boxed. Units '
+          + 'that drift more than two percent in output are stripped for parts.'),
+      ),
+
+      // --- 02 -----------------------------------------------------------
+      h(Chapter, { id: 'light' },
+        h('p', {},
+          'The shade is spun, not pressed, so the inside carries a continuous '
+          + 'curve and the pool of light has no seam in it. The meter below fills '
+          + 'the moment this chapter reaches you.'),
+        h(Island, { component: LumenMeter, mode: 'visible' }),
+      ),
+
+      // --- 03 -----------------------------------------------------------
+      h(Chapter, { id: 'materials' },
+        h('p', {},
+          'Nothing here is a composite pretending to be metal. The full bench '
+          + 'sheet is below; reach for it and it becomes filterable.'),
+        h(Island, { component: SpecExplorer, mode: 'interaction' }),
+      ),
+
+      // --- 04 -----------------------------------------------------------
+      h(Chapter, { id: 'compare' },
+        h('p', {},
+          'Against the incandescent it is meant to retire. On a narrow screen '
+          + 'these are two plain tables, which is the honest way to read them '
+          + 'there.'),
+        h(Island, { component: WideCompare, mode: 'media', mediaQuery: '(min-width: 900px)' }),
+      ),
+
+      // --- 05 -----------------------------------------------------------
+      h(Chapter, { id: 'notes' },
+        h('p', {},
+          'This page is one server-rendered document. Five islands hydrate on '
+          + 'five different triggers, and the list below fills in as each one '
+          + 'wakes up.'),
+        h(ProductionNotes, {}),
+        h('div', { class: 'hydration-log' },
+          h('h3', {}, 'Island wake-up order'),
+          h('ol', { 'data-hydration-log': '' },
+            () => hydrationLog().map((entry) => h('li', { 'data-hydrated-island': entry.name },
+              h('code', {}, entry.name),
+              h('span', { class: 'log-mode' }, `client:${entry.mode}`),
+              h('span', { class: 'log-time' }, `${entry.at} ms`),
+            )),
+          ),
+          h('p', { class: 'muted small' },
+            'Empty in the server HTML, and empty here if scripting is off: the '
+            + 'page reads the same either way.'),
+        ),
+      ),
+    ),
+
+    h('footer', { class: 'story-footer' },
+      h('p', {}, 'Northline Works is fictional. Every figure on this page is invented for the demo.'),
+    ),
+  );
+}

--- a/smoke/apps/scrollytelling/src/story.js
+++ b/smoke/apps/scrollytelling/src/story.js
@@ -1,0 +1,76 @@
+// The narrative content. Pure data, no framework imports, so the server and the
+// browser read the same copy without either one pulling in the other's runtime.
+//
+// Northline 01 is a fictional product. Every figure below is invented for the
+// demo, which is why the page prints them as product claims and never as facts
+// about the world.
+
+export const chapters = [
+  { id: 'open', num: '00', title: 'Northline 01' },
+  { id: 'origin', num: '01', title: 'Where it starts' },
+  { id: 'light', num: '02', title: 'What it puts out' },
+  { id: 'materials', num: '03', title: 'What it is made of' },
+  { id: 'compare', num: '04', title: 'What it replaces' },
+  { id: 'notes', num: '05', title: 'Colophon' },
+];
+
+/** The counter in chapter 01 tweens up to this. */
+export const BURN_IN_HOURS = 4200;
+
+/** The meter in chapter 02 springs up to this. */
+export const RATED_LUMENS = 1240;
+
+export const colorways = [
+  { id: 'brass', label: 'Brass', tint: '#c8912f' },
+  { id: 'graphite', label: 'Graphite', tint: '#7b8794' },
+  { id: 'oxblood', label: 'Oxblood', tint: '#9c3b3b' },
+];
+
+export const specGroups = [
+  { id: 'all', label: 'Everything' },
+  { id: 'optics', label: 'Optics' },
+  { id: 'body', label: 'Body' },
+  { id: 'power', label: 'Power' },
+];
+
+export const specs = [
+  { group: 'optics', label: 'Rated output', value: '1,240 lm' },
+  { group: 'optics', label: 'Colour temperature', value: '2700K' },
+  { group: 'optics', label: 'Colour rendering', value: 'CRI 97' },
+  { group: 'optics', label: 'Beam angle', value: '38 degrees' },
+  { group: 'body', label: 'Shade', value: 'Spun aluminium, 1.2 mm' },
+  { group: 'body', label: 'Arm', value: 'Cold-drawn steel' },
+  { group: 'body', label: 'Reach', value: '620 mm' },
+  { group: 'body', label: 'Mass', value: '2.4 kg' },
+  { group: 'power', label: 'Draw at full', value: '11 W' },
+  { group: 'power', label: 'Standby', value: '0.2 W' },
+  { group: 'power', label: 'Cable', value: '2.1 m, braided' },
+];
+
+/** Chapter 04's comparison, wiped between by the wide-viewport island. */
+export const comparison = {
+  left: {
+    name: 'The 60 W bulb it replaces',
+    rows: [
+      { label: 'Draw', value: '60 W', fill: 100 },
+      { label: 'Output', value: '810 lm', fill: 65 },
+      { label: 'Heat at the shade', value: '92 C', fill: 96 },
+      { label: 'Rated life', value: '1,000 h', fill: 24 },
+    ],
+  },
+  right: {
+    name: 'Northline 01',
+    rows: [
+      { label: 'Draw', value: '11 W', fill: 18 },
+      { label: 'Output', value: '1,240 lm', fill: 100 },
+      { label: 'Heat at the shade', value: '41 C', fill: 43 },
+      { label: 'Rated life', value: '25,000 h', fill: 100 },
+    ],
+  },
+};
+
+export const productionNotes = [
+  'Every shade is spun on a 1962 Herbert lathe, then annealed twice.',
+  'The arm is cut oversize and ground back, so the pivot never sees a weld.',
+  'Units that fail burn-in are stripped for parts, never reworked.',
+];

--- a/smoke/apps/scrollytelling/src/styles.css
+++ b/smoke/apps/scrollytelling/src/styles.css
@@ -1,0 +1,535 @@
+/* Northline 01: a long, dark, quiet reading page.
+   The only colour that moves is --lamp, which the client:load island rewrites. */
+
+:root {
+  color-scheme: dark;
+  --lamp: #c8912f;
+  --ink: #f4efe6;
+  --muted: #9a9186;
+  --line: #2b2724;
+  --paper: #141210;
+  --panel: #1c1917;
+  font-family: ui-serif, Georgia, "Times New Roman", serif;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(1100px 620px at 50% -8%, rgba(200, 145, 47, 0.16), transparent 62%),
+    var(--paper);
+  color: var(--ink);
+  font-size: 18px;
+  line-height: 1.65;
+}
+
+.story { padding-bottom: 4rem; }
+
+/* --- Fixed chrome --------------------------------------------------------- */
+
+.story-header {
+  position: fixed;
+  inset: 0 0 auto 0;
+  z-index: 20;
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem 0.9rem;
+  background: rgba(20, 18, 16, 0.86);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--line);
+}
+
+.wordmark {
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 0.82rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.read-out {
+  margin: 0 0 0 auto;
+  font-size: 0.74rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.progress-track {
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 3px;
+  background: var(--line);
+}
+
+.progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--lamp), #f0d9a8);
+  transform: scaleX(0);
+  transform-origin: 0 50%;
+}
+
+/* --- Chapter rail (client:idle island) ------------------------------------ */
+
+.chapter-nav {
+  position: fixed;
+  top: 50%;
+  right: 1.5rem;
+  z-index: 15;
+  transform: translateY(-50%);
+  display: none;
+}
+
+@media (min-width: 1100px) { .chapter-nav { display: block; } }
+
+.chapter-nav ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.15rem;
+  border-right: 1px solid var(--line);
+}
+
+.chapter-link {
+  display: grid;
+  grid-template-columns: 2.1rem 1fr;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.25rem 0.9rem 0.25rem 0;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  border-right: 2px solid transparent;
+  margin-right: -1px;
+}
+
+.chapter-link:hover { color: var(--ink); }
+.chapter-link.is-current { color: var(--lamp); border-right-color: var(--lamp); }
+.chapter-num { font-variant-numeric: tabular-nums; opacity: 0.7; }
+
+/* --- Chapters ------------------------------------------------------------- */
+
+.story-main {
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.chapter {
+  min-height: 100vh;
+  padding: 22vh 0 14vh;
+  border-bottom: 1px solid var(--line);
+  /* The header is fixed, so a fragment jump would otherwise land under it. */
+  scroll-margin-top: 4rem;
+}
+
+.chapter:last-child { border-bottom: 0; }
+
+/* The reveal only exists when scripting does: a no-JS visitor gets the page
+   fully visible rather than a document of empty screens. */
+[data-js="on"] .chapter {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+
+[data-js="on"] .chapter[data-revealed] { opacity: 1; transform: none; }
+
+.chapter-eyebrow {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.3em;
+  color: var(--lamp);
+}
+
+.chapter-heading {
+  margin: 0.35rem 0 1.4rem;
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+}
+
+.lede { font-size: 1.22rem; color: #d9d0c2; }
+.muted { color: var(--muted); }
+.small { font-size: 0.86rem; }
+
+.scroll-cue {
+  margin-top: 3rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.island-tag {
+  margin: 0 0 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.island-tag::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 0.5rem;
+  border-radius: 50%;
+  background: var(--line);
+  vertical-align: middle;
+}
+
+[data-island-hydrated] .island-tag::before { background: var(--lamp); }
+
+/* --- The lamp ------------------------------------------------------------- */
+
+.lamp {
+  position: relative;
+  display: block;
+  height: 220px;
+  margin: 2.5rem 0 2rem;
+}
+
+.lamp-shade {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 186px;
+  height: 64px;
+  margin-left: -93px;
+  background: linear-gradient(168deg, var(--lamp), rgba(0, 0, 0, 0.6));
+  clip-path: polygon(19% 0, 81% 0, 100% 100%, 0 100%);
+  border-radius: 3px 3px 0 0;
+  transition: background 0.4s ease;
+}
+
+/* The beam: a cone that fades out well before it reaches the desk, so the
+   shade and the pool read as two ends of the same light. */
+.lamp-cone {
+  position: absolute;
+  left: 50%;
+  top: 62px;
+  width: 430px;
+  height: 112px;
+  margin-left: -215px;
+  /* The top edge is exactly the shade's 186px opening, centred in a 430px box.
+     The radial fill keeps the beam brightest down its middle, and the blur
+     stops the clip from cutting a hard-edged pyramid out of the dark. */
+  clip-path: polygon(28.4% 0, 71.6% 0, 100% 100%, 0 100%);
+  background: radial-gradient(ellipse 52% 106% at 50% -6%, rgba(250, 235, 202, 0.34), transparent 70%);
+  filter: blur(9px);
+}
+
+.lamp-pool {
+  position: absolute;
+  left: 50%;
+  bottom: 6px;
+  width: 430px;
+  height: 30px;
+  margin-left: -215px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(240, 217, 168, 0.3), transparent 68%);
+}
+
+/* --- Colorway island ------------------------------------------------------ */
+
+.colorway { margin-top: 1.5rem; }
+.swatches { display: flex; gap: 0.6rem; }
+
+.swatch {
+  font: inherit;
+  font-size: 0.86rem;
+  color: var(--ink);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.35rem 0.95rem 0.35rem 0.7rem;
+  cursor: pointer;
+}
+
+.swatch::before {
+  content: "";
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  margin-right: 0.5rem;
+  border-radius: 50%;
+  background: var(--swatch);
+  vertical-align: -1px;
+}
+
+.swatch:hover { border-color: var(--lamp); }
+.swatch[aria-pressed="true"] { border-color: var(--lamp); background: rgba(200, 145, 47, 0.14); }
+.colorway-name { color: var(--muted); font-size: 0.9rem; }
+
+/* --- Counter -------------------------------------------------------------- */
+
+.stat {
+  margin: 2.2rem 0 0.4rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.stat-num {
+  font-size: clamp(3rem, 12vw, 5.5rem);
+  line-height: 1;
+  color: var(--lamp);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.03em;
+}
+
+.stat-unit { color: var(--muted); font-size: 1rem; }
+
+/* --- Lumen meter ---------------------------------------------------------- */
+
+.meter {
+  margin: 2rem 0 0;
+  padding: 1.4rem 1.5rem 1.1rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+}
+
+.meter figcaption { color: var(--muted); font-size: 0.92rem; }
+.meter strong { color: var(--ink); font-weight: 600; }
+
+.meter-track {
+  height: 14px;
+  margin: 1.1rem 0 0.7rem;
+  background: #100e0d;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.meter-fill {
+  width: 0;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(200, 145, 47, 0.6), var(--lamp), #f0d9a8);
+}
+
+.meter-readout {
+  display: block;
+  font-size: 2.1rem;
+  color: var(--lamp);
+  font-variant-numeric: tabular-nums;
+}
+
+.meter-scale {
+  display: flex;
+  justify-content: space-between;
+  list-style: none;
+  margin: 0.4rem 0 0;
+  padding: 0;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* --- Spec explorer -------------------------------------------------------- */
+
+.spec-explorer { margin-top: 2rem; }
+
+.spec-filters { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; }
+
+.chip {
+  font: inherit;
+  font-size: 0.82rem;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.25rem 0.85rem;
+  cursor: pointer;
+}
+
+.chip:hover { color: var(--ink); border-color: var(--lamp); }
+.chip.is-on { color: var(--paper); background: var(--lamp); border-color: var(--lamp); }
+
+.spec-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.spec-table caption {
+  text-align: left;
+  color: var(--muted);
+  font-size: 0.82rem;
+  padding-bottom: 0.6rem;
+}
+
+.spec-table th,
+.spec-table td {
+  text-align: left;
+  padding: 0.6rem 0.4rem;
+  border-bottom: 1px solid var(--line);
+  font-weight: 400;
+}
+
+.spec-table thead th {
+  color: var(--muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.spec-table td { color: var(--lamp); font-variant-numeric: tabular-nums; }
+
+/* --- Comparison ----------------------------------------------------------- */
+
+.compare { margin-top: 2rem; }
+
+.compare-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .compare-grid { grid-template-columns: var(--wipe, 50%) 1fr; }
+}
+
+.compare-panel {
+  padding: 1.1rem 1.2rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  min-width: 0;
+}
+
+.compare-panel h3 { margin: 0 0 0.8rem; font-size: 1rem; font-weight: 500; }
+.compare-left { color: var(--muted); }
+.compare-right { border-color: rgba(200, 145, 47, 0.4); }
+
+.compare-panel dl { margin: 0; display: grid; gap: 0.55rem; }
+.compare-panel dt { font-size: 0.78rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); }
+.compare-panel dd { margin: 0.1rem 0 0; }
+
+.compare-value { display: block; font-variant-numeric: tabular-nums; }
+
+.compare-bar {
+  display: block;
+  height: 5px;
+  margin-top: 0.3rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--lamp), rgba(200, 145, 47, 0.25));
+  width: var(--fill, 50%);
+}
+
+.compare-left .compare-bar { background: linear-gradient(90deg, #6b6259, rgba(107, 98, 89, 0.25)); }
+
+.wipe-control {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.wipe-control input { flex: 1; accent-color: var(--lamp); }
+
+/* --- Notes + log ---------------------------------------------------------- */
+
+.notes-block { margin-top: 1.5rem; }
+
+.ghost {
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--ink);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.45rem 1rem;
+  cursor: pointer;
+}
+
+.ghost:hover { border-color: var(--lamp); }
+
+.notes {
+  margin-top: 1rem;
+  padding: 1.1rem 1.3rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--lamp);
+  border-radius: 0 12px 12px 0;
+}
+
+.notes h3 { margin: 0 0 0.6rem; font-size: 0.95rem; font-weight: 500; }
+.notes ul { margin: 0; padding-left: 1.1rem; color: var(--muted); }
+.notes li + li { margin-top: 0.4rem; }
+
+/* cssTransition() adds -enter, then -enter-active, then swaps both for -done.
+   Order matters: the active rule has to come after the from-state rule. */
+.fade-enter { opacity: 0; transform: translateY(-10px); }
+.fade-enter-active { opacity: 1; transform: none; transition: opacity 0.42s ease, transform 0.42s ease; }
+.fade-enter-done { opacity: 1; }
+.fade-exit { opacity: 1; }
+.fade-exit-active { opacity: 0; transform: translateY(-10px); transition: opacity 0.42s ease, transform 0.42s ease; }
+
+.hydration-log { margin-top: 2.5rem; }
+.hydration-log h3 { font-size: 0.78rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--muted); }
+
+.hydration-log ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--line);
+}
+
+.hydration-log li {
+  display: flex;
+  gap: 0.9rem;
+  align-items: baseline;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.86rem;
+}
+
+.hydration-log code { color: var(--lamp); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.log-mode { color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; }
+.log-time { margin-left: auto; color: var(--muted); font-variant-numeric: tabular-nums; }
+
+.story-footer {
+  max-width: 46rem;
+  margin: 3rem auto 0;
+  padding: 0 1.5rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+/* --- Reduced motion ------------------------------------------------------- */
+/* The springs and tweens check this themselves and snap to their final value;
+   this block handles everything CSS owns. */
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+
+  [data-js="on"] .chapter {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .fade-enter,
+  .fade-exit-active { opacity: 1; transform: none; }
+  .fade-enter-active,
+  .fade-exit-active { transition: none; }
+  .lamp-shade { transition: none; }
+}

--- a/smoke/apps/storefront/.gitignore
+++ b/smoke/apps/storefront/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/smoke/apps/storefront/export.js
+++ b/smoke/apps/storefront/export.js
@@ -1,0 +1,31 @@
+// Build-time static export: `npm run export`.
+//
+// exportStatic walks the route table, renders every static and hybrid route to
+// dist/<path>/index.html, and writes a __what_data.json beside each one so a
+// client-side navigation can pick up loader data without a round trip. Dynamic
+// routes are enumerated through getStaticPaths.
+//
+// This is the only thing in the app that proves "prerendered at build time"
+// rather than "rendered on first request and then cached", which is a different
+// claim with a different failure mode.
+
+import { rm } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { exportStatic } from 'what-framework/server';
+import { routes } from './src/routes.js';
+import { documentOptions } from './server.js';
+
+const outDir = fileURLToPath(new URL('dist', import.meta.url));
+
+await rm(outDir, { recursive: true, force: true });
+
+// documentOptions.head is a getter (it re-reads the devtools token per render),
+// so spread it into a plain object once here rather than passing the live one.
+const { pages } = await exportStatic({
+  routes,
+  outDir,
+  documentOptions: { ...documentOptions, head: documentOptions.head },
+});
+
+console.log(`[storefront] exported ${pages.length} page(s) to dist/`);
+for (const page of pages) console.log(`  ${page}`);

--- a/smoke/apps/storefront/package.json
+++ b/smoke/apps/storefront/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "smoke-storefront",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Ecommerce smoke app: static/hybrid/server pages, cart store, server actions, cookie auth, query cache.",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js",
+    "export": "node export.js"
+  },
+  "dependencies": {
+    "what-framework": "0.12.2",
+    "what-isr": "0.12.2",
+    "what-server": "0.12.2"
+  },
+  "devDependencies": {
+    "what-devtools": "0.12.2",
+    "what-devtools-mcp": "0.12.2"
+  }
+}

--- a/smoke/apps/storefront/package.json
+++ b/smoke/apps/storefront/package.json
@@ -10,12 +10,12 @@
     "export": "node export.js"
   },
   "dependencies": {
-    "what-framework": "0.12.2",
-    "what-isr": "0.12.2",
-    "what-server": "0.12.2"
+    "what-framework": "0.12.3",
+    "what-isr": "0.12.3",
+    "what-server": "0.12.3"
   },
   "devDependencies": {
-    "what-devtools": "0.12.2",
-    "what-devtools-mcp": "0.12.2"
+    "what-devtools": "0.12.3",
+    "what-devtools-mcp": "0.12.3"
   }
 }

--- a/smoke/apps/storefront/public/favicon.svg
+++ b/smoke/apps/storefront/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)" />
+  <path d="M17 20h10l5 20 5-20h10L36 49h-8z" fill="#fff" />
+</svg>

--- a/smoke/apps/storefront/server.js
+++ b/smoke/apps/storefront/server.js
@@ -1,0 +1,272 @@
+// Storefront smoke app: full-stack server. `npm run dev` (auto-restart) or `node server.js`
+// Serves http://localhost:3000. Wires the Node adapter + origin-first ISR engine +
+// on-demand revalidation webhook + poll scheduler. No CDN and no bundler
+// required: the client entry and the framework are served as native ES modules
+// (see the import map below).
+
+import http from 'node:http';
+import { randomBytes } from 'node:crypto';
+import { existsSync, statSync, createReadStream, readFileSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequestHandler, renderDocument, toNodeListener } from 'what-framework/server';
+import {
+  createCacheEngine,
+  createMemoryStore,
+  createRevalidateWebhook,
+  createScheduler,
+} from 'what-isr';
+import { routes } from './src/routes.js';
+
+const ROOT = fileURLToPath(new URL('.', import.meta.url));
+const isProd = process.env.NODE_ENV === 'production';
+
+// Secret for the on-demand revalidation webhook (POST /__what_revalidate).
+// Required in production; auto-generated per run in dev so there is never a
+// shared default secret.
+let REVALIDATE_SECRET = process.env.WHAT_REVALIDATE_SECRET;
+if (!REVALIDATE_SECRET) {
+  if (isProd) {
+    console.error(
+      '[storefront] WHAT_REVALIDATE_SECRET must be set in production.\n' +
+      "  Generate one:  node -e \"console.log(require('node:crypto').randomBytes(24).toString('hex'))\""
+    );
+    process.exit(1);
+  }
+  REVALIDATE_SECRET = randomBytes(24).toString('hex');
+  console.log(`[dev] WHAT_REVALIDATE_SECRET not set, generated for this run: ${REVALIDATE_SECRET}`);
+}
+
+// Origin ISR cache. Swap createMemoryStore() for createFilesystemStore({dir})
+// to survive restarts, or createRedisStore({client}) for multi-instance.
+// `render` powers scheduled regeneration (renderRoute is defined below;
+// function declarations hoist, so the reference is valid here).
+const cache = createCacheEngine({ store: createMemoryStore(), render: renderRoute });
+
+// Non-200 renders (soft-404s like /blog/nonexistent) must never be ISR-cached.
+// A cached "Not found" would shadow a post created later and poison SEO. The
+// engine skips storing them; this wrapper also drops any stored non-200 entry
+// and forces the response uncacheable (belt and suspenders).
+const appCache = {
+  ...cache,
+  async handle(routeMatch, render) {
+    let result = await cache.handle(routeMatch, render);
+    if (result && result.status && result.status !== 200) {
+      try { await cache.store.delete(cache.keyFor(routeMatch)); } catch { /* best effort */ }
+      const headers = { ...(result.headers || {}) };
+      delete headers['Cache-Control'];
+      delete headers['cache-control'];
+      headers['Cache-Control'] = 'private, no-store';
+      result = { ...result, headers };
+    }
+    return result;
+  },
+};
+
+// Keep the home listing warm every 5 minutes regardless of traffic.
+const scheduler = createScheduler(cache);
+scheduler.register(
+  { path: '/', query: {}, params: {}, config: routes[0].page, route: routes[0] },
+  { intervalMs: 5 * 60 * 1000 }
+);
+
+// The browser loads /src/entry-client.js as a native ES module; this import
+// map resolves its bare imports. Sources are served from node_modules below.
+const importMap = {
+  imports: {
+    'what-framework': '/node_modules/what-framework/src/index.js',
+    'what-core': '/node_modules/what-core/src/index.js',
+    // The client half of the server package: island hydration and
+    // enhanceForms(). It imports nothing from node:*, so it loads in a browser.
+    'what-server/islands': '/node_modules/what-server/src/islands.js',
+    // Dev only. This template is buildless, so there is no Vite plugin to inject
+    // the devtools bridge the way the SPA template gets it. Mapping the two
+    // specifiers here (and serving them below) is all it takes for the MCP
+    // `what_*` tools to see this app: entry-client.js dynamically imports them
+    // behind the __WHAT_DEV__ flag, so production never fetches either module.
+    ...(isProd ? {} : {
+      'what-devtools': '/node_modules/what-devtools/src/index.js',
+      'what-devtools-mcp/client': '/node_modules/what-devtools-mcp/src/client.js',
+    }),
+  },
+};
+
+// The MCP bridge writes its token here when `npx what-devtools-mcp` starts.
+// Read per render, not once at boot, so starting the bridge after the server is
+// already up only costs a page reload.
+//
+// The token is passed INLINE rather than via the Vite plugin's same-origin
+// discovery endpoint, which this server does not implement. That is deliberate:
+// the client only probes for a bridge when it has a token or a discovery URL, so
+// an app running without the MCP server makes no requests and logs nothing at
+// all. Handing it a discovery URL that 404s would put a red line in every
+// developer's console on every page load.
+function mcpToken() {
+  try {
+    return JSON.parse(readFileSync(join(ROOT, 'node_modules', '.cache', 'what-devtools-mcp', 'token'), 'utf8')).token || '';
+  } catch {
+    return '';
+  }
+}
+
+function devToolsHead() {
+  if (isProd) return '';
+  const token = mcpToken();
+  if (!token) return '<script>globalThis.__WHAT_DEV__=true</script>';
+  return `<script>globalThis.__WHAT_DEV__=true;globalThis.__WHAT_MCP__=${JSON.stringify({ port: 9229, token })}</script>`;
+}
+
+export const documentOptions = {
+  clientEntry: '/src/entry-client.js',
+  // A getter, so devToolsHead() re-reads the token on every render.
+  get head() {
+    return `<script type="importmap">${JSON.stringify(importMap)}</script>` +
+      devToolsHead() +
+      '<link rel="stylesheet" href="/src/styles.css">' +
+      '<link rel="icon" type="image/svg+xml" href="/favicon.svg">';
+  },
+};
+
+// Render a matched route. Mirrors the framework default renderer, plus:
+//   - passes csrfToken through to loaders (so /new can SSR the no-JS form token)
+//   - honors a loader's `notFound: true` with a real 404 status (the appCache
+//     wrapper above keeps those responses out of the ISR cache)
+async function renderRoute(routeMatch) {
+  const { route, params, query, request, csrfToken } = routeMatch;
+  const reqCtx = { params, query, request, csrfToken };
+  const loaderData = typeof route.loader === 'function' ? await route.loader(reqCtx) : undefined;
+  const notFound = !!(loaderData && loaderData.notFound);
+  const pageModule = { default: route.component, loader: () => loaderData };
+  const opts = csrfToken ? { ...documentOptions, csrfToken } : documentOptions;
+  const html = await renderDocument(pageModule, reqCtx, opts);
+  return {
+    html,
+    status: notFound ? 404 : 200,
+    tags: (routeMatch.config && routeMatch.config.tags) || [],
+    path: routeMatch.path,
+  };
+}
+
+export function createHandler() {
+  return createRequestHandler({
+    routes,
+    cache: appCache,
+    render: renderRoute,
+    revalidateWebhook: createRevalidateWebhook(cache, { secret: REVALIDATE_SECRET }),
+    document: documentOptions,
+  });
+}
+
+// --- Static files (client entry, page modules, framework sources, public/) ---
+
+const MIME = {
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+  '.woff2': 'font/woff2',
+};
+
+// Deny-by-default static serving: ONLY the allowlisted client files below are
+// served from the project root. Server-only modules (src/db.js, src/actions/**
+// and src/routes.js) are importable by Node but 404 over HTTP, so DB code and
+// mutation logic never leak to the browser. When you add new client-side files
+// outside these locations, add them here explicitly.
+const SERVED_FILES = new Set(['/src/entry-client.js', '/src/styles.css']);
+const SERVED_PREFIXES = [
+  '/src/pages/',                  // page modules (hydrated by entry-client)
+  '/src/components/',             // client-shared UI
+  '/src/store/',                  // the global cart store
+  '/src/lib/',                    // client-safe helpers (action caller)
+  '/node_modules/what-framework/',
+  '/node_modules/what-core/',
+  '/node_modules/what-server/',
+  // Dev only: the devtools bridge entry-client imports when __WHAT_DEV__ is set.
+  // Gated on isProd so a production deploy never serves dev tooling.
+  ...(isProd ? [] : ['/node_modules/what-devtools/', '/node_modules/what-devtools-mcp/']),
+];
+
+function resolveStaticFile(pathname) {
+  if (pathname.includes('..') || pathname.includes(' ')) return null;
+  const allowed = SERVED_FILES.has(pathname) || SERVED_PREFIXES.some((p) => pathname.startsWith(p));
+  const file = allowed
+    ? resolve(join(ROOT, pathname))
+    : resolve(join(ROOT, 'public', pathname));
+  if (!file.startsWith(resolve(ROOT))) return null;
+  if (!existsSync(file) || !statSync(file).isFile()) return null;
+  return file;
+}
+
+// --- Start (node server.js / npm run dev), not when imported by tests ---
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const app = toNodeListener(createHandler());
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+
+    // --- JSON API ---------------------------------------------------------
+    if (url.pathname === '/api/search') {
+      const { searchProducts } = await import('./src/db.js');
+      const body = JSON.stringify(searchProducts(url.searchParams.get('q') ?? ''));
+      res.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' });
+      return res.end(body);
+    }
+
+    // Session endpoints. A server action cannot set Set-Cookie (the action
+    // handler owns its response headers), so sign-in is a real endpoint. It is
+    // a plain form POST, so it works with scripting disabled.
+    if ((url.pathname === '/api/login' || url.pathname === '/api/logout') && req.method === 'POST') {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const form = new URLSearchParams(Buffer.concat(chunks).toString('utf8'));
+      const { signIn, signOut, SESSION_COOKIE } = await import('./src/auth.js');
+
+      if (url.pathname === '/api/logout') {
+        const cookie = req.headers.cookie ?? '';
+        const token = (cookie.match(new RegExp(`(?:^|;\\s*)${SESSION_COOKIE}=([^;]+)`)) || [])[1];
+        signOut(token && decodeURIComponent(token));
+        res.writeHead(303, {
+          location: '/account',
+          'set-cookie': `${SESSION_COOKIE}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`,
+        });
+        return res.end();
+      }
+
+      const token = signIn(form.get('email') ?? '', form.get('password') ?? '');
+      if (!token) {
+        res.writeHead(303, { location: '/account?error=1' });
+        return res.end();
+      }
+      res.writeHead(303, {
+        location: '/account',
+        'set-cookie': `${SESSION_COOKIE}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Lax`,
+      });
+      return res.end();
+    }
+
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      const pathname = decodeURIComponent(url.pathname);
+      const file = resolveStaticFile(pathname);
+      if (file) {
+        res.writeHead(200, { 'content-type': MIME[extname(file)] || 'application/octet-stream' });
+        if (req.method === 'HEAD') return res.end();
+        return createReadStream(file).pipe(res);
+      }
+    }
+    app(req, res);
+  });
+
+  scheduler.start();
+  const stop = () => { try { scheduler.stop(); } catch {} server.close(); };
+  process.once('SIGTERM', stop);
+  process.once('SIGINT', stop);
+
+  const port = Number(process.env.PORT) || 3000;
+  server.listen(port, () => console.log(`storefront ready at http://localhost:${port}`));
+}

--- a/smoke/apps/storefront/smoke.config.mjs
+++ b/smoke/apps/storefront/smoke.config.mjs
@@ -1,0 +1,372 @@
+// Storefront smoke contract.
+//
+// Every capability listed in `covers` must be proven by a passing check below,
+// and the runner fails if one is declared and never reported. The checks are
+// ordered deliberately: the cache assertions run before anything posts a review,
+// because a review purges the 'products' tag and would make a later MISS/HIT
+// pair meaningless.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { startProcess, waitForHttp, withPage } from '../../harness/index.mjs';
+
+export default {
+  description: 'Ecommerce: static/hybrid/server pages, a global cart store, cookie auth, server actions, query cache.',
+
+  covers: [
+    'render:static',
+    'render:server',
+    'render:hybrid-isr',
+    'render:hydration',
+    'render:no-hydration-mismatch',
+    'route:table',
+    'route:params',
+    'state:signal',
+    'state:computed',
+    'state:global-store',
+    'state:persisted',
+    'state:batch',
+    'data:loader',
+    'data:loader-request',
+    'data:query',
+    'data:invalidate',
+    'server:action-js',
+    'server:action-nojs',
+    'server:csrf',
+    'server:revalidate',
+    'server:action-error',
+    'cmp:control-flow',
+    'cmp:head',
+    'a11y:aria-enumerated',
+  ],
+
+  async check({ workDir, appPort, browser, check, reporter, log, run }) {
+    const base = `http://127.0.0.1:${appPort}`;
+
+    // === Build-time static export =========================================
+    // Distinct from "rendered on first request and then cached": this proves
+    // HTML exists on disk before anything is served.
+    run('npm', ['run', 'export'], { cwd: workDir });
+
+    const productHtmlPath = join(workDir, 'dist', 'product', 'aeron-mug', 'index.html');
+    const exported = existsSync(productHtmlPath) ? readFileSync(productHtmlPath, 'utf8') : '';
+    check('render:static', exported.includes('Aeron Mug') && exported.includes('$18.00'),
+      'getStaticPaths page is prerendered to disk',
+      exported ? `${exported.length} bytes` : 'dist/product/aeron-mug/index.html missing');
+
+    const dataPath = join(workDir, 'dist', 'product', 'aeron-mug', '__what_data.json');
+    reporter.assert(existsSync(dataPath), 'static export writes loader data beside the page');
+    reporter.assert(!existsSync(join(workDir, 'dist', 'cart')),
+      'server-mode routes are excluded from the static export');
+
+    // === Server ===========================================================
+    const server = startProcess('node', ['server.js'], {
+      cwd: workDir,
+      env: { ...process.env, PORT: String(appPort), NODE_ENV: '' },
+    });
+    // Readiness must not touch a cached route: probing '/' would populate the
+    // ISR entry and the MISS/HIT assertion below would measure its own warmup.
+    await waitForHttp(`${base}/api/search?q=`, { child: server });
+
+    // === ISR: MISS then HIT ==============================================
+    const first = await fetch(`${base}/`);
+    const firstHtml = await first.text();
+    const second = await fetch(`${base}/`);
+    await second.text();
+
+    check('render:hybrid-isr',
+      first.headers.get('x-what-cache') === 'MISS' && second.headers.get('x-what-cache') === 'HIT',
+      'hybrid page misses then hits the ISR cache',
+      `${first.headers.get('x-what-cache')} then ${second.headers.get('x-what-cache')}`);
+
+    // Loader data has to be IN the first byte, not fetched after hydration.
+    check('data:loader', firstHtml.includes('Aeron Mug') && firstHtml.includes('Wool Desk Mat'),
+      'loader data is present in server HTML');
+
+    check('cmp:head',
+      /<title>Smoke Supply Co\.<\/title>/.test(firstHtml)
+        && /<meta[^>]+name="description"[^>]+content="Desk goods/.test(firstHtml),
+      'Head renders title and meta server-side');
+
+    // The bug this pins: What used to serialize boolean-looking ARIA values as
+    // an empty attribute, so `aria-disabled=false` became `aria-disabled=""`,
+    // which assistive tech reads as TRUE. Both spellings must be strings.
+    check('a11y:aria-enumerated',
+      firstHtml.includes('aria-disabled="false"') && firstHtml.includes('aria-disabled="true"'),
+      'aria-* enumerated values serialize as "true"/"false"',
+      firstHtml.includes('aria-disabled=""') ? 'found an empty aria-disabled' : '');
+
+    // === Routing =========================================================
+    const routeStatuses = {};
+    for (const path of ['/', '/cart', '/search', '/account', '/review', '/product/aeron-mug']) {
+      routeStatuses[path] = (await fetch(`${base}${path}`)).status;
+    }
+    check('route:table', Object.values(routeStatuses).every((s) => s === 200),
+      'every route in the table answers 200', JSON.stringify(routeStatuses));
+
+    const product = await fetch(`${base}/product/desk-mat`);
+    const productHtml = await product.text();
+    const missing = await fetch(`${base}/product/does-not-exist`);
+    check('route:params',
+      productHtml.includes('Wool Desk Mat') && missing.status === 404,
+      'dynamic param resolves, unknown param 404s',
+      `known=${product.status} unknown=${missing.status}`);
+
+    // === Server mode is never cached =====================================
+    const cart = await fetch(`${base}/cart`);
+    await cart.text();
+    check('render:server',
+      /no-store/.test(cart.headers.get('cache-control') || '')
+        && cart.headers.get('x-what-cache') !== 'HIT',
+      'server-mode page is rendered per request and not cached',
+      `cache-control=${cart.headers.get('cache-control')}`);
+
+    // === Loader reads the request ========================================
+    const anonAccount = await (await fetch(`${base}/account`)).text();
+    const login = await fetch(`${base}/api/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ email: 'demo@smoke.test', password: 'hunter2' }),
+      redirect: 'manual',
+    });
+    const sessionCookie = (login.headers.get('set-cookie') || '').split(';')[0];
+    const authedAccount = await (await fetch(`${base}/account`, { headers: { cookie: sessionCookie } })).text();
+
+    check('data:loader-request',
+      anonAccount.includes('data-signin')
+        && !anonAccount.includes('data-account')
+        && authedAccount.includes('data-account')
+        && /data-email[^>]*>demo@smoke\.test</.test(authedAccount),
+      'the loader branches on the request cookie, before any HTML exists',
+      `anon-signin=${anonAccount.includes('data-signin')} authed-account=${authedAccount.includes('data-account')}`);
+
+    // === CSRF ============================================================
+    // A token cookie exists (the adapter set one on the first HTML response),
+    // but the request presents the wrong one. That is the attack the
+    // double-submit check exists to stop.
+    const csrfCookie = (first.headers.get('set-cookie') || '').split(';')[0];
+    const badToken = await fetch(`${base}/__what_action`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-what-action': 'checkout',
+        'x-csrf-token': 'not-the-real-token',
+        cookie: csrfCookie,
+      },
+      body: JSON.stringify({ args: [{ lines: [{ slug: 'aeron-mug', qty: 1 }] }] }),
+    });
+    const noToken = await fetch(`${base}/__what_action`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-what-action': 'checkout' },
+      body: JSON.stringify({ args: [{ lines: [] }] }),
+    });
+    check('server:csrf', badToken.status === 403 && noToken.status === 403,
+      'an action with a wrong or missing CSRF token is rejected',
+      `wrong=${badToken.status} missing=${noToken.status}`);
+
+    // === A throwing action ===============================================
+    const realToken = decodeURIComponent(csrfCookie.split('=')[1] || '');
+    const boom = await fetch(`${base}/__what_action`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-what-action': 'checkout',
+        'x-csrf-token': realToken,
+        cookie: csrfCookie,
+      },
+      body: JSON.stringify({ args: [{ lines: [] }] }),
+    });
+    const boomBody = await boom.json().catch(() => ({}));
+    const stillUp = await fetch(`${base}/`);
+    await stillUp.text();
+    check('server:action-error',
+      boom.status === 500 && boomBody.message === 'Action failed' && stillUp.status === 200,
+      'a thrown action returns a generic failure and the server keeps serving',
+      `status=${boom.status} message=${boomBody.message} next=${stillUp.status}`);
+
+    // === Browser: hydration + client state ===============================
+    await withPage(browser, `${base}/product/aeron-mug`, async (page, diag) => {
+      await page.click('[data-add]');
+      await page.waitForFunction(() => document.querySelector('[data-added]')?.textContent.trim().length > 0);
+
+      check('state:signal',
+        (await page.textContent('[data-added]')).includes('Added to cart'),
+        'a local signal written by a click updates the DOM');
+
+      check('render:hydration', diag.errors.length === 0,
+        'the page hydrated and became interactive with no errors',
+        diag.errors.slice(0, 2).join(' | '));
+
+      const mismatches = diag.all.filter((l) => /Hydration mismatch/i.test(l));
+      check('render:no-hydration-mismatch', mismatches.length === 0,
+        'hydration reused the server DOM without mismatch warnings',
+        mismatches.slice(0, 2).join(' | '));
+
+      check('state:computed',
+        (await page.textContent('[data-cart-subtotal]')) === '$18.00',
+        'the computed subtotal tracks the store');
+
+      // Same tab, different page: the module-scope store is the only thing
+      // carrying the cart across the navigation.
+      await page.goto(`${base}/`, { waitUntil: 'networkidle' });
+      const countOnHome = await page.textContent('[data-cart-count]');
+      check('state:global-store', countOnHome === '1',
+        'a global store add is visible on another route', `badge=${countOnHome}`);
+
+      // Full reload: only localStorage can carry it now.
+      await page.reload({ waitUntil: 'networkidle' });
+      const countAfterReload = await page.textContent('[data-cart-count]');
+      check('state:persisted', countAfterReload === '1',
+        'the cart survives a full page reload', `badge=${countAfterReload}`);
+
+      // --- Control flow + cart interactions -----------------------------
+      await page.goto(`${base}/cart`, { waitUntil: 'networkidle' });
+      const hadTable = await page.locator('[data-cart-table]').count();
+      await page.click('[data-inc="aeron-mug"]');
+      await page.waitForFunction(() => document.querySelector('[data-qty="aeron-mug"]')?.textContent === '2');
+      const subtotalAfterInc = await page.textContent('[data-subtotal]');
+
+      // Empty it and back again, so both arms of <Show> are exercised.
+      await page.click('[data-dec="aeron-mug"]');
+      await page.click('[data-dec="aeron-mug"]');
+      await page.waitForSelector('[data-cart-empty]');
+      const emptyShown = await page.locator('[data-cart-empty]').count();
+
+      check('cmp:control-flow',
+        hadTable === 1 && subtotalAfterInc === '$36.00' && emptyShown === 1,
+        'Show/For render and swap arms reactively',
+        `table=${hadTable} subtotal=${subtotalAfterInc} empty=${emptyShown}`);
+
+      // --- batch --------------------------------------------------------
+      // The DOM is identical batched or not. The observable difference is how
+      // many times a reader runs, so measure that directly against the store.
+      const batching = await page.evaluate(async () => {
+        // Same URLs the import map resolves, so these are the page's own module
+        // instances, not fresh copies.
+        const core = await import('/node_modules/what-framework/src/index.js');
+        const store = await import('/src/store/cart.js');
+
+        store.addItem({ slug: 'aeron-mug', title: 'Aeron Mug', price: 1800 }, 1);
+        store.addItem({ slug: 'desk-mat', title: 'Wool Desk Mat', price: 6500 }, 1);
+
+        let runs = 0;
+        const dispose = core.effect(() => { store.count(); runs++; });
+        const afterSubscribe = runs;
+
+        store.applyBulk([['aeron-mug', 4], ['desk-mat', 5]]);
+        const batched = runs - afterSubscribe;
+
+        const beforeUnbatched = runs;
+        store.setQty('aeron-mug', 6);
+        store.setQty('desk-mat', 7);
+        const unbatched = runs - beforeUnbatched;
+
+        dispose?.();
+        store.clear();
+        return { batched, unbatched };
+      });
+
+      check('state:batch',
+        batching.batched === 1 && batching.unbatched === 2,
+        'batched writes settle once; the same writes unbatched settle twice',
+        `batched=${batching.batched} unbatched=${batching.unbatched}`);
+    });
+
+    // === Query cache =====================================================
+    await withPage(browser, `${base}/search`, async (page) => {
+      // The first render queries with an empty term and lists everything, so
+      // "aeron-mug is present" is true before the search even runs. Wait for the
+      // list to NARROW, which is the only state that proves the reactive part of
+      // the query key re-ran the fetch.
+      const initialFetches = Number(await page.textContent('[data-fetch-count]'));
+      await page.fill('[data-search-input]', 'mug');
+      await page.waitForFunction(
+        () => document.querySelectorAll('[data-result]').length === 1
+          && document.querySelector('[data-result="aeron-mug"]'),
+        undefined,
+        { timeout: 10000 },
+      );
+
+      const results = await page.locator('[data-result]').count();
+      const fetchesAfterSearch = Number(await page.textContent('[data-fetch-count]'));
+      check('data:query', results === 1 && fetchesAfterSearch > initialFetches,
+        'useQuery refetches when the reactive part of the key changes',
+        `results=${results} fetches=${initialFetches} -> ${fetchesAfterSearch}`);
+
+      // invalidateQueries(['products']) has to reach ['products','search',term]
+      // as a PREFIX. Passing an array key here used to match nothing at all.
+      await page.click('[data-invalidate]');
+      await page.waitForFunction(
+        (before) => Number(document.querySelector('[data-fetch-count]')?.textContent) > before,
+        fetchesAfterSearch,
+        { timeout: 5000 },
+      );
+      const fetchesAfterInvalidate = Number(await page.textContent('[data-fetch-count]'));
+      check('data:invalidate', fetchesAfterInvalidate > fetchesAfterSearch,
+        'invalidateQueries with an array prefix refetches the matching key',
+        `${fetchesAfterSearch} -> ${fetchesAfterInvalidate}`);
+    });
+
+    // === Server actions, both paths ======================================
+    // Warm the static product page so the revalidation assertion below is
+    // measuring a real purge rather than a cold cache.
+    const warm1 = await fetch(`${base}/product/cable-clip`);
+    await warm1.text();
+    const warm2 = await fetch(`${base}/product/cable-clip`);
+    await warm2.text();
+    reporter.assert(warm2.headers.get('x-what-cache') === 'HIT',
+      'static product page is cached before the revalidation test',
+      `x-what-cache=${warm2.headers.get('x-what-cache')}`);
+
+    // --- With JavaScript: enhanceForms intercepts and posts ---------------
+    await withPage(browser, `${base}/review`, async (page, diag) => {
+      await page.selectOption('#review-slug', 'cable-clip');
+      await page.fill('#review-body', 'Holds cables. Reviewed with JS.');
+      await Promise.all([
+        page.waitForURL(/\/review\?posted=1/, { timeout: 15000 }),
+        page.click('[data-review-submit]'),
+      ]);
+      const posted = await page.locator('[data-review-posted]').count();
+      check('server:action-js', posted === 1,
+        'an enhanced <Form> posts the action and follows its redirect',
+        diag.errors.slice(0, 2).join(' | '));
+    });
+
+    // --- Revalidation: the cached static page must show it ---------------
+    const afterAction = await fetch(`${base}/product/cable-clip`);
+    const afterActionHtml = await afterAction.text();
+    check('server:revalidate',
+      afterActionHtml.includes('Reviewed with JS.')
+        && afterAction.headers.get('x-what-cache') !== 'HIT',
+      'revalidateTag purges the cached page so the new data is visible',
+      `x-what-cache=${afterAction.headers.get('x-what-cache')}`);
+
+    // --- Without JavaScript ----------------------------------------------
+    // A context that genuinely cannot run scripts. Enhancement is impossible by
+    // construction, so this exercises the plain HTML form submit.
+    const noJs = await browser.newContext({ javaScriptEnabled: false });
+    try {
+      await withPage(browser, `${base}/review`, async (page) => {
+        await page.selectOption('#review-slug', 'field-notes');
+        await page.fill('#review-body', 'Posted with scripting disabled.');
+        await Promise.all([
+          page.waitForURL(/\/review\?posted=1/, { timeout: 15000 }),
+          page.click('[data-review-submit]'),
+        ]);
+        const posted = await page.locator('[data-review-posted]').count();
+
+        const stored = await fetch(`${base}/product/field-notes`);
+        const storedHtml = await stored.text();
+        check('server:action-nojs',
+          posted === 1 && storedHtml.includes('Posted with scripting disabled.'),
+          'a <Form> action completes with JavaScript disabled',
+          `redirected=${posted === 1} persisted=${storedHtml.includes('Posted with scripting disabled.')}`);
+      }, { context: noJs });
+    } finally {
+      await noJs.close();
+    }
+
+    log('storefront checks complete');
+  },
+};

--- a/smoke/apps/storefront/src/actions/shop.js
+++ b/smoke/apps/storefront/src/actions/shop.js
@@ -1,0 +1,41 @@
+// Server actions. Importing this module registers them so /__what_action can
+// dispatch. Server-only: never served to the browser.
+
+import { action } from 'what-framework/server';
+import { revalidateTag } from 'what-framework/server';
+
+/**
+ * Post a review, then bust every page tagged 'products'.
+ *
+ * The revalidation is the interesting half: the product page is `mode:'static'`
+ * and the home page is `mode:'hybrid'`, so without this the new review would be
+ * invisible behind the cache. The suite asserts the cached page reflects it.
+ */
+export const addReviewAction = action(
+  async (form) => {
+    const { addReview } = await import('../db.js');
+    const slug = String(form?.slug ?? '');
+    const body = String(form?.body ?? '');
+    const reviews = addReview(slug, body);
+    await revalidateTag('products');
+    return { ok: true, count: reviews.length };
+  },
+  { id: 'addReview' },
+);
+
+/** Server-side cart validation: proves an action can reject bad input. */
+export const checkoutAction = action(
+  async (form) => {
+    const lines = Array.isArray(form?.lines) ? form.lines : [];
+    if (lines.length === 0) throw new Error('cart is empty');
+    const { getProduct } = await import('../db.js');
+    let total = 0;
+    for (const line of lines) {
+      const product = getProduct(String(line.slug));
+      if (!product) throw new Error(`unknown product: ${line.slug}`);
+      total += product.price * Math.max(1, Number(line.qty) || 1);
+    }
+    return { ok: true, orderId: `SMK-${String(total).padStart(6, '0')}`, total };
+  },
+  { id: 'checkout' },
+);

--- a/smoke/apps/storefront/src/auth.js
+++ b/smoke/apps/storefront/src/auth.js
@@ -1,0 +1,31 @@
+// Server-only session handling. Deliberately minimal: this app exists to
+// exercise the framework, not to be an auth library. The one property that
+// matters here is that the gate runs on the server before any HTML exists.
+
+const USERS = new Map([['demo@smoke.test', 'hunter2']]);
+const SESSIONS = new Map(); // token -> { email }
+
+export const SESSION_COOKIE = 'smoke_session';
+
+function readCookie(request, name) {
+  const header = request?.headers?.get?.('cookie') ?? request?.headers?.cookie ?? '';
+  const match = String(header).match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export function sessionFromRequest(request) {
+  const token = readCookie(request, SESSION_COOKIE);
+  if (!token) return null;
+  return SESSIONS.get(token) ?? null;
+}
+
+export function signIn(email, password) {
+  if (USERS.get(email) !== password) return null;
+  const token = `s_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+  SESSIONS.set(token, { email });
+  return token;
+}
+
+export function signOut(token) {
+  if (token) SESSIONS.delete(token);
+}

--- a/smoke/apps/storefront/src/components/chrome.js
+++ b/smoke/apps/storefront/src/components/chrome.js
@@ -1,0 +1,42 @@
+// Shared page chrome. Client-safe (no server imports) so it can be served to
+// the browser and reused by every hydrated page.
+
+import { h } from 'what-framework';
+import { count, subtotal, formatPrice } from '../store/cart.js';
+
+/**
+ * Site header. The cart badge reads the GLOBAL store, so an add performed on a
+ * product page is visible here on every other page without any prop threading.
+ * `aria-live` on the badge means the count change is announced, and
+ * `aria-current` is an enumerated ARIA value, not an HTML boolean: it must
+ * serialize as the string "page", never as an empty attribute.
+ */
+export function Header({ current = '' }) {
+  const link = (href, label, id) =>
+    h('a', {
+      href,
+      'data-nav': id,
+      class: current === id ? 'nav-link is-active' : 'nav-link',
+      ...(current === id ? { 'aria-current': 'page' } : {}),
+    }, label);
+
+  return h('header', { class: 'site-header' },
+    h('a', { href: '/', class: 'brand' }, 'Smoke Supply Co.'),
+    h('nav', { 'aria-label': 'Primary' },
+      link('/', 'Shop', 'home'),
+      link('/search', 'Search', 'search'),
+      link('/cart', 'Cart', 'cart'),
+      link('/account', 'Account', 'account'),
+    ),
+    h('a', { href: '/cart', class: 'cart-badge', 'data-cart-badge': '' },
+      h('span', { 'data-cart-count': '' }, () => String(count())),
+      h('span', { class: 'cart-sub', 'data-cart-subtotal': '' }, () => formatPrice(subtotal())),
+    ),
+  );
+}
+
+export function Footer() {
+  return h('footer', { class: 'site-footer' },
+    h('p', {}, 'Smoke Supply Co., a What Framework smoke app.'),
+  );
+}

--- a/smoke/apps/storefront/src/db.js
+++ b/smoke/apps/storefront/src/db.js
@@ -1,0 +1,44 @@
+// Server-only "database". Never served to the browser (see SERVED_PREFIXES in
+// server.js): pages import it lazily inside their loader, which only runs on
+// the server.
+
+const PRODUCTS = [
+  { slug: 'aeron-mug', title: 'Aeron Mug', price: 1800, blurb: 'Ceramic, 12oz, dishwasher safe.', stock: 12, tags: ['kitchen'] },
+  { slug: 'field-notes', title: 'Field Notes 3-pack', price: 1295, blurb: 'Graph paper, pocket sized.', stock: 40, tags: ['paper'] },
+  { slug: 'desk-mat', title: 'Wool Desk Mat', price: 6500, blurb: 'Merino felt, 900x400mm.', stock: 5, tags: ['desk'] },
+  { slug: 'cable-clip', title: 'Cable Clips (6)', price: 900, blurb: 'Silicone, adhesive backed.', stock: 0, tags: ['desk'] },
+];
+
+// Mutated by the addReview action so revalidation has something observable to
+// prove: a cached page must show a review that did not exist when it was cached.
+const REVIEWS = new Map();
+
+export function listProducts() {
+  return PRODUCTS.map(({ slug, title, price, blurb, stock }) => ({ slug, title, price, blurb, stock }));
+}
+
+export function getProduct(slug) {
+  const p = PRODUCTS.find((x) => x.slug === slug);
+  if (!p) return null;
+  return { ...p, reviews: REVIEWS.get(slug) ?? [] };
+}
+
+export function productSlugs() {
+  return PRODUCTS.map((p) => p.slug);
+}
+
+export function addReview(slug, body) {
+  if (!PRODUCTS.some((p) => p.slug === slug)) throw new Error(`no such product: ${slug}`);
+  const text = String(body ?? '').trim();
+  if (!text) throw new Error('review body is required');
+  const list = REVIEWS.get(slug) ?? [];
+  list.push({ id: `r${list.length + 1}`, body: text.slice(0, 200) });
+  REVIEWS.set(slug, list);
+  return list;
+}
+
+export function searchProducts(q) {
+  const needle = String(q ?? '').trim().toLowerCase();
+  if (!needle) return listProducts();
+  return listProducts().filter((p) => p.title.toLowerCase().includes(needle));
+}

--- a/smoke/apps/storefront/src/entry-client.js
+++ b/smoke/apps/storefront/src/entry-client.js
@@ -1,0 +1,60 @@
+// Client hydration entry.
+//
+// Import page modules directly, never ./routes.js: the route table also imports
+// the server actions, which pull in the database.
+
+import { h, hydrate, effect } from 'what-framework';
+import { enhanceForms } from 'what-server/islands';
+import { count, subtotal, formatPrice } from './store/cart.js';
+import Home from './pages/home.js';
+import Product from './pages/product.js';
+import Cart from './pages/cart.js';
+import Search from './pages/search.js';
+import Account from './pages/account.js';
+
+// /review is deliberately absent. It is a server-rendered form with no client
+// state, and its component imports <Form> from what-framework/server, which is
+// server code: hydrating it would mean shipping the action handler, the CSRF
+// generator and the adapters to the browser to render a <form> that already
+// exists in the HTML. enhanceForms() below gives it the JS path without any of
+// that, which is the whole point of progressive enhancement.
+function matchPage(pathname) {
+  if (pathname === '/') return h(Home, {});
+  if (pathname === '/cart') return h(Cart, {});
+  if (pathname === '/search') return h(Search, {});
+  if (pathname === '/account') return h(Account, {});
+  const product = pathname.match(/^\/product\/([^/]+)\/?$/);
+  if (product) return h(Product, { slug: decodeURIComponent(product[1]) });
+  return null;
+}
+
+const vnode = matchPage(location.pathname);
+
+if (vnode) {
+  hydrate(vnode, document.body);
+} else {
+  // A page with no client component still has the shared header, and the cart
+  // it renders came from the server, where localStorage does not exist. Bind
+  // the badge to the store so it agrees with every other page.
+  const countEl = document.querySelector('[data-cart-count]');
+  const subtotalEl = document.querySelector('[data-cart-subtotal]');
+  if (countEl && subtotalEl) {
+    effect(() => { countEl.textContent = String(count()); });
+    effect(() => { subtotalEl.textContent = formatPrice(subtotal()); });
+  }
+}
+
+// Progressive enhancement for <Form>: posts to /__what_action without a page
+// reload, then follows the action's redirect. With scripting disabled the same
+// form submits natively, which is the path <Form> is designed around.
+enhanceForms();
+
+// Dev-only devtools bridge (see server.js). Dynamic imports behind the flag, so
+// a production page never fetches either module.
+if (globalThis.__WHAT_DEV__) {
+  Promise.all([import('what-core'), import('what-devtools')])
+    .then(([core, devtools]) => {
+      devtools.installDevTools?.(core);
+    })
+    .catch(() => { /* devtools are optional */ });
+}

--- a/smoke/apps/storefront/src/lib/actions-client.js
+++ b/smoke/apps/storefront/src/lib/actions-client.js
@@ -1,0 +1,34 @@
+// Client-side action caller.
+//
+// Server action modules import the database, so they are never served to the
+// browser. The browser does not need them: an action is addressed by id over
+// the served-action protocol (POST /__what_action with the X-What-Action
+// header), which is exactly what the framework's own action() client does.
+
+/** The double-submit CSRF token the server embedded in the page. */
+export function csrfToken() {
+  const meta = document.querySelector('meta[name="what-csrf-token"]');
+  if (meta) return meta.getAttribute('content') ?? '';
+  const match = document.cookie.match(/(?:^|;\s*)what-csrf=([^;]+)/);
+  return match ? decodeURIComponent(match[1]) : '';
+}
+
+export async function callAction(id, args = {}) {
+  const token = csrfToken();
+  const headers = { 'content-type': 'application/json', 'x-what-action': id };
+  if (token) headers['x-csrf-token'] = token;
+
+  const res = await fetch('/__what_action', {
+    method: 'POST',
+    headers,
+    credentials: 'same-origin',
+    body: JSON.stringify({ args: [args] }),
+  });
+
+  // On success the body IS the action's return value. On failure it is
+  // { message }, and a thrown action deliberately reports a generic
+  // "Action failed" so internals never reach the client.
+  const payload = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(payload.message || `action failed (${res.status})`);
+  return payload;
+}

--- a/smoke/apps/storefront/src/pages/account.js
+++ b/smoke/apps/storefront/src/pages/account.js
@@ -1,0 +1,58 @@
+// Account: SERVER mode, behind an auth gate.
+//
+// The gate is enforced on the SERVER, in the loader, before any HTML is
+// produced. That is the only place it can be enforced honestly: a client-side
+// guard is a UI convenience, not access control, because the page's data has
+// already been sent by then.
+
+import { h, Head, useLoaderData } from 'what-framework';
+import { Header, Footer } from '../components/chrome.js';
+
+export const page = { mode: 'server' };
+
+export const loader = async ({ request, csrfToken }) => {
+  const { sessionFromRequest } = await import('../auth.js');
+  const session = sessionFromRequest(request);
+  return { session, csrfToken: csrfToken ?? '' };
+};
+
+export default function Account() {
+  const { session, csrfToken } = useLoaderData();
+
+  if (!session) {
+    return h('div', { class: 'page' },
+      h(Head, { title: 'Sign in | Smoke Supply Co.' }),
+      h(Header, { current: 'account' }),
+      h('main', { class: 'container' },
+        h('h1', { 'data-signin': '' }, 'Sign in'),
+        h('p', { class: 'muted' }, 'Use demo@smoke.test / hunter2.'),
+        // A plain form POST, not a server action. Actions cannot set response
+        // headers, so they cannot establish a session cookie: sign-in has to be
+        // a real endpoint. Works with scripting disabled, which is the point.
+        h('form', { method: 'post', action: '/api/login', class: 'auth-form' },
+          h('input', { type: 'hidden', name: 'csrf', value: csrfToken }),
+          h('label', { for: 'email' }, 'Email'),
+          h('input', { id: 'email', name: 'email', type: 'email', required: true, autocomplete: 'username' }),
+          h('label', { for: 'password' }, 'Password'),
+          h('input', { id: 'password', name: 'password', type: 'password', required: true, autocomplete: 'current-password' }),
+          h('button', { type: 'submit', 'data-login': '' }, 'Sign in'),
+        ),
+      ),
+      h(Footer, {}),
+    );
+  }
+
+  return h('div', { class: 'page' },
+    h(Head, { title: 'Your account | Smoke Supply Co.' }),
+    h(Header, { current: 'account' }),
+    h('main', { class: 'container' },
+      h('h1', { 'data-account': '' }, 'Your account'),
+      h('p', {}, 'Signed in as ', h('strong', { 'data-email': '' }, session.email)),
+      h('form', { method: 'post', action: '/api/logout' },
+        h('input', { type: 'hidden', name: 'csrf', value: csrfToken }),
+        h('button', { type: 'submit', 'data-logout': '' }, 'Sign out'),
+      ),
+    ),
+    h(Footer, {}),
+  );
+}

--- a/smoke/apps/storefront/src/pages/cart.js
+++ b/smoke/apps/storefront/src/pages/cart.js
@@ -1,0 +1,93 @@
+// Cart: SERVER mode (never cached).
+//
+// The page shell is rendered per request; the cart itself is CLIENT state, read
+// from the global store after hydration. That split is the point: a cached cart
+// would show one shopper another shopper's basket.
+
+import { h, Head, signal, Show, For } from 'what-framework';
+import { Header, Footer } from '../components/chrome.js';
+import { lines, subtotal, setQty, clear, formatPrice, count } from '../store/cart.js';
+import { callAction } from '../lib/actions-client.js';
+
+export const page = { mode: 'server' };
+
+export const loader = async ({ csrfToken }) => ({ csrfToken: csrfToken ?? '' });
+
+export default function Cart() {
+  const status = signal('', 'checkout:status');
+  const busy = signal(false, 'checkout:busy');
+
+  async function checkout() {
+    if (count() === 0) return;
+    busy(true);
+    status('');
+    try {
+      // Addressed by id over the served-action protocol. The action module
+      // itself imports the database and is never sent to the browser.
+      const res = await callAction('checkout', { lines: lines() });
+      status(`Order ${res.orderId} placed`);
+      clear();
+    } catch (err) {
+      status(`Checkout failed: ${err.message}`);
+    } finally {
+      busy(false);
+    }
+  }
+
+  return h('div', { class: 'page' },
+    h(Head, { title: 'Your cart | Smoke Supply Co.' }),
+    h(Header, { current: 'cart' }),
+    h('main', { class: 'container' },
+      h('h1', {}, 'Your cart'),
+
+      // <Show> with a reactive `when`: the empty state and the table swap
+      // without a page load as lines change.
+      h(Show, {
+        when: () => count() > 0,
+        fallback: h('p', { class: 'muted', 'data-cart-empty': '' }, 'Your cart is empty.'),
+      },
+        h('div', { 'data-cart-table': '' },
+          h('ul', { class: 'cart-lines' },
+            // Raw items, not signal accessors. This app is buildless, so <For>
+            // runs through the runtime component in what-core, which hands the
+            // render function the item value itself. The compiled path lowers
+            // <For key={...}> to mapArray and hands over a signal accessor
+            // instead. That divergence is a framework issue, not an app choice:
+            // see smoke/FINDINGS.md. Written against the path that actually
+            // executes here.
+            h(For, { each: lines }, (line) =>
+              h('li', { class: 'cart-line', 'data-line': line.slug },
+                h('span', { class: 'cart-line-title' }, line.title),
+                h('span', { class: 'cart-line-qty' },
+                  h('button', {
+                    'data-dec': line.slug,
+                    'aria-label': `Decrease ${line.title}`,
+                    onclick: () => setQty(line.slug, line.qty - 1),
+                  }, 'Less'),
+                  h('output', { 'data-qty': line.slug }, String(line.qty)),
+                  h('button', {
+                    'data-inc': line.slug,
+                    'aria-label': `Increase ${line.title}`,
+                    onclick: () => setQty(line.slug, line.qty + 1),
+                  }, 'More'),
+                ),
+                h('span', { class: 'cart-line-price' }, formatPrice(line.qty * line.price)),
+              ),
+            ),
+          ),
+          h('p', { class: 'cart-total' }, 'Subtotal: ',
+            h('strong', { 'data-subtotal': '' }, () => formatPrice(subtotal()))),
+          h('button', {
+            class: 'primary',
+            'data-checkout': '',
+            'aria-busy': () => (busy() ? 'true' : 'false'),
+            onclick: checkout,
+          }, 'Checkout'),
+        ),
+      ),
+
+      h('p', { class: 'status', 'data-checkout-status': '' }, () => status()),
+    ),
+    h(Footer, {}),
+  );
+}

--- a/smoke/apps/storefront/src/pages/home.js
+++ b/smoke/apps/storefront/src/pages/home.js
@@ -1,0 +1,53 @@
+// Home: HYBRID (ISR).
+//
+// mode:'hybrid' means: serve from the ISR cache, regenerate in the background
+// after `revalidate` seconds, and let an action bust it by tag. The suite proves
+// all three: a first request MISSes, a second HITs, and a review posted through
+// a server action makes the tagged page reflect new data.
+
+import { h, Head, useLoaderData } from 'what-framework';
+import { Header, Footer } from '../components/chrome.js';
+import { formatPrice } from '../store/cart.js';
+
+export const page = { mode: 'hybrid', revalidate: 60, tags: ['products'] };
+
+export const loader = async () => {
+  const { listProducts } = await import('../db.js'); // server-only
+  return { products: listProducts(), renderedAt: Date.now() };
+};
+
+export default function Home() {
+  const { products } = useLoaderData();
+
+  return h('div', { class: 'page' },
+    h(Head, {
+      title: 'Smoke Supply Co.',
+      meta: [{ name: 'description', content: 'Desk goods for people who test things.' }],
+    }),
+    h(Header, { current: 'home' }),
+    h('main', { class: 'container' },
+      h('h1', {}, 'Everything for the desk'),
+      h('p', { class: 'lede' }, 'Server-rendered, ISR-cached, hydrated on the client.'),
+
+      // A keyed list. `key` lets the compiler lower this to keyed reconciliation
+      // so rows are moved rather than recreated.
+      h('ul', { class: 'product-grid', 'data-products': '' }, products.map((p) =>
+        h('li', { key: p.slug, class: 'product-card', 'data-product': p.slug },
+          h('a', { href: `/product/${p.slug}` },
+            h('h2', {}, p.title),
+            h('p', { class: 'blurb' }, p.blurb),
+            h('p', { class: 'price' }, formatPrice(p.price)),
+          ),
+          // Enumerated ARIA, not an HTML boolean: must render the STRING
+          // "true"/"false", never an empty attribute and never absent.
+          h('span', {
+            class: 'stock',
+            'data-stock': p.slug,
+            'aria-disabled': p.stock === 0 ? 'true' : 'false',
+          }, p.stock === 0 ? 'Out of stock' : `${p.stock} in stock`),
+        ),
+      )),
+    ),
+    h(Footer, {}),
+  );
+}

--- a/smoke/apps/storefront/src/pages/product.js
+++ b/smoke/apps/storefront/src/pages/product.js
@@ -1,0 +1,89 @@
+// Product: STATIC (SSG) with a dynamic param.
+//
+// getStaticPaths enumerates the pages to prerender at build time; the route
+// param resolves per page. The add-to-cart button writes to the global store.
+//
+// The review FORM is deliberately not here. A cached page (static or hybrid) is
+// shared across visitors, so the adapter does not embed a per-user CSRF token in
+// it. A <Form> rendered here would post an empty token and be rejected with
+// scripting disabled. The form lives on /review, which is mode:'server'. What
+// this page proves instead is the other half: a review posted there busts the
+// 'products' tag, so this cached page shows it on the next request.
+
+import { h, Head, signal, useLoaderData } from 'what-framework';
+import { Header, Footer } from '../components/chrome.js';
+import { addItem, formatPrice } from '../store/cart.js';
+
+export const page = { mode: 'static', revalidate: 300, tags: ['products'] };
+
+export const getStaticPaths = async () => {
+  const { productSlugs } = await import('../db.js');
+  return {
+    paths: productSlugs().map((slug) => ({ params: { slug } })),
+    // An unlisted slug renders on first request; the loader's notFound turns it
+    // into a real 404 that the server refuses to cache.
+    fallback: 'blocking',
+  };
+};
+
+export const loader = async ({ params }) => {
+  const { getProduct } = await import('../db.js');
+  const product = getProduct(params.slug);
+  if (!product) return { notFound: true, product: null };
+  return { product };
+};
+
+export default function Product() {
+  const { product, notFound } = useLoaderData();
+
+  if (notFound || !product) {
+    return h('div', { class: 'page' },
+      h(Head, { title: 'Not found' }),
+      h(Header, {}),
+      h('main', { class: 'container' },
+        h('h1', { 'data-not-found': '' }, 'Product not found'),
+        h('p', {}, h('a', { href: '/' }, 'Back to the shop')),
+      ),
+      h(Footer, {}),
+    );
+  }
+
+  const added = signal(false, 'added');
+  const inStock = product.stock > 0;
+
+  return h('div', { class: 'page' },
+    h(Head, {
+      title: `${product.title} | Smoke Supply Co.`,
+      meta: [{ name: 'description', content: product.blurb }],
+    }),
+    h(Header, {}),
+    h('main', { class: 'container product-detail' },
+      h('h1', { 'data-title': '' }, product.title),
+      h('p', { class: 'price', 'data-price': '' }, formatPrice(product.price)),
+      h('p', { class: 'blurb' }, product.blurb),
+
+      h('button', {
+        'data-add': '',
+        class: 'primary',
+        disabled: !inStock,
+        'aria-disabled': inStock ? 'false' : 'true',
+        onclick: () => { addItem(product); added(true); },
+      }, inStock ? 'Add to cart' : 'Out of stock'),
+
+      // Reactive thunk child: shows only after the click, proving hydration
+      // attached the handler to server-rendered DOM.
+      h('p', { class: 'added-note', 'data-added': '' }, () => (added() ? 'Added to cart' : '')),
+
+      h('section', { class: 'reviews' },
+        h('h2', {}, 'Reviews'),
+        h('ul', { 'data-reviews': '' },
+          product.reviews.length === 0
+            ? h('li', { class: 'muted', 'data-no-reviews': '' }, 'No reviews yet.')
+            : product.reviews.map((r) => h('li', { key: r.id }, r.body)),
+        ),
+        h('p', {}, h('a', { href: `/review?slug=${product.slug}`, 'data-write-review': '' }, 'Write a review')),
+      ),
+    ),
+    h(Footer, {}),
+  );
+}

--- a/smoke/apps/storefront/src/pages/review.js
+++ b/smoke/apps/storefront/src/pages/review.js
@@ -1,0 +1,68 @@
+// Write a review: SERVER mode, and the no-JS server-action path.
+//
+// This page is mode:'server' for a specific reason. Cached HTML is shared
+// between visitors, so the adapter never embeds a per-visitor CSRF token in it,
+// which means a <Form> on a static or hybrid page has no token to submit and the
+// double-submit check rejects the post when JavaScript is off. A server-rendered
+// page gets `csrfToken` handed to its loader, so the form works with scripting
+// fully disabled. That is the case this page exists to hold down.
+
+import { h, Head, useLoaderData } from 'what-framework';
+import { Form } from 'what-framework/server';
+import { Header, Footer } from '../components/chrome.js';
+import { addReviewAction } from '../actions/shop.js';
+
+export const page = { mode: 'server' };
+
+export const loader = async ({ query, csrfToken }) => {
+  const { listProducts } = await import('../db.js');
+  return {
+    products: listProducts(),
+    selected: String(query?.slug ?? ''),
+    posted: String(query?.posted ?? '') === '1',
+    csrfToken: csrfToken ?? '',
+  };
+};
+
+export default function Review() {
+  const { products, selected, posted, csrfToken } = useLoaderData();
+
+  return h('div', { class: 'page' },
+    h(Head, { title: 'Write a review | Smoke Supply Co.' }),
+    h(Header, {}),
+    h('main', { class: 'container' },
+      h('h1', {}, 'Write a review'),
+
+      posted
+        ? h('p', { class: 'status', 'data-review-posted': '' }, 'Thanks, your review is live.')
+        : null,
+
+      // One form, both paths. With scripting on, enhanceForms() intercepts the
+      // submit and posts to the same endpoint with the same encoding. With
+      // scripting off, the browser submits it natively. The suite drives both,
+      // and proving the no-JS path needs a context that genuinely has no JS, not
+      // a form that opts out of enhancement.
+      h(Form, {
+        action: addReviewAction,
+        csrfToken,
+        redirect: '/review?posted=1',
+        class: 'review-form',
+      },
+        h('label', { for: 'review-slug' }, 'Product'),
+        h('select', { id: 'review-slug', name: 'slug' },
+          products.map((p) =>
+            h('option', {
+              key: p.slug,
+              value: p.slug,
+              ...(p.slug === selected ? { selected: true } : {}),
+            }, p.title),
+          ),
+        ),
+        h('label', { for: 'review-body' }, 'Your review'),
+        h('textarea', { id: 'review-body', name: 'body', required: true, placeholder: 'How was it?' }),
+        h('button', { type: 'submit', 'data-review-submit': '' }, 'Post review'),
+      ),
+    ),
+    h(Footer, {}),
+  );
+}

--- a/smoke/apps/storefront/src/pages/search.js
+++ b/smoke/apps/storefront/src/pages/search.js
@@ -1,0 +1,73 @@
+// Search: SERVER shell, client-driven results.
+//
+// This is the react-query-shaped surface: useQuery caches by key, exposes
+// loading/data, and invalidateQueries(['products']) refetches every key beneath
+// that prefix. The prefix behaviour is the part worth proving, because passing
+// an array key used to silently do nothing at all.
+
+import { h, Head, signal, useQuery, invalidateQueries, debounce } from 'what-framework';
+import { Header, Footer } from '../components/chrome.js';
+import { formatPrice } from '../store/cart.js';
+
+export const page = { mode: 'server' };
+
+export const loader = async () => ({ ok: true });
+
+async function fetchSearch(term) {
+  const res = await fetch(`/api/search?q=${encodeURIComponent(term)}`);
+  if (!res.ok) throw new Error(`search failed (${res.status})`);
+  return res.json();
+}
+
+export default function Search() {
+  const term = signal('', 'search:term');
+  const refetches = signal(0, 'search:refetches');
+
+  // Key is an ARRAY: ['products', 'search', term]. invalidateQueries(['products'])
+  // must reach it as a prefix.
+  const query = useQuery({
+    queryKey: ['products', 'search', () => term()],
+    queryFn: async () => {
+      refetches((n) => n + 1);
+      return fetchSearch(term());
+    },
+    staleTime: 0,
+  });
+
+  const onInput = debounce((event) => term(event.target.value), 80);
+
+  return h('div', { class: 'page' },
+    h(Head, { title: 'Search | Smoke Supply Co.' }),
+    h(Header, { current: 'search' }),
+    h('main', { class: 'container' },
+      h('h1', {}, 'Search'),
+      h('label', { for: 'q' }, 'Find a product'),
+      h('input', { id: 'q', 'data-search-input': '', type: 'search', placeholder: 'mug', oninput: onInput }),
+
+      h('p', { class: 'muted' },
+        h('span', { 'data-query-state': '' }, () => (query.isLoading() ? 'loading' : 'idle')),
+        ' · fetches: ',
+        h('span', { 'data-fetch-count': '' }, () => String(refetches())),
+      ),
+
+      h('button', {
+        'data-invalidate': '',
+        // The documented prefix shape. Everything under ['products', ...] refetches.
+        onclick: () => invalidateQueries(['products']),
+      }, 'Refresh results'),
+
+      h('ul', { 'data-results': '' }, () => {
+        const data = query.data();
+        if (!data) return h('li', { class: 'muted' }, 'No results yet.');
+        return data.map((p) =>
+          h('li', { key: p.slug, 'data-result': p.slug },
+            h('a', { href: `/product/${p.slug}` }, p.title),
+            ' · ',
+            formatPrice(p.price),
+          ),
+        );
+      }),
+    ),
+    h(Footer, {}),
+  );
+}

--- a/smoke/apps/storefront/src/routes.js
+++ b/smoke/apps/storefront/src/routes.js
@@ -1,0 +1,23 @@
+// Route table. Each entry carries the page component plus its live
+// loader/getStaticPaths/page bindings.
+//
+// Server-only: importing this pulls in the actions, which pull in the database.
+
+import Home, { loader as homeLoader, page as homePage } from './pages/home.js';
+import Product, { loader as productLoader, getStaticPaths as productPaths, page as productPage } from './pages/product.js';
+import Cart, { loader as cartLoader, page as cartPage } from './pages/cart.js';
+import Search, { loader as searchLoader, page as searchPage } from './pages/search.js';
+import Account, { loader as accountLoader, page as accountPage } from './pages/account.js';
+import Review, { loader as reviewLoader, page as reviewPage } from './pages/review.js';
+
+// Importing the actions registers them so /__what_action can dispatch.
+import './actions/shop.js';
+
+export const routes = [
+  { path: '/', component: Home, loader: homeLoader, page: homePage, mode: homePage.mode },
+  { path: '/product/:slug', component: Product, loader: productLoader, getStaticPaths: productPaths, page: productPage, mode: productPage.mode },
+  { path: '/cart', component: Cart, loader: cartLoader, page: cartPage, mode: cartPage.mode },
+  { path: '/search', component: Search, loader: searchLoader, page: searchPage, mode: searchPage.mode },
+  { path: '/account', component: Account, loader: accountLoader, page: accountPage, mode: accountPage.mode },
+  { path: '/review', component: Review, loader: reviewLoader, page: reviewPage, mode: reviewPage.mode },
+];

--- a/smoke/apps/storefront/src/store/cart.js
+++ b/smoke/apps/storefront/src/store/cart.js
@@ -1,0 +1,82 @@
+// Global cart store.
+//
+// Module-scoped, so every page that imports it reads and writes the SAME state:
+// this is What's answer to a global store, and it is what the suite checks when
+// it asserts the header badge on one page reflects an add performed on another.
+//
+// Persistence is deliberate too. The cart survives a full page reload, which is
+// a real requirement for a storefront and the only way to prove that client
+// state is not silently reset by hydration.
+
+import { signal, computed, batch } from 'what-framework';
+
+const STORAGE_KEY = 'storefront:cart:v1';
+
+function readPersisted() {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    return Array.isArray(raw) ? raw.filter((l) => l && typeof l.slug === 'string') : [];
+  } catch {
+    return []; // corrupt storage must not take the whole store down
+  }
+}
+
+// `lines` is the single source of truth: [{ slug, title, price, qty }]
+export const lines = signal(readPersisted(), 'cart:lines');
+
+export const count = computed(() => lines().reduce((n, l) => n + l.qty, 0));
+export const subtotal = computed(() => lines().reduce((n, l) => n + l.qty * l.price, 0));
+
+function persist(next) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch { /* quota or private mode: the cart still works in memory */ }
+}
+
+export function addItem(product, qty = 1) {
+  const next = lines().map((l) => ({ ...l }));
+  const hit = next.find((l) => l.slug === product.slug);
+  if (hit) hit.qty += qty;
+  else next.push({ slug: product.slug, title: product.title, price: product.price, qty });
+  lines(next);
+  persist(next);
+  return next;
+}
+
+export function setQty(slug, qty) {
+  const next = lines()
+    .map((l) => (l.slug === slug ? { ...l, qty: Math.max(0, qty) } : l))
+    .filter((l) => l.qty > 0);
+  lines(next);
+  persist(next);
+  return next;
+}
+
+export function clear() {
+  lines([]);
+  persist([]);
+}
+
+/**
+ * Apply several quantity changes as ONE settle.
+ *
+ * Each setQty is its own write. Without batch an observer runs once per write
+ * and briefly sees a half-applied cart: the count already updated for the first
+ * line while the second still holds its old quantity. batch collapses them, so
+ * every reader sees exactly one consistent state. The suite measures the
+ * observer's run count, which is the only way to tell the two apart from
+ * outside: the final DOM is identical either way.
+ */
+export function applyBulk(updates) {
+  batch(() => {
+    for (const [slug, qty] of updates) setQty(slug, qty);
+  });
+  persist(lines());
+  return lines();
+}
+
+export function formatPrice(cents) {
+  return `$${(cents / 100).toFixed(2)}`;
+}

--- a/smoke/apps/storefront/src/styles.css
+++ b/smoke/apps/storefront/src/styles.css
@@ -1,0 +1,285 @@
+:root {
+  color-scheme: light;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif;
+  --ink: #0f172a;
+  --muted: #64748b;
+  --line: #d8dfea;
+  --accent: #2563eb;
+  --surface: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f4f6fb;
+  color: var(--ink);
+}
+
+.container {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 4rem;
+}
+
+a {
+  color: var(--accent);
+}
+
+h1 {
+  font-size: 1.75rem;
+  letter-spacing: -0.02em;
+}
+
+.lede,
+.muted {
+  color: var(--muted);
+}
+
+button {
+  border: 1px solid #9aa7bb;
+  background: var(--surface);
+  color: var(--ink);
+  padding: 0.4rem 0.9rem;
+  border-radius: 10px;
+  cursor: pointer;
+  font: inherit;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* --- Chrome -------------------------------------------------------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.9rem 1.5rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+}
+
+.brand {
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1rem;
+  flex: 1;
+}
+
+.nav-link {
+  text-decoration: none;
+  color: var(--muted);
+  padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+}
+
+.nav-link.is-active {
+  color: var(--ink);
+  border-bottom-color: var(--accent);
+}
+
+.cart-badge {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  text-decoration: none;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  background: #f8fafc;
+}
+
+.cart-sub {
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.site-footer {
+  border-top: 1px solid var(--line);
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+/* --- Product listing ----------------------------------------------------- */
+
+.product-grid {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+}
+
+.product-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.product-card a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.product-card h2 {
+  font-size: 1.05rem;
+  margin: 0 0 0.35rem;
+}
+
+.blurb {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem;
+}
+
+.price {
+  font-weight: 700;
+  margin: 0;
+}
+
+.stock {
+  display: inline-block;
+  margin-top: 0.6rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.stock[aria-disabled='true'] {
+  color: #b91c1c;
+}
+
+.product-detail .price {
+  font-size: 1.25rem;
+}
+
+.added-note:not(:empty) {
+  color: #15803d;
+  font-weight: 600;
+}
+
+/* --- Cart ---------------------------------------------------------------- */
+
+.cart-lines {
+  list-style: none;
+  margin: 1rem 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.cart-line {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.6rem 0.9rem;
+}
+
+.cart-line-qty {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cart-line-qty output {
+  min-width: 2ch;
+  text-align: center;
+  font-weight: 700;
+}
+
+.cart-total {
+  font-size: 1.05rem;
+}
+
+.status:not(:empty) {
+  margin-top: 1rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 10px;
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+}
+
+/* --- Forms --------------------------------------------------------------- */
+
+form {
+  display: grid;
+  gap: 0.6rem;
+  max-width: 460px;
+  margin-top: 1rem;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+input,
+textarea,
+select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #9aa7bb;
+  border-radius: 10px;
+  font: inherit;
+  background: var(--surface);
+}
+
+textarea {
+  min-height: 5rem;
+  resize: vertical;
+}
+
+form button {
+  justify-self: start;
+}
+
+/* --- Search -------------------------------------------------------------- */
+
+[data-results] {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.reviews ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.reviews li {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+}

--- a/smoke/harness/capabilities.mjs
+++ b/smoke/harness/capabilities.mjs
@@ -1,0 +1,143 @@
+// The capability contract.
+//
+// "Full coverage" is worthless as a claim and useful as a check. This file is
+// the list of framework capabilities the app suite is responsible for, and the
+// runner FAILS when a capability has no app covering it, or when an app claims
+// a capability whose checks did not actually run.
+//
+// Adding a capability here without covering it turns the suite red. That is the
+// point: it is how a gap becomes visible on the day it appears rather than in
+// the next audit.
+
+/**
+ * capability id -> { area, what it proves }
+ * An app declares `covers: [...ids]` and must emit a passing check per id.
+ */
+export const CAPABILITIES = {
+  // --- Render modes -------------------------------------------------------
+  'render:static': { area: 'render', desc: 'a static (SSG) page is prerendered to HTML at build time' },
+  'render:server': { area: 'render', desc: 'a server page renders per request with fresh data' },
+  'render:hybrid-isr': { area: 'render', desc: 'a hybrid page is cached and served as an ISR HIT on the second request' },
+  'render:client-spa': { area: 'render', desc: 'a client-only route renders without server HTML' },
+  'render:hydration': { area: 'render', desc: 'server HTML hydrates and becomes interactive with zero page errors' },
+  'render:no-hydration-mismatch': { area: 'render', desc: 'hydration reuses server DOM without mismatch warnings' },
+
+  // --- Routing ------------------------------------------------------------
+  'route:table': { area: 'routing', desc: 'multi-page routing via a route table' },
+  'route:params': { area: 'routing', desc: 'dynamic route params resolve (/product/:slug)' },
+  'route:nested-layout': { area: 'routing', desc: 'a nested layout wraps its child routes' },
+  'route:guard': { area: 'routing', desc: 'an auth guard redirects an unauthenticated visitor' },
+  'route:loading': { area: 'routing', desc: "a route's loading component shows while navigating TO it" },
+  'route:error': { area: 'routing', desc: "a route's error component catches a throw from the page" },
+  'route:404': { area: 'routing', desc: 'an unknown path renders the not-found fallback' },
+  'route:link-active': { area: 'routing', desc: 'Link/NavLink applies active classes for the current route' },
+  'route:programmatic': { area: 'routing', desc: 'navigate() moves between routes from code' },
+
+  // --- State --------------------------------------------------------------
+  'state:signal': { area: 'state', desc: 'local signal state updates the DOM' },
+  'state:computed': { area: 'state', desc: 'computed derives from signals and stays in sync' },
+  'state:global-store': { area: 'state', desc: 'a module-scoped store is shared across routes/components' },
+  'state:persisted': { area: 'state', desc: 'state survives a full page reload (localStorage)' },
+  'state:context': { area: 'state', desc: 'context provides a value to a deep child' },
+  'state:batch': { area: 'state', desc: 'batched writes settle to one consistent render' },
+
+  // --- Data ---------------------------------------------------------------
+  'data:loader': { area: 'data', desc: 'a route loader supplies data to SSR via useLoaderData' },
+  'data:loader-request': { area: 'data', desc: 'a loader reads the incoming request (cookies) and branches what it renders' },
+  'data:query': { area: 'data', desc: 'useQuery fetches, caches and exposes loading/success' },
+  'data:invalidate': { area: 'data', desc: 'invalidateQueries with an array prefix refetches matching keys' },
+  'data:infinite': { area: 'data', desc: 'useInfiniteQuery appends the next page' },
+  'data:optimistic': { area: 'data', desc: 'an optimistic update applies immediately and reconciles' },
+  'data:resource-suspense': { area: 'data', desc: 'createResource suspends and resolves under Suspense' },
+
+  // --- Server -------------------------------------------------------------
+  'server:action-js': { area: 'server', desc: 'a server action runs from the client and updates the page' },
+  'server:action-nojs': { area: 'server', desc: 'a <Form> action works with JavaScript disabled' },
+  'server:csrf': { area: 'server', desc: 'an action without a valid CSRF token is rejected' },
+  'server:revalidate': { area: 'server', desc: 'an action revalidates a cached page so the change is visible' },
+  'server:action-error': { area: 'server', desc: 'a throwing action returns a generic failure and leaves the server serving' },
+
+  // --- Islands ------------------------------------------------------------
+  'island:load': { area: 'islands', desc: 'client:load hydrates immediately' },
+  'island:idle': { area: 'islands', desc: 'client:idle hydrates when the browser goes idle' },
+  'island:visible': { area: 'islands', desc: 'client:visible hydrates when scrolled into view, not before' },
+  'island:interaction': { area: 'islands', desc: 'client:interaction hydrates on first user interaction, not before' },
+  'island:media': { area: 'islands', desc: 'client:media hydrates only when the media query matches' },
+  'island:ssr-content': { area: 'islands', desc: 'an island ships real server HTML, not an empty placeholder' },
+
+  // --- Components ---------------------------------------------------------
+  'cmp:control-flow': { area: 'components', desc: 'Show/For/Switch render and update reactively' },
+  // NOTE: only the COMPILED path implements this. The runtime h()/automatic-JSX
+  // path in dom.js never reads vnode.key and rebuilds every row on each change,
+  // so this capability must be claimed by an app that runs what-compiler.
+  'cmp:keyed-list': { area: 'components', desc: 'a keyed list reorders without recreating rows (compiled path)' },
+  'cmp:error-boundary': { area: 'components', desc: 'ErrorBoundary catches a throw AFTER a state change, not just first paint' },
+  'cmp:suspense-lazy': { area: 'components', desc: 'a lazy component reached by navigation shows a fallback then resolves' },
+  'cmp:portal': { area: 'components', desc: 'Portal renders a modal outside its parent DOM position' },
+  'cmp:head': { area: 'components', desc: 'Head sets document title and meta tags, server-rendered' },
+
+  // --- Animation ----------------------------------------------------------
+  'anim:scroll-progress': { area: 'animation', desc: 'scroll position drives an animated value' },
+  'anim:intersect': { area: 'animation', desc: 'onIntersect reveals elements as they enter the viewport' },
+  'anim:spring-tween': { area: 'animation', desc: 'spring/tween animate a value over time' },
+  'anim:transition': { area: 'animation', desc: 'an enter/leave transition runs on a mount/unmount' },
+
+  // --- Forms & a11y -------------------------------------------------------
+  'form:validation': { area: 'forms', desc: 'useForm rejects invalid input and surfaces field errors' },
+  'form:submit': { area: 'forms', desc: 'a valid form submits and produces the expected result' },
+  'a11y:ids': { area: 'a11y', desc: 'useId pairs a label with its input, stable across SSR and hydration' },
+  'a11y:focus-trap': { area: 'a11y', desc: 'focus stays inside an open dialog' },
+  'a11y:live-region': { area: 'a11y', desc: 'an announcement reaches a live region' },
+  'a11y:aria-enumerated': { area: 'a11y', desc: 'aria-* booleans serialize as "true"/"false", never empty or absent' },
+};
+
+/** Every app's declared coverage, checked against CAPABILITIES at run time. */
+export function validateCoverage(apps) {
+  const problems = [];
+  const covered = new Map(); // capability -> [app names]
+
+  for (const app of apps) {
+    for (const id of app.covers) {
+      if (!CAPABILITIES[id]) problems.push(`${app.name} declares unknown capability "${id}"`);
+      if (!covered.has(id)) covered.set(id, []);
+      covered.get(id).push(app.name);
+    }
+  }
+
+  const uncovered = Object.keys(CAPABILITIES).filter((id) => !covered.has(id));
+  for (const id of uncovered) {
+    problems.push(`capability "${id}" (${CAPABILITIES[id].desc}) is not covered by any app`);
+  }
+
+  return { problems, covered, uncovered };
+}
+
+/**
+ * A declared capability with no passing check is the failure mode this whole
+ * file exists to prevent: a suite that reports coverage it never exercised.
+ */
+export function auditResults(apps, results) {
+  const problems = [];
+  const passedIds = new Set(
+    results.filter((r) => r.passed && r.capability).map((r) => r.capability),
+  );
+
+  for (const app of apps) {
+    for (const id of app.covers) {
+      if (!passedIds.has(id)) {
+        problems.push(`${app.name} declares "${id}" but no passing check reported it`);
+      }
+    }
+  }
+  return problems;
+}
+
+export function coverageReport(covered) {
+  const byArea = {};
+  for (const [id, def] of Object.entries(CAPABILITIES)) {
+    byArea[def.area] ??= { total: 0, covered: 0 };
+    byArea[def.area].total++;
+    if (covered.has(id)) byArea[def.area].covered++;
+  }
+  return byArea;
+}

--- a/smoke/harness/index.mjs
+++ b/smoke/harness/index.mjs
@@ -1,0 +1,232 @@
+// Shared primitives for the app smoke suite.
+//
+// The suite exists because of a specific failure: 0.12.0 and 0.12.1 shipped a
+// what-server packaging defect that every workspace test passed straight
+// through. It was only visible to something that INSTALLED the published
+// artifact and used it. So the defining feature here is `resolvePackageSource`:
+// the same apps run against local tarballs (pre-release regression) or against
+// the real registry (post-release verification).
+
+import { execFileSync, spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Workspace dir -> published package name. Everything an app can reach,
+// directly or transitively, so npm never silently falls back to the registry
+// when we asked for workspace code.
+export const WORKSPACE_PACKAGES = {
+  'packages/what': 'what-framework',
+  'packages/core': 'what-core',
+  'packages/router': 'what-router',
+  'packages/server': 'what-server',
+  'packages/compiler': 'what-compiler',
+  'packages/cache': 'what-isr',
+  'packages/devtools': 'what-devtools',
+  'packages/devtools-mcp': 'what-devtools-mcp',
+  'packages/eslint-plugin': 'eslint-plugin-what',
+};
+
+const children = new Set();
+
+export function killAllChildren() {
+  for (const child of children) {
+    try { process.kill(-child.pid, 'SIGKILL'); } catch {}
+    try { child.kill('SIGKILL'); } catch {}
+  }
+  children.clear();
+}
+
+process.on('exit', killAllChildren);
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => { killAllChildren(); process.exit(1); });
+}
+
+export function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+    ...opts,
+  });
+}
+
+export function startProcess(cmd, args, opts = {}) {
+  // detached so we can kill the whole process group: dev servers spawn
+  // children that outlive a bare child.kill() and then hold the port.
+  const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'], detached: true, ...opts });
+  child.logs = '';
+  child.stdout?.on('data', (d) => { child.logs += d; });
+  child.stderr?.on('data', (d) => { child.logs += d; });
+  children.add(child);
+  child.on('exit', () => children.delete(child));
+  return child;
+}
+
+/**
+ * A stale process answering on our port makes every downstream assertion lie,
+ * because it is serving a DIFFERENT app. Refuse to start rather than report
+ * someone else's passing results as ours.
+ */
+export async function assertPortFree(port) {
+  try {
+    await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(800) });
+  } catch {
+    return;
+  }
+  throw new Error(
+    `port ${port} is already in use; kill the stale process first ` +
+    `(lsof -nP -iTCP:${port} -sTCP:LISTEN)`,
+  );
+}
+
+export async function waitForHttp(url, { timeoutMs = 60000, child } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child && child.exitCode !== null) {
+      throw new Error(`process exited (${child.exitCode}) before ${url} was up:\n${child.logs}`);
+    }
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
+      if (res.ok) return res;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`timed out waiting for ${url}${child ? `\n--- logs ---\n${child.logs}` : ''}`);
+}
+
+/**
+ * Resolve where the app's what-* dependencies come from.
+ *
+ *   workspace -> `npm pack` each workspace package, install the tarballs.
+ *                Catches source regressions before a release exists.
+ *   npm       -> install `name@version` straight from the registry.
+ *                Catches PACKAGING defects: a types path that is declared but
+ *                not published, an export condition shadowed by another, a
+ *                dependency that only resolves inside the monorepo. Workspace
+ *                mode is blind to every one of those by construction.
+ */
+export function resolvePackageSource({ source, version, repoRoot, tarballDir, log = () => {} }) {
+  if (source === 'npm') {
+    const specs = {};
+    for (const name of Object.values(WORKSPACE_PACKAGES)) specs[name] = `${version}`;
+    log(`resolving what-* from the npm registry at ${version}`);
+    return { kind: 'npm', specs };
+  }
+
+  mkdirSync(tarballDir, { recursive: true });
+  const specs = {};
+  for (const [dir, name] of Object.entries(WORKSPACE_PACKAGES)) {
+    const out = run('npm', ['pack', join(repoRoot, dir), '--pack-destination', tarballDir, '--silent']);
+    const file = out.trim().split('\n').pop();
+    const tarball = join(tarballDir, file);
+    if (!existsSync(tarball)) throw new Error(`npm pack of ${name} did not produce ${file}`);
+    specs[name] = `file:${tarball}`;
+  }
+  log(`packed ${Object.keys(specs).length} workspace packages`);
+  return { kind: 'workspace', specs };
+}
+
+/**
+ * Point every what-* dependency at the resolved source. `overrides` covers the
+ * transitive graph (what-framework -> what-core/router/server/compiler) so a
+ * stale registry copy can never sneak into a workspace run, which would make
+ * the run silently meaningless.
+ */
+export function applyPackageSource(appDir, specs) {
+  const pkgPath = join(appDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  for (const section of ['dependencies', 'devDependencies']) {
+    for (const dep of Object.keys(pkg[section] || {})) {
+      if (specs[dep]) pkg[section][dep] = specs[dep];
+    }
+  }
+  pkg.overrides = { ...pkg.overrides, ...specs };
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+  return pkg;
+}
+
+/**
+ * Assert the installed tree really came from the source we asked for. Without
+ * this, a resolution fallback turns a green run into a lie about which bytes
+ * were tested.
+ */
+export function verifyInstalledSource(appDir, { kind, version }) {
+  const problems = [];
+  for (const name of Object.values(WORKSPACE_PACKAGES)) {
+    const manifest = join(appDir, 'node_modules', name, 'package.json');
+    if (!existsSync(manifest)) continue; // not every app uses every package
+    const installed = JSON.parse(readFileSync(manifest, 'utf8'));
+    if (kind === 'npm' && installed.version !== version) {
+      problems.push(`${name} is ${installed.version}, expected ${version} from the registry`);
+    }
+  }
+  if (problems.length) throw new Error(`installed tree does not match the requested source:\n  ${problems.join('\n  ')}`);
+}
+
+export async function launchBrowser({ required = true } = {}) {
+  try {
+    const { chromium } = await import('playwright');
+    return await chromium.launch();
+  } catch (err) {
+    if (required) {
+      throw new Error(
+        `Chromium failed to launch: ${err.message.split('\n')[0]}\n` +
+        'Every check in this suite is browser-driven, so there is no meaningful ' +
+        'degraded mode: run `npx playwright install chromium`.',
+      );
+    }
+    return null;
+  }
+}
+
+/**
+ * Open a page and collect everything that went wrong on it. Nothing is thrown:
+ * a check asserts on the collection, because "it rendered" and "it rendered
+ * without complaining" are different claims and the second one is the one that
+ * catches hydration mismatches.
+ *
+ * Warnings are kept separately from errors on purpose. A hydration mismatch is
+ * a console WARNING, so a collector that only watched errors would report a
+ * clean page while the client was silently throwing away the server's DOM.
+ */
+export async function withPage(browser, url, fn, { context } = {}) {
+  const page = context ? await context.newPage() : await browser.newPage();
+  const diag = { errors: [], warnings: [], all: [] };
+  page.on('pageerror', (e) => {
+    diag.errors.push(`pageerror: ${e.message}`);
+    diag.all.push(`pageerror: ${e.message}`);
+  });
+  page.on('console', (m) => {
+    const line = `${m.type()}: ${m.text()}`;
+    diag.all.push(line);
+    if (m.type() === 'error') diag.errors.push(line);
+    else if (m.type() === 'warning') diag.warnings.push(line);
+  });
+  try {
+    await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+    return await fn(page, diag);
+  } finally {
+    await page.close();
+  }
+}
+
+/** Collector so one app's failure does not hide the rest of its checks. */
+export function createReporter(appName) {
+  const results = [];
+  return {
+    results,
+    ok(name, detail = '') {
+      results.push({ app: appName, name, passed: true, detail });
+      console.log(`    ok   ${name}${detail ? ` (${detail})` : ''}`);
+    },
+    fail(name, detail = '') {
+      results.push({ app: appName, name, passed: false, detail });
+      console.log(`    FAIL ${name}${detail ? `: ${detail}` : ''}`);
+    },
+    assert(cond, name, detail = '') {
+      if (cond) this.ok(name, detail);
+      else this.fail(name, detail);
+      return !!cond;
+    },
+    get failures() { return results.filter((r) => !r.passed); },
+  };
+}

--- a/smoke/run.mjs
+++ b/smoke/run.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+// App smoke suite: builds and drives real applications against a chosen build
+// of the framework, then asserts a declared capability matrix actually held.
+//
+// Why this exists, precisely: 0.12.0 and 0.12.1 shipped a what-server packaging
+// defect that every unit test, the type gates and the scaffold smoke all passed.
+// It was only observable to something that INSTALLED the published artifact and
+// used it. `--source=npm` is that something.
+//
+// Usage:
+//   node smoke/run.mjs                          # workspace code (pre-release)
+//   node smoke/run.mjs --source=npm             # published `latest`
+//   node smoke/run.mjs --source=npm --version=0.12.2
+//   node smoke/run.mjs --apps=storefront        # one app, while iterating
+//   node smoke/run.mjs --keep                   # keep the workdir to inspect
+//
+// Exits non-zero if any check fails, any capability is uncovered, or any
+// declared capability never reported a passing check.
+
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  applyPackageSource,
+  assertPortFree,
+  createReporter,
+  killAllChildren,
+  launchBrowser,
+  resolvePackageSource,
+  run,
+  verifyInstalledSource,
+} from './harness/index.mjs';
+import { CAPABILITIES, auditResults, coverageReport, validateCoverage } from './harness/capabilities.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, '..');
+const APPS_DIR = join(HERE, 'apps');
+const PORT_BASE = Number(process.env.WHAT_SMOKE_APP_PORT_BASE) || 4700;
+
+function flag(name, fallback = null) {
+  const hit = process.argv.find((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+  if (!hit) return fallback;
+  const eq = hit.indexOf('=');
+  return eq === -1 ? true : hit.slice(eq + 1);
+}
+
+const SOURCE = flag('source', 'workspace');
+const KEEP = !!flag('keep', false);
+const ONLY = flag('apps', null);
+
+if (!['workspace', 'npm'].includes(SOURCE)) {
+  console.error(`--source must be "workspace" or "npm" (got "${SOURCE}")`);
+  process.exit(2);
+}
+
+const VERSION = flag('version', null)
+  || JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf8')).version;
+
+function log(msg) { console.log(`[smoke-apps] ${msg}`); }
+
+// --- Load app definitions --------------------------------------------------
+
+const appNames = readdirSync(APPS_DIR).filter((d) => existsSync(join(APPS_DIR, d, 'smoke.config.mjs')));
+const wanted = ONLY ? String(ONLY).split(',').map((s) => s.trim()) : appNames;
+
+const apps = [];
+for (const name of wanted) {
+  if (!appNames.includes(name)) {
+    console.error(`unknown app "${name}"; available: ${appNames.join(', ')}`);
+    process.exit(2);
+  }
+  const mod = await import(join(APPS_DIR, name, 'smoke.config.mjs'));
+  apps.push({ name, dir: join(APPS_DIR, name), ...mod.default });
+}
+
+// --- Coverage contract (before doing any expensive work) -------------------
+// Only enforced on a full run: a filtered run legitimately covers a subset.
+
+const isFullRun = !ONLY;
+const { problems: coverageProblems, covered } = validateCoverage(apps);
+if (isFullRun && coverageProblems.length) {
+  console.error('\nCapability coverage contract violated:');
+  for (const p of coverageProblems) console.error(`  - ${p}`);
+  console.error('\nEither cover the capability in an app or remove it from smoke/harness/capabilities.mjs.');
+  process.exit(1);
+}
+
+log(`source=${SOURCE}${SOURCE === 'npm' ? ` version=${VERSION}` : ''} apps=${apps.map((a) => a.name).join(',')}`);
+
+// --- Run -------------------------------------------------------------------
+
+const workRoot = mkdtempSync(join(tmpdir(), 'what-smoke-apps-'));
+const allResults = [];
+let browser = null;
+
+try {
+  const pkgSource = resolvePackageSource({
+    source: SOURCE,
+    version: VERSION,
+    repoRoot: REPO,
+    tarballDir: join(workRoot, 'tarballs'),
+    log,
+  });
+
+  browser = await launchBrowser({ required: true });
+
+  let port = PORT_BASE;
+  for (const app of apps) {
+    console.log(`\n── ${app.name} ──────────────────────────────────────────`);
+    const appPort = port++;
+    await assertPortFree(appPort);
+
+    // Copy to a workdir so the checked-in app stays pristine and demoable:
+    // `cd smoke/apps/<name> && npm i && npm run dev` must keep working.
+    const workDir = join(workRoot, app.name);
+    cpSync(app.dir, workDir, {
+      recursive: true,
+      filter: (src) => !src.includes('node_modules') && !src.includes(`${app.name}/dist`),
+    });
+
+    applyPackageSource(workDir, pkgSource.specs);
+    run('npm', ['install', '--no-audit', '--no-fund'], { cwd: workDir });
+    verifyInstalledSource(workDir, { kind: pkgSource.kind, version: VERSION });
+    log(`installed ${app.name} (${pkgSource.kind})`);
+
+    const reporter = createReporter(app.name);
+    const capabilityOf = new Map();
+    const check = (capability, cond, name, detail) => {
+      const passed = reporter.assert(cond, `[${capability}] ${name}`, detail);
+      capabilityOf.set(capability, (capabilityOf.get(capability) ?? true) && passed);
+      return passed;
+    };
+
+    try {
+      await app.check({
+        workDir,
+        port,
+        appPort,
+        browser,
+        check,
+        reporter,
+        log: (m) => console.log(`    .. ${m}`),
+        run,
+      });
+    } catch (err) {
+      reporter.fail('app harness', err.message.split('\n').slice(0, 4).join(' | '));
+    }
+
+    for (const r of reporter.results) {
+      const m = /^\[([^\]]+)\]/.exec(r.name);
+      allResults.push({ ...r, capability: m ? m[1] : null });
+    }
+    killAllChildren();
+  }
+} finally {
+  if (browser) await browser.close().catch(() => {});
+  killAllChildren();
+  if (!KEEP) rmSync(workRoot, { recursive: true, force: true });
+  else log(`workdir kept at ${workRoot}`);
+}
+
+// --- Report ----------------------------------------------------------------
+
+const failures = allResults.filter((r) => !r.passed);
+const unproven = isFullRun ? auditResults(apps, allResults) : [];
+
+console.log('\n──────────── coverage ────────────');
+const report = coverageReport(covered);
+for (const [area, { total, covered: c }] of Object.entries(report)) {
+  const mark = c === total ? 'ok  ' : 'GAP ';
+  console.log(`  ${mark} ${area.padEnd(12)} ${c}/${total}`);
+}
+console.log(`\nchecks: ${allResults.length - failures.length}/${allResults.length} passed across ${apps.length} app(s)`);
+
+const artifact = {
+  source: SOURCE,
+  version: VERSION,
+  apps: apps.map((a) => a.name),
+  capabilities: Object.keys(CAPABILITIES).length,
+  results: allResults,
+  failures: failures.length,
+  unproven,
+};
+mkdirSync(join(REPO, 'artifacts'), { recursive: true });
+writeFileSync(join(REPO, 'artifacts', 'smoke-apps.json'), `${JSON.stringify(artifact, null, 2)}\n`);
+
+if (failures.length) {
+  console.error('\nFailed checks:');
+  for (const f of failures) console.error(`  - ${f.app}: ${f.name}${f.detail ? `: ${f.detail}` : ''}`);
+}
+if (unproven.length) {
+  console.error('\nDeclared capabilities with no passing check (the suite would be overstating coverage):');
+  for (const u of unproven) console.error(`  - ${u}`);
+}
+
+if (failures.length || unproven.length) process.exit(1);
+console.log('\nAll app smoke checks passed.');


### PR DESCRIPTION
Fixes 22 correctness bugs across SSR, hydration, the compiler, the router and the query layer. npm's `latest` (0.12.2) is broken in ways a workspace test cannot see, which is the reason this branch also adds two verification mechanisms rather than just fixes.

## The largest

**No component using a hook could be server-rendered.** `renderToString` called the component function with nothing on the component stack, so all ten context-dependent hooks (`useState`, `useSignal`, `useComputed`, `useEffect`, `useMemo`, `useCallback`, `useRef`, `useReducer`, `onMount`, `onCleanup`) plus `Context.Provider` threw. One of them anywhere in the tree and the page failed to render. All three server paths had their own copy of the bare call.

**A compiled keyed list rendered empty on the server and crashed hydration.** `.map()` with `key`, and `<For>`, lower to a mapArray inserter taking `(parent, marker)`. Neither SSR nor hydration had a branch for it. The server swallowed the throw and emitted an empty container; the client's throw escaped `hydrate()` and left the whole page inert.

**A reactive region lost its owning component on every re-run**, so `useContext` fell through to the default and `<ErrorBoundary>` stopped catching, but only once the app was interactive. `dom.js` had this fix; `render.js`'s `insert()`, the path the compiler emits, did not.

**The compiler called every destructured prop as if it were a signal**, throwing `x is not a function` on any ordinary string prop and rendering nothing for that component and its subtree.

Full list and diagnosis of all 22 in `smoke/FINDINGS.md`.

## How they were found, and why there are 22

Four real applications, driven in a real browser, then adversarial review of each round of fixes, then fuzzing. Almost every bug needed **two features combined** to reproduce (SSR *and* a hook; SSR *and* hydration *and* a toggle; a query key *and* a signal *and* an invalidation), which is why the 1,900-test unit suite was green through all of them.

Three rounds of hand-written fixes each closed the case in front of them and left the class open, and two of those rounds shipped a new bug while doing it. What closed the class was a different kind of test.

## What this branch adds so it does not happen again

**An application smoke suite** (`npm run smoke:apps`). Four demoable apps driven in a browser, runnable against the workspace **or the published packages** (`smoke:apps:npm`). The published mode is the direct answer to the 0.12.0/0.12.1 packaging defects, which were invisible to every workspace test by construction. A capability contract fails the run when a framework capability has no app covering it, or when an app claims one that no passing check reported. 84 checks, 55 capabilities, 10/10 categories covered.

**A differential hydration fuzz.** 400 generated trees, each server-rendered with one set of signal values and hydrated with another, asserted identical to a client-only render. It knows nothing about markers or cursors, so unlike a hand-written case it cannot be satisfied by a narrow fix.

| | divergent |
|---|---|
| 0.12.2 as published, under browser conditions | 186 / 400 |
| 0.12.2 with the dev-only correction forced on | 32 / 400 |
| after the first round of fixes | 35 / 400 |
| this branch | **0 / 400** |

The middle rows are the point: the second round of hand-written fixes made the aggregate slightly worse while every hand-written test stayed green.

Both are wired into `release:verify` and CI, and `smoke:apps:npm` runs against the published artifacts after publish.

## Verification

- 1,995 unit tests pass (up from 1,900; every fix has a test that fails without it, verified by reverting each)
- 84/84 browser smoke checks across 4 apps, 55/55 capabilities
- `npm run release:verify` exits 0 at 0.12.3

## Semver

Patch. No public API changes. The new exports (`_beginComponentSSR`, `_endComponentSSR`, `_mapArrayToArray`) are underscore-internal. The compiler change alters emitted code for destructured props, but the previous output threw, so nothing correct depended on it.

## Known gaps, deliberately deferred to 0.13.0

- `renderToString` still emits no `<!--fn-->` markers for reactive regions, so hydration infers region boundaries rather than being told them. Exact enough to score 0/400, but emitting markers is the durable fix. Deferred because it changes every server-rendered byte.
- `hydrateNode` has no branch for `<ErrorBoundary>` / `<Suspense>` boundary tags or `<Portal>`; `<Portal>` cannot be server-rendered at all.
- The runtime render path has no keyed reconciliation, and `<For>` passes raw items on the runtime path and accessors on the compiled path. Unifying them is an API decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
