### PR TITLE
chore: sync package-lock workspace versions to 0.12.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "what-fw",
-  "version": "0.11.8",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "what-fw",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "workspaces": [
         "packages/*",
         "benchmark"
@@ -6583,10 +6583,10 @@
     },
     "packages/cache": {
       "name": "what-isr",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "peerDependencies": {
-        "what-server": "^0.11.8"
+        "what-server": "^0.12.4"
       },
       "peerDependenciesMeta": {
         "what-server": {
@@ -6596,10 +6596,10 @@
     },
     "packages/cli": {
       "name": "what-framework-cli",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "dependencies": {
-        "what-framework": "^0.11.8"
+        "what-framework": "^0.12.4"
       },
       "bin": {
         "what": "src/cli.js"
@@ -6607,7 +6607,7 @@
     },
     "packages/compiler": {
       "name": "what-compiler",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.23.0",
@@ -6615,16 +6615,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0",
-        "what-core": "^0.11.8"
+        "what-core": "^0.12.4"
       }
     },
     "packages/core": {
       "name": "what-core",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT"
     },
     "packages/create-what": {
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "bin": {
         "create-what": "index.js"
@@ -6632,15 +6632,15 @@
     },
     "packages/devtools": {
       "name": "what-devtools",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "peerDependencies": {
-        "what-core": "^0.11.8"
+        "what-core": "^0.12.4"
       }
     },
     "packages/devtools-mcp": {
       "name": "what-devtools-mcp",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -6661,7 +6661,7 @@
     },
     "packages/eslint-plugin": {
       "name": "eslint-plugin-what",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "peerDependencies": {
         "eslint": ">=9.0.0"
@@ -6669,7 +6669,7 @@
     },
     "packages/mcp-server": {
       "name": "what-mcp",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "deprecated": "Use what-devtools-mcp instead. This package is superseded by the unified MCP server.",
       "license": "MIT",
       "dependencies": {
@@ -6681,27 +6681,27 @@
     },
     "packages/react-compat": {
       "name": "what-react",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "peerDependencies": {
-        "what-core": "^0.11.8"
+        "what-core": "^0.12.4"
       }
     },
     "packages/router": {
       "name": "what-router",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "peerDependencies": {
-        "what-core": "^0.11.8"
+        "what-core": "^0.12.4"
       }
     },
     "packages/server": {
       "name": "what-server",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "peerDependencies": {
-        "what-core": "^0.11.8",
-        "what-router": "^0.11.8"
+        "what-core": "^0.12.4",
+        "what-router": "^0.12.4"
       },
       "peerDependenciesMeta": {
         "what-router": {
@@ -6711,17 +6711,17 @@
     },
     "packages/what": {
       "name": "what-framework",
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "dependencies": {
-        "what-compiler": "^0.11.8",
-        "what-core": "^0.11.8",
-        "what-router": "^0.11.8",
-        "what-server": "^0.11.8"
+        "what-compiler": "^0.12.4",
+        "what-core": "^0.12.4",
+        "what-router": "^0.12.4",
+        "what-server": "^0.12.4"
       }
     },
     "packages/what-text": {
-      "version": "0.11.8",
+      "version": "0.12.4",
       "license": "MIT",
       "peerDependencies": {
         "@chenglou/pretext": ">=0.0.5",


### PR DESCRIPTION
The 14 workspace entries in `package-lock.json`, and the internal `what-*` ranges between them, had been left at `0.11.8` since that release. The lockfile has therefore disagreed with every `package.json` in the repo for four releases running.

Nothing was broken by it. `npm ci` treats a linked workspace's `version` as informational and resolves it from the `package.json` on disk, which is why CI stayed green through 0.12.0 to 0.12.4 and why the publish workflow shipped correct packages. It is still a lockfile that describes a tree the repo does not have, and the next person to read it for the truth would get the wrong answer.

Regenerated with `npm install --package-lock-only`.

### The whole diff

28 lines. Every one is a workspace `version` or an internal `what-*` range moving `0.11.8` -> `0.12.4`:

- 15x `"version": "0.11.8"` -> `"0.12.4"` (14 workspaces + the root)
- 13x `"what-core" | "what-server" | "what-router" | "what-compiler" | "what-framework": "^0.11.8"` -> `"^0.12.4"`

**No external dependency moved.** `npm ci --dry-run` resolves against it. CI here re-runs the real `npm ci` in eight jobs, which is the point of putting it through a PR rather than straight onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)